### PR TITLE
refactor(#699): wrap User in KoheraUserSummary domain model

### DIFF
--- a/lib/core/services/client_avatar_resolver.dart
+++ b/lib/core/services/client_avatar_resolver.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+import 'package:kohera/core/utils/media_auth.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
+import 'package:matrix/matrix.dart';
+
+/// [AvatarResolver] backed by a Matrix SDK [Client].
+///
+/// Resolves `mxc://` URIs via `Uri.getThumbnailUri` and attaches auth headers
+/// via [mediaAuthHeaders] (scoped to the homeserver host to prevent token
+/// leakage to federated media servers).
+class ClientAvatarResolver implements AvatarResolver {
+  ClientAvatarResolver(this._client);
+
+  final Client _client;
+
+  @override
+  Future<AvatarThumbnail?> resolve(String? mxcUrl, {required double size}) async {
+    if (mxcUrl == null) return null;
+    try {
+      final uri = Uri.parse(mxcUrl);
+      final thumb = await uri.getThumbnailUri(
+        _client,
+        width: (size * 2).toInt(),
+        height: (size * 2).toInt(),
+      );
+      final url = thumb.toString();
+      return AvatarThumbnail(url: url, headers: mediaAuthHeaders(_client, url));
+    } catch (e) {
+      debugPrint('[Kohera] Failed to resolve avatar thumbnail: $e');
+      return null;
+    }
+  }
+}

--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:kohera/core/services/client_avatar_resolver.dart';
 import 'package:kohera/core/services/session_backup.dart';
 import 'package:kohera/core/services/sticker_pack_service.dart';
 import 'package:kohera/core/services/sub_services/auth_service.dart';
@@ -16,6 +17,7 @@ import 'package:kohera/core/services/sub_services/uia_service.dart';
 import 'package:kohera/core/utils/network_error.dart';
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart';
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:matrix/matrix.dart';
 // ignore: implementation_imports, no public API for ClientInitException
 import 'package:matrix/src/utils/client_init_exception.dart';
@@ -74,6 +76,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
       connectivity: RealOutboxConnectivity(),
     );
     stickerPacks = StickerPackService(client: _client);
+    avatarResolver = ClientAvatarResolver(_client);
     auth.addListener(_onAuthChanged);
   }
 
@@ -118,6 +121,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
   late final SyncService sync;
   late final AuthService auth;
   late final OutboxService outbox;
+  late final AvatarResolver avatarResolver;
   late final StickerPackService stickerPacks;
 
   StreamSubscription<LoginState>? _loginStateSub;

--- a/lib/features/calling/widgets/participant_tile.dart
+++ b/lib/features/calling/widgets/participant_tile.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 import 'package:kohera/core/services/call_service.dart';
+import 'package:kohera/core/services/client_avatar_resolver.dart';
 import 'package:kohera/features/calling/models/call_participant.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
 import 'package:livekit_client/livekit_client.dart' as livekit;
@@ -158,9 +159,10 @@ class _ParticipantTileState extends State<ParticipantTile> {
       color: cs.surfaceContainerHighest,
       child: Center(
         child: UserAvatar(
-          client: matrixClient,
-          avatarUrl: _resolvedAvatarUrl,
+          avatarResolver: ClientAvatarResolver(matrixClient),
+          avatarUrl: _resolvedAvatarUrl?.toString(),
           userId: widget.participant.id,
+          displayname: widget.participant.displayName,
           size: 64,
         ),
       ),

--- a/lib/features/chat/models/kohera_read_receipt.dart
+++ b/lib/features/chat/models/kohera_read_receipt.dart
@@ -1,0 +1,14 @@
+import 'package:kohera/shared/models/kohera_user_summary.dart';
+
+/// A read receipt with a pre-computed [KoheraUserSummary] and timestamp.
+///
+/// Produced by the conversion boundary (`buildReceiptMap` in
+/// `read_receipts.dart`) from the SDK `Receipt` type. Consumed by
+/// `ReadReceiptsRow` and `showReadersSheet` — neither of which touch the
+/// Matrix SDK directly.
+class KoheraReadReceipt {
+  const KoheraReadReceipt({required this.user, required this.time});
+
+  final KoheraUserSummary user;
+  final DateTime time;
+}

--- a/lib/features/chat/widgets/chat_message_item.dart
+++ b/lib/features/chat/widgets/chat_message_item.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/utils/reply_fallback.dart';
+import 'package:kohera/features/chat/models/kohera_read_receipt.dart';
 import 'package:kohera/features/chat/services/thread_summary.dart';
 import 'package:kohera/features/chat/widgets/delete_event_dialog.dart';
 import 'package:kohera/features/chat/widgets/emoji_picker_sheet.dart';
@@ -14,6 +16,7 @@ import 'package:kohera/features/chat/widgets/read_receipts.dart';
 import 'package:kohera/features/chat/widgets/swipeable_message.dart';
 import 'package:kohera/features/chat/widgets/thread_indicator_chip.dart';
 import 'package:matrix/matrix.dart';
+import 'package:provider/provider.dart';
 
 class ChatMessageItem extends StatelessWidget {
   const ChatMessageItem({
@@ -44,7 +47,7 @@ class ChatMessageItem extends StatelessWidget {
   final Timeline? timeline;
   final Client client;
   final String? highlightedEventId;
-  final Map<String, List<Receipt>> receiptMap;
+  final Map<String, List<KoheraReadReceipt>> receiptMap;
   final void Function(Event event)? onReply;
   final void Function(Event event)? onEdit;
   final Future<void> Function(Event event)? onPin;
@@ -69,7 +72,7 @@ class ChatMessageItem extends StatelessWidget {
         timeline != null &&
         event.hasAggregatedEvents(timeline!, RelationshipTypes.thread);
     final receipts = receiptMap[event.eventId]
-        ?.where((r) => r.user.id != event.senderId)
+        ?.where((r) => r.user.userId != event.senderId)
         .toList();
 
     Widget? reactionBubble;
@@ -87,7 +90,7 @@ class ChatMessageItem extends StatelessWidget {
     if (receipts != null && receipts.isNotEmpty) {
       subBubble = ReadReceiptsRow(
         receipts: receipts,
-        client: client,
+        avatarResolver: context.read<MatrixService>().avatarResolver,
         isMe: isMe,
       );
     }

--- a/lib/features/chat/widgets/mention_suggestion_overlay.dart
+++ b/lib/features/chat/widgets/mention_suggestion_overlay.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kohera/core/services/client_avatar_resolver.dart';
 import 'package:kohera/features/chat/widgets/mention_autocomplete_controller.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
@@ -127,9 +128,10 @@ class _SuggestionTile extends StatelessWidget {
       }
     }
     return UserAvatar(
-      client: client,
-      avatarUrl: suggestion.avatarUrl,
+      avatarResolver: ClientAvatarResolver(client),
+      avatarUrl: suggestion.avatarUrl?.toString(),
       userId: suggestion.id,
+      displayname: suggestion.displayName,
       size: 32,
     );
   }

--- a/lib/features/chat/widgets/message_bubble.dart
+++ b/lib/features/chat/widgets/message_bubble.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:kohera/core/services/client_avatar_resolver.dart';
 import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/utils/platform_info.dart';
 import 'package:kohera/features/chat/widgets/density_metrics.dart';
@@ -10,6 +11,7 @@ import 'package:kohera/features/chat/widgets/message_bubble_context_menu.dart';
 import 'package:kohera/features/chat/widgets/message_bubble_hover_bar_slot.dart';
 import 'package:kohera/features/chat/widgets/message_bubble_skin.dart';
 import 'package:kohera/features/rooms/widgets/member_sheet_dialog.dart';
+import 'package:kohera/shared/models/kohera_user_summary_mapper.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
@@ -246,9 +248,10 @@ class _MessageBubbleState extends State<MessageBubble> {
           mouseCursor: SystemMouseCursors.click,
           onTap: _showSenderSheet,
           child: UserAvatar(
-            client: widget.event.room.client,
-            avatarUrl: widget.event.senderFromMemoryOrFallback.avatarUrl,
+            avatarResolver: ClientAvatarResolver(widget.event.room.client),
+            avatarUrl: widget.event.senderFromMemoryOrFallback.avatarUrl?.toString(),
             userId: widget.event.senderId,
+            displayname: widget.event.senderFromMemoryOrFallback.calcDisplayname(),
             size: diameter,
           ),
         ),
@@ -258,10 +261,12 @@ class _MessageBubbleState extends State<MessageBubble> {
   }
 
   void _showSenderSheet() {
+    final sender = widget.event.senderFromMemoryOrFallback;
     unawaited(showMemberSheet(
       context,
       room: widget.event.room,
-      user: widget.event.senderFromMemoryOrFallback,
+      user: toKoheraUserSummary(sender),
+      isBanned: sender.membership == Membership.ban,
     ),);
   }
 }

--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -5,6 +5,7 @@ import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/utils/platform_info.dart';
 import 'package:kohera/features/calling/models/call_constants.dart';
+import 'package:kohera/features/chat/models/kohera_read_receipt.dart';
 import 'package:kohera/features/chat/services/state_event_resolver.dart';
 import 'package:kohera/features/chat/widgets/call_event_tile.dart';
 import 'package:kohera/features/chat/widgets/chat_message_item.dart';
@@ -515,7 +516,7 @@ class MessageListViewState extends State<MessageListView> {
             widget.matrix.client.userID,
             threadRootId: widget.threadRootEventId,
           )
-        : <String, List<Receipt>>{};
+        : <String, List<KoheraReadReceipt>>{};
     final hasLoadingIndicator = _loadingHistory || widget.extraLoading;
     final totalCount = events.length + (hasLoadingIndicator ? 1 : 0);
 

--- a/lib/features/chat/widgets/pinned_messages_popup.dart
+++ b/lib/features/chat/widgets/pinned_messages_popup.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:kohera/core/extensions/context_extension.dart';
+import 'package:kohera/core/services/client_avatar_resolver.dart';
 import 'package:kohera/core/utils/reply_fallback.dart';
 import 'package:kohera/features/chat/widgets/html_message_text.dart';
 import 'package:kohera/features/chat/widgets/linkable_text.dart';
@@ -323,9 +324,10 @@ class _PinnedMessageTile extends StatelessWidget {
                   Row(
                     children: [
                       UserAvatar(
-                        client: event.room.client,
-                        avatarUrl: sender.avatarUrl,
+                        avatarResolver: ClientAvatarResolver(event.room.client),
+                        avatarUrl: sender.avatarUrl?.toString(),
                         userId: event.senderId,
+                        displayname: sender.calcDisplayname(),
                         size: 24,
                       ),
                       const SizedBox(width: 8),

--- a/lib/features/chat/widgets/reaction_chips.dart
+++ b/lib/features/chat/widgets/reaction_chips.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:kohera/core/services/client_avatar_resolver.dart';
 import 'package:kohera/core/utils/emoji_spans.dart';
 import 'package:kohera/features/chat/widgets/long_press_wrapper.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
@@ -203,9 +204,10 @@ void showReactorsSheet(
                   final name = user.displayName ?? re.senderId;
                   return ListTile(
                     leading: UserAvatar(
-                      client: room.client,
-                      avatarUrl: user.avatarUrl,
+                      avatarResolver: ClientAvatarResolver(room.client),
+                      avatarUrl: user.avatarUrl?.toString(),
                       userId: re.senderId,
+                      displayname: name,
                       size: 36,
                     ),
                     title: Text(name),

--- a/lib/features/chat/widgets/read_receipts.dart
+++ b/lib/features/chat/widgets/read_receipts.dart
@@ -1,22 +1,30 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:kohera/features/chat/models/kohera_read_receipt.dart';
+import 'package:kohera/shared/models/kohera_user_summary_mapper.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
 import 'package:matrix/matrix.dart';
 
 // ── Receipt map builder ──────────────────────────────────────
 
-/// Builds a map from eventId → list of [Receipt] for other users.
+/// Builds a map from eventId → list of [KoheraReadReceipt] for other users.
+///
+/// This is the conversion boundary: it reads SDK receipt state from [room]
+/// and produces Kohera-owned [KoheraReadReceipt]s with pre-computed
+/// [KoheraUserSummary] fields. The consuming widgets (ReadReceiptsRow,
+/// showReadersSheet) never touch the Matrix SDK directly.
 ///
 /// Iterates [room.receiptState.global.otherUsers] (and optionally
 /// mainThread) once, so cost is O(N) where N = number of users with
 /// receipts, rather than O(N×M) if we queried per-event.
-Map<String, List<Receipt>> buildReceiptMap(
+Map<String, List<KoheraReadReceipt>> buildReceiptMap(
   Room room,
   String? myUserId, {
   String? threadRootId,
 }) {
-  final map = <String, List<Receipt>>{};
+  final map = <String, List<KoheraReadReceipt>>{};
   final seen = <String>{};
 
   void addReceipts(Map<String, LatestReceiptStateData> users) {
@@ -27,7 +35,10 @@ Map<String, List<Receipt>> buildReceiptMap(
 
       final data = entry.value;
       final user = room.unsafeGetUserFromMemoryOrFallback(userId);
-      final receipt = Receipt(user, data.timestamp);
+      final receipt = KoheraReadReceipt(
+        user: toKoheraUserSummary(user),
+        time: data.timestamp,
+      );
       (map[data.eventId] ??= []).add(receipt);
     }
   }
@@ -54,11 +65,14 @@ Map<String, List<Receipt>> buildReceiptMap(
 /// with a "+N" badge when more than 3 users have read it.
 class ReadReceiptsRow extends StatelessWidget {
   const ReadReceiptsRow({
-    required this.receipts, required this.client, required this.isMe, super.key,
+    required this.receipts,
+    required this.avatarResolver,
+    required this.isMe,
+    super.key,
   });
 
-  final List<Receipt> receipts;
-  final Client client;
+  final List<KoheraReadReceipt> receipts;
+  final AvatarResolver avatarResolver;
   final bool isMe;
 
   static const double _avatarSize = 16;
@@ -75,7 +89,7 @@ class ReadReceiptsRow extends StatelessWidget {
     final overflow = receipts.length - _maxVisible;
 
     return GestureDetector(
-      onTap: () => showReadersSheet(context, receipts, client),
+      onTap: () => showReadersSheet(context, receipts, avatarResolver),
       child: Padding(
         padding: const EdgeInsets.only(top: 2, bottom: 4),
         child: Row(
@@ -97,9 +111,10 @@ class ReadReceiptsRow extends StatelessWidget {
                       child: _AvatarBorder(
                         borderWidth: _borderWidth,
                         child: UserAvatar(
-                          client: client,
+                          avatarResolver: avatarResolver,
                           avatarUrl: receipts[i].user.avatarUrl,
-                          userId: receipts[i].user.id,
+                          userId: receipts[i].user.userId,
+                          displayname: receipts[i].user.displayname,
                           size: _avatarSize,
                         ),
                       ),
@@ -159,8 +174,8 @@ class _AvatarBorder extends StatelessWidget {
 /// Shows a modal bottom sheet listing all users who have read a message.
 void showReadersSheet(
   BuildContext context,
-  List<Receipt> receipts,
-  Client client,
+  List<KoheraReadReceipt> receipts,
+  AvatarResolver avatarResolver,
 ) {
   unawaited(showModalBottomSheet(
     context: context,
@@ -184,8 +199,7 @@ void showReadersSheet(
                 itemCount: receipts.length,
                 itemBuilder: (context, i) {
                   final receipt = receipts[i];
-                  final name =
-                      receipt.user.displayName ?? receipt.user.id;
+                  final name = receipt.user.displayname;
                   final timeOfDay =
                       TimeOfDay.fromDateTime(receipt.time.toLocal());
                   final timeStr =
@@ -193,9 +207,10 @@ void showReadersSheet(
 
                   return ListTile(
                     leading: UserAvatar(
-                      client: client,
+                      avatarResolver: avatarResolver,
                       avatarUrl: receipt.user.avatarUrl,
-                      userId: receipt.user.id,
+                      userId: receipt.user.userId,
+                      displayname: receipt.user.displayname,
                       size: 36,
                     ),
                     title: Text(name),

--- a/lib/features/chat/widgets/search_result_tile.dart
+++ b/lib/features/chat/widgets/search_result_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kohera/core/services/client_avatar_resolver.dart';
 import 'package:kohera/core/utils/text_highlight.dart';
 import 'package:kohera/core/utils/time_format.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
@@ -31,9 +32,10 @@ class SearchResultTile extends StatelessWidget {
           children: [
             // Sender avatar
             UserAvatar(
-              client: event.room.client,
-              avatarUrl: event.senderFromMemoryOrFallback.avatarUrl,
+              avatarResolver: ClientAvatarResolver(event.room.client),
+              avatarUrl: event.senderFromMemoryOrFallback.avatarUrl?.toString(),
               userId: event.senderId,
+              displayname: event.senderFromMemoryOrFallback.calcDisplayname(),
               size: 36,
             ),
             const SizedBox(width: 12),

--- a/lib/features/rooms/widgets/member_sheet_dialog.dart
+++ b/lib/features/rooms/widgets/member_sheet_dialog.dart
@@ -11,6 +11,8 @@ import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:kohera/features/rooms/models/room_role.dart';
 import 'package:kohera/features/rooms/services/power_level_service.dart';
+import 'package:kohera/shared/models/kohera_user_summary.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
@@ -23,11 +25,13 @@ import 'package:provider/provider.dart';
 Future<void> showMemberSheet(
   BuildContext context, {
   required Room room,
-  required User user,
+  required KoheraUserSummary user,
+  bool isBanned = false,
 }) {
   final matrix = context.read<MatrixService>();
-  final isMe = user.id == room.client.userID;
+  final isMe = user.userId == room.client.userID;
   final ownLevel = room.getPowerLevelByUserId(room.client.userID!);
+  final powerLevel = room.getPowerLevelByUserId(user.userId);
 
   Future<void> startDm() async {
     if (!context.mounted) return;
@@ -37,7 +41,7 @@ Future<void> showMemberSheet(
     try {
       final client = matrix.client;
       final dmRoomId = await client.startDirectChat(
-        user.id,
+        user.userId,
         enableEncryption: true,
       );
       if (client.getRoomById(dmRoomId) == null) {
@@ -69,7 +73,10 @@ Future<void> showMemberSheet(
       room: room,
       presence: matrix.presence,
       ownLevel: ownLevel,
+      powerLevel: powerLevel,
+      isBanned: isBanned,
       isMe: isMe,
+      avatarResolver: matrix.avatarResolver,
       onStartDm: isMe ? null : startDm,
     ),
   );
@@ -83,16 +90,22 @@ class MemberSheetDialog extends StatefulWidget {
     required this.room,
     required this.presence,
     required this.ownLevel,
+    required this.powerLevel,
+    required this.isBanned,
     required this.isMe,
+    required this.avatarResolver,
     this.onStartDm,
     super.key,
   });
 
-  final User user;
+  final KoheraUserSummary user;
   final Room room;
   final PresenceService presence;
   final int ownLevel;
+  final int powerLevel;
+  final bool isBanned;
   final bool isMe;
+  final AvatarResolver avatarResolver;
   final Future<void> Function()? onStartDm;
 
   @override
@@ -136,7 +149,7 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
 
     // Require explicit confirmation before demoting another admin.
     if (currentPowerLevel >= 100) {
-      final displayName = widget.user.displayName ?? widget.user.id;
+      final displayName = widget.user.displayname;
       final confirmed = await confirmDialog(
         context,
         title: 'Demote admin?',
@@ -154,7 +167,7 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
     try {
       await PowerLevelService.update(
         widget.room,
-        PowerLevelPatch(users: {widget.user.id: newRole.toPowerLevel()}),
+        PowerLevelPatch(users: {widget.user.userId: newRole.toPowerLevel()}),
       );
     } on PowerLevelException catch (e) {
       if (mounted) setState(() => _roleError = e.message);
@@ -164,7 +177,7 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
   }
 
   Future<void> _kick() async {
-    final displayName = widget.user.displayName ?? widget.user.id;
+    final displayName = widget.user.displayname;
     final cs = Theme.of(context).colorScheme;
     final reason = await _promptModerationReason(
       title: 'Kick member?',
@@ -180,7 +193,7 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
     try {
       await widget.room.client.kick(
         widget.room.id,
-        widget.user.id,
+        widget.user.userId,
         reason: reason.isEmpty ? null : reason,
       );
       if (mounted) Navigator.pop(context);
@@ -196,7 +209,7 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
   }
 
   Future<void> _ban() async {
-    final displayName = widget.user.displayName ?? widget.user.id;
+    final displayName = widget.user.displayname;
     final cs = Theme.of(context).colorScheme;
     final reason = await _promptModerationReason(
       title: 'Ban member?',
@@ -212,7 +225,7 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
     try {
       await widget.room.client.ban(
         widget.room.id,
-        widget.user.id,
+        widget.user.userId,
         reason: reason.isEmpty ? null : reason,
       );
       if (mounted) Navigator.pop(context);
@@ -228,7 +241,7 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
   }
 
   Future<void> _unban() async {
-    final displayName = widget.user.displayName ?? widget.user.id;
+    final displayName = widget.user.displayname;
     final confirmed = await confirmDialog(
       context,
       title: 'Unban member?',
@@ -241,7 +254,7 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
       _actionError = null;
     });
     try {
-      await widget.room.client.unban(widget.room.id, widget.user.id);
+      await widget.room.client.unban(widget.room.id, widget.user.userId);
       if (mounted) Navigator.pop(context);
     } catch (e) {
       debugPrint('[Kohera] Unban failed: $e');
@@ -321,10 +334,10 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
     final tt = Theme.of(context).textTheme;
     final user = widget.user;
     final room = widget.room;
-    final powerLevel = room.getPowerLevelByUserId(user.id);
+    final powerLevel = widget.powerLevel;
     final currentRole = RoomRole.fromPowerLevel(powerLevel);
-    final displayName = user.displayName ?? user.id;
-    final isBanned = user.membership == Membership.ban;
+    final displayName = user.displayname;
+    final isBanned = widget.isBanned;
 
     final canChangeRole = !widget.isMe &&
         room.canChangePowerLevel &&
@@ -344,9 +357,10 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
       title: Column(
         children: [
           UserAvatar(
-            client: room.client,
-            userId: user.id,
+            avatarResolver: widget.avatarResolver,
+            userId: user.userId,
             avatarUrl: user.avatarUrl,
+            displayname: user.displayname,
             presence: widget.presence,
             size: 64,
           ),
@@ -361,7 +375,7 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
             children: [
               Flexible(
                 child: SelectableText(
-                  user.id,
+                  user.userId,
                   style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
                   textAlign: TextAlign.center,
                 ),
@@ -373,7 +387,7 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
                 tooltip: 'Copy MXID',
                 color: cs.onSurfaceVariant,
                 onPressed: () {
-                  unawaited(Clipboard.setData(ClipboardData(text: user.id)));
+                  unawaited(Clipboard.setData(ClipboardData(text: user.userId)));
                   context.showSnack('Copied to clipboard');
                 },
               ),

--- a/lib/features/rooms/widgets/room_members_section.dart
+++ b/lib/features/rooms/widgets/room_members_section.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/features/rooms/widgets/member_sheet_dialog.dart';
+import 'package:kohera/shared/models/kohera_user_summary.dart';
+import 'package:kohera/shared/models/kohera_user_summary_mapper.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
@@ -19,7 +21,8 @@ class RoomMembersSection extends StatefulWidget {
 }
 
 class _RoomMembersSectionState extends State<RoomMembersSection> {
-  List<User> _members = [];
+  List<KoheraUserSummary> _members = [];
+  final Set<String> _bannedUserIds = {};
   bool _loading = true;
   bool _expanded = false;
   int? _lastMemberCount;
@@ -62,11 +65,11 @@ class _RoomMembersSectionState extends State<RoomMembersSection> {
     setState(() => _query = next);
   }
 
-  List<User> _filtered() {
+  List<KoheraUserSummary> _filtered() {
     if (_query.isEmpty) return _members;
     return _members.where((u) {
-      final name = (u.displayName ?? '').toLowerCase();
-      final id = u.id.toLowerCase();
+      final name = u.displayname.toLowerCase();
+      final id = u.userId.toLowerCase();
       return name.contains(_query) || id.contains(_query);
     }).toList();
   }
@@ -86,17 +89,26 @@ class _RoomMembersSectionState extends State<RoomMembersSection> {
     try {
       final members = await widget.room.requestParticipants([Membership.join]);
       if (!mounted || gen != _loadGeneration) return;
+      // Convert SDK User → KoheraUserSummary at the boundary.
+      // Track banned users separately since KoheraUserSummary has no
+      // membership field (deferred to KoheraRoomMember, slice #10).
+      final bannedIds = <String>{};
+      for (final u in members) {
+        if (u.membership == Membership.ban) bannedIds.add(u.id);
+      }
+      final summaries = members.map(toKoheraUserSummary).toList();
       // Sort: admins first, then mods, then alphabetical.
-      members.sort((a, b) {
-        final pa = widget.room.getPowerLevelByUserId(a.id);
-        final pb = widget.room.getPowerLevelByUserId(b.id);
+      summaries.sort((a, b) {
+        final pa = widget.room.getPowerLevelByUserId(a.userId);
+        final pb = widget.room.getPowerLevelByUserId(b.userId);
         if (pa != pb) return pb.compareTo(pa);
-        final na = a.displayName ?? a.id;
-        final nb = b.displayName ?? b.id;
-        return na.compareTo(nb);
+        return a.displayname.compareTo(b.displayname);
       });
       setState(() {
-        _members = members;
+        _members = summaries;
+        _bannedUserIds
+          ..clear()
+          ..addAll(bannedIds);
         _loading = false;
         _lastMemberCount = widget.room.summary.mJoinedMemberCount;
       });
@@ -171,7 +183,11 @@ class _RoomMembersSectionState extends State<RoomMembersSection> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 for (final member in visible)
-                  _MemberTile(user: member, room: widget.room),
+                  _MemberTile(
+                    user: member,
+                    room: widget.room,
+                    isBanned: _bannedUserIds.contains(member.userId),
+                  ),
                 if (!showAll && filtered.length > 5)
                   TextButton(
                     onPressed: () => setState(() => _expanded = true),
@@ -192,10 +208,15 @@ class _RoomMembersSectionState extends State<RoomMembersSection> {
 // ── Member tile ────────────────────────────────────────────────
 
 class _MemberTile extends StatefulWidget {
-  const _MemberTile({required this.user, required this.room});
+  const _MemberTile({
+    required this.user,
+    required this.room,
+    this.isBanned = false,
+  });
 
-  final User user;
+  final KoheraUserSummary user;
   final Room room;
+  final bool isBanned;
 
   @override
   State<_MemberTile> createState() => _MemberTileState();
@@ -206,15 +227,16 @@ class _MemberTileState extends State<_MemberTile> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
-    final powerLevel = widget.room.getPowerLevelByUserId(widget.user.id);
-    final displayName = widget.user.displayName ?? widget.user.id;
+    final powerLevel = widget.room.getPowerLevelByUserId(widget.user.userId);
+    final displayName = widget.user.displayname;
 
     return ListTile(
       dense: true,
       leading: UserAvatar(
-        client: widget.room.client,
-        userId: widget.user.id,
+        avatarResolver: context.read<MatrixService>().avatarResolver,
+        userId: widget.user.userId,
         avatarUrl: widget.user.avatarUrl,
+        displayname: widget.user.displayname,
         presence: context.read<MatrixService>().presence,
         size: 32,
       ),
@@ -224,7 +246,7 @@ class _MemberTileState extends State<_MemberTile> {
         style: tt.bodyMedium,
       ),
       subtitle: Text(
-        widget.user.id,
+        widget.user.userId,
         style: tt.bodySmall,
         overflow: TextOverflow.ellipsis,
       ),
@@ -268,6 +290,7 @@ class _MemberTileState extends State<_MemberTile> {
       context,
       room: widget.room,
       user: widget.user,
+      isBanned: widget.isBanned,
     ),);
   }
 }

--- a/lib/features/rooms/widgets/room_tile.dart
+++ b/lib/features/rooms/widgets/room_tile.dart
@@ -617,9 +617,10 @@ class _CallParticipantList extends StatelessWidget {
                         ? 'You'
                         : user.displayName ?? id,
                     child: UserAvatar(
-                      client: client,
-                      avatarUrl: user.avatarUrl,
+                      avatarResolver: context.read<MatrixService>().avatarResolver,
+                      avatarUrl: user.avatarUrl?.toString(),
                       userId: id,
+                      displayname: user.displayName ?? id,
                       size: _avatarSize,
                     ),
                   );

--- a/lib/features/settings/widgets/account_switcher.dart
+++ b/lib/features/settings/widgets/account_switcher.dart
@@ -27,8 +27,9 @@ class AccountSwitcher extends StatelessWidget {
                 if (i > 0) const Divider(height: 1, indent: 56),
                 ListTile(
                   leading: UserAvatar(
-                    client: manager.services[i].client,
-                    userId: manager.services[i].client.userID,
+                    avatarResolver: manager.services[i].avatarResolver,
+                    userId: manager.services[i].client.userID ?? '',
+                    displayname: manager.services[i].client.userID ?? 'Unknown',
                     presence: manager.services[i].presence,
                     size: 36,
                   ),

--- a/lib/features/settings/widgets/profile_avatar_card.dart
+++ b/lib/features/settings/widgets/profile_avatar_card.dart
@@ -148,9 +148,10 @@ class _ProfileAvatarCardState extends State<ProfileAvatarCard> {
                 Stack(
                   children: [
                     UserAvatar(
-                      client: client,
-                      avatarUrl: _avatarUrl,
-                      userId: client.userID,
+                      avatarResolver: matrix.avatarResolver,
+                      avatarUrl: _avatarUrl?.toString(),
+                      userId: client.userID ?? '',
+                      displayname: client.userID ?? 'Unknown',
                       size: 56,
                     ),
                     if (_avatarUploading)

--- a/lib/features/spaces/widgets/space_rail.dart
+++ b/lib/features/spaces/widgets/space_rail.dart
@@ -590,8 +590,9 @@ class _AccountButtonState extends State<_AccountButton> {
               child: Row(
                 children: [
                   UserAvatar(
-                    client: manager.services[i].client,
-                    userId: manager.services[i].client.userID,
+                    avatarResolver: manager.services[i].avatarResolver,
+                    userId: manager.services[i].client.userID ?? '',
+                    displayname: manager.services[i].client.userID ?? 'Unknown',
                     size: 28,
                   ),
                   const SizedBox(width: 10),
@@ -621,9 +622,10 @@ class _AccountButtonState extends State<_AccountButton> {
       child: MouseRegion(
         cursor: SystemMouseCursors.click,
         child: UserAvatar(
-          client: matrix.client,
-          avatarUrl: _avatarUrl,
-          userId: userId,
+          avatarResolver: matrix.avatarResolver,
+          avatarUrl: _avatarUrl?.toString(),
+          userId: userId ?? '',
+          displayname: userId ?? 'Unknown',
           size: 36,
         ),
       ),

--- a/lib/shared/models/kohera_user_summary.dart
+++ b/lib/shared/models/kohera_user_summary.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/foundation.dart';
+
+/// A Kohera-owned domain model representing a Matrix user with pre-computed
+/// display fields.
+///
+/// This is the foundation model for member and avatar widgets. It carries no
+/// `package:matrix/matrix.dart` dependency — the SDK `User` is converted to this
+/// type at the conversion boundary (e.g. `RoomMembersSection`, `showMemberSheet`).
+///
+/// `KoheraRoomMember` (slice #10 of epic #697) will extend this with
+/// `membership` and `powerLevel` fields.
+@immutable
+class KoheraUserSummary {
+  const KoheraUserSummary({
+    required this.userId,
+    required this.displayname,
+    this.avatarUrl,
+  });
+
+  /// The Matrix user ID (e.g. `@alice:example.com`).
+  final String userId;
+
+  /// The resolved display name. Produced by `User.calcDisplayname()` at the
+  /// conversion boundary — never null (falls back to the user ID).
+  final String displayname;
+
+  /// The raw `mxc://` avatar URI as a string, or `null` if the user has no
+  /// avatar. Resolved to an HTTP thumbnail URL by [AvatarResolver] at render
+  /// time.
+  final String? avatarUrl;
+
+  KoheraUserSummary copyWith({
+    String? userId,
+    String? displayname,
+    String? avatarUrl,
+  }) =>
+      KoheraUserSummary(
+        userId: userId ?? this.userId,
+        displayname: displayname ?? this.displayname,
+        avatarUrl: avatarUrl ?? this.avatarUrl,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is KoheraUserSummary &&
+          userId == other.userId &&
+          displayname == other.displayname &&
+          avatarUrl == other.avatarUrl;
+
+  @override
+  int get hashCode =>
+      Object.hash(userId, displayname, avatarUrl);
+
+  @override
+  String toString() =>
+      'KoheraUserSummary(userId: $userId, displayname: $displayname, '
+      'avatarUrl: $avatarUrl)';
+}

--- a/lib/shared/models/kohera_user_summary_mapper.dart
+++ b/lib/shared/models/kohera_user_summary_mapper.dart
@@ -1,0 +1,16 @@
+import 'package:kohera/shared/models/kohera_user_summary.dart';
+import 'package:matrix/matrix.dart';
+
+/// Converts a Matrix SDK [User] into a [KoheraUserSummary] domain model.
+///
+/// This is the single conversion boundary for `User` → `KoheraUserSummary`.
+/// It calls `user.calcDisplayname()` once (which resolves the room profile
+/// display name) and reads `user.avatarUrl` / `user.id`.
+///
+/// Call this wherever `User` objects are obtained from the SDK
+/// (room participants, typing users, read receipt users).
+KoheraUserSummary toKoheraUserSummary(User user) => KoheraUserSummary(
+      userId: user.id,
+      displayname: user.calcDisplayname(),
+      avatarUrl: user.avatarUrl?.toString(),
+    );

--- a/lib/shared/services/avatar_resolver.dart
+++ b/lib/shared/services/avatar_resolver.dart
@@ -1,0 +1,26 @@
+/// The result of resolving an `mxc://` avatar URI to an HTTP thumbnail URL
+/// with optional authentication headers.
+class AvatarThumbnail {
+  const AvatarThumbnail({required this.url, this.headers});
+
+  /// The resolved HTTP(S) thumbnail URL.
+  final String url;
+
+  /// Auth headers for authenticated media endpoints, or `null` if the
+  /// endpoint does not require authentication.
+  final Map<String, String>? headers;
+}
+
+/// Resolves `mxc://` avatar URIs to HTTP thumbnail URLs with auth headers.
+///
+/// This abstraction decouples avatar-rendering widgets from
+/// `package:matrix/matrix.dart` — the concrete implementation
+/// ([ClientAvatarResolver]) wraps the Matrix `Client`, but widgets only
+/// depend on this interface.
+abstract interface class AvatarResolver {
+  /// Resolves [mxcUrl] (an `mxc://` URI string) to a thumbnail URL sized for
+  /// [size] pixels (the resolver doubles the dimension for retina).
+  ///
+  /// Returns `null` if [mxcUrl] is null or resolution fails.
+  Future<AvatarThumbnail?> resolve(String? mxcUrl, {required double size});
+}

--- a/lib/shared/widgets/media_viewer_shell.dart
+++ b/lib/shared/widgets/media_viewer_shell.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:kohera/core/services/client_avatar_resolver.dart';
 import 'package:kohera/core/utils/media_cache_io.dart'
     if (dart.library.js_interop) 'package:kohera/core/utils/media_cache_web.dart';
 import 'package:kohera/core/utils/time_format.dart';
@@ -133,9 +134,10 @@ class _MediaViewerShellState extends State<MediaViewerShell> {
                   child: Row(
                     children: [
                       UserAvatar(
-                        client: widget.event.room.client,
-                        avatarUrl: sender.avatarUrl,
+                        avatarResolver: ClientAvatarResolver(widget.event.room.client),
+                        avatarUrl: sender.avatarUrl?.toString(),
                         userId: sender.id,
+                        displayname: sender.calcDisplayname(),
                         size: 32,
                       ),
                       const SizedBox(width: 8),

--- a/lib/shared/widgets/user_avatar.dart
+++ b/lib/shared/widgets/user_avatar.dart
@@ -4,30 +4,45 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart';
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/sub_services/presence_service.dart';
-import 'package:kohera/core/utils/media_auth.dart';
 import 'package:kohera/core/utils/sender_color.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/widgets/presence_dot.dart';
-import 'package:matrix/matrix.dart';
 
 /// Displays a user's Matrix avatar with a colored-initial fallback.
 ///
-/// Resolves the mxc:// [avatarUrl] asynchronously via [getThumbnailUri]
-/// and passes auth headers for authenticated media endpoints.
+/// Resolves the mxc:// [avatarUrl] asynchronously via [avatarResolver] and
+/// passes auth headers for authenticated media endpoints.
 ///
 /// When [presence] and [userId] are both supplied, an opt-in status dot is
 /// overlaid on the bottom-right. Unknown presence renders no dot.
 class UserAvatar extends StatefulWidget {
   const UserAvatar({
-    required this.client, super.key,
+    required this.userId,
+    required this.displayname,
     this.avatarUrl,
-    this.userId,
+    this.avatarResolver,
     this.size = 44,
     this.presence,
+    super.key,
   });
 
-  final Client client;
-  final Uri? avatarUrl;
-  final String? userId;
+  /// The Matrix user ID (e.g. `@alice:example.com`). Used for the initial
+  /// fallback and the presence dot.
+  final String userId;
+
+  /// The resolved display name. Currently unused for rendering (the initial
+  /// is derived from [userId] to preserve existing behaviour) but stored for
+  /// future tooltip/accessibility use.
+  final String displayname;
+
+  /// The raw `mxc://` avatar URI as a string, or `null` if the user has no
+  /// avatar.
+  final String? avatarUrl;
+
+  /// Resolves [avatarUrl] to an HTTP thumbnail URL with auth headers.
+  /// If `null`, only the fallback initial is shown.
+  final AvatarResolver? avatarResolver;
+
   final double size;
   final PresenceService? presence;
 
@@ -37,6 +52,7 @@ class UserAvatar extends StatefulWidget {
 
 class _UserAvatarState extends State<UserAvatar> {
   String? _resolvedUrl;
+  Map<String, String>? _resolvedHeaders;
 
   @override
   void initState() {
@@ -49,20 +65,25 @@ class _UserAvatarState extends State<UserAvatar> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.avatarUrl != widget.avatarUrl) {
       _resolvedUrl = null;
+      _resolvedHeaders = null;
       unawaited(_resolveThumbnail());
     }
   }
 
   Future<void> _resolveThumbnail() async {
-    final avatarUrl = widget.avatarUrl;
-    if (avatarUrl == null) return;
+    final resolver = widget.avatarResolver;
+    if (resolver == null) return;
     try {
-      final uri = await avatarUrl.getThumbnailUri(
-        widget.client,
-        width: (widget.size * 2).toInt(),
-        height: (widget.size * 2).toInt(),
+      final result = await resolver.resolve(
+        widget.avatarUrl,
+        size: widget.size,
       );
-      if (mounted) setState(() => _resolvedUrl = uri.toString());
+      if (mounted && result != null) {
+        setState(() {
+          _resolvedUrl = result.url;
+          _resolvedHeaders = result.headers;
+        });
+      }
     } catch (e) {
       debugPrint('[Kohera] Failed to resolve avatar thumbnail: $e');
     }
@@ -72,8 +93,7 @@ class _UserAvatarState extends State<UserAvatar> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final initial = _userInitial(widget.userId);
-    final bgColor =
-        senderColor(widget.userId ?? '', cs, fallback: cs.primaryContainer);
+    final bgColor = senderColor(widget.userId, cs, fallback: cs.primaryContainer);
 
     final avatar = ClipOval(
       child: SizedBox(
@@ -82,7 +102,7 @@ class _UserAvatarState extends State<UserAvatar> {
         child: _resolvedUrl != null
             ? CachedNetworkImage(
                 imageUrl: _resolvedUrl!,
-                httpHeaders: mediaAuthHeaders(widget.client, _resolvedUrl!),
+                httpHeaders: _resolvedHeaders,
                 imageRenderMethodForWeb: ImageRenderMethodForWeb.HttpGet,
                 fit: BoxFit.cover,
                 placeholder: (_, __) => _Fallback(
@@ -112,11 +132,11 @@ class _UserAvatarState extends State<UserAvatar> {
     );
   }
 
-  static String _userInitial(String? userId) {
-    if (userId != null && userId.length > 1) return userId[1].toUpperCase();
-    return (userId ?? '?')[0].toUpperCase();
+  static String _userInitial(String userId) {
+    if (userId.isEmpty) return '?';
+    if (userId.length > 1) return userId[1].toUpperCase();
+    return userId[0].toUpperCase();
   }
-
 }
 
 class _Fallback extends StatelessWidget {

--- a/test/e2e/room_management_test.dart
+++ b/test/e2e/room_management_test.dart
@@ -82,6 +82,7 @@ MockUser makeUser(String id, String displayName, {Room? room}) {
   final user = MockUser();
   when(user.id).thenReturn(id);
   when(user.displayName).thenReturn(displayName);
+  when(user.calcDisplayname()).thenReturn(displayName);
   when(user.room).thenReturn(room ?? MockRoom());
   when(user.membership).thenReturn(Membership.join);
   return user;

--- a/test/models/kohera_user_summary_test.dart
+++ b/test/models/kohera_user_summary_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/shared/models/kohera_user_summary.dart';
+
+void main() {
+  group('KoheraUserSummary', () {
+    test('constructs with required fields', () {
+      const user = KoheraUserSummary(
+        userId: '@alice:example.com',
+        displayname: 'Alice',
+        avatarUrl: 'mxc://example.com/avatar123',
+      );
+
+      expect(user.userId, '@alice:example.com');
+      expect(user.displayname, 'Alice');
+      expect(user.avatarUrl, 'mxc://example.com/avatar123');
+    });
+
+    test('constructs with null avatarUrl', () {
+      const user = KoheraUserSummary(
+        userId: '@bob:example.com',
+        displayname: 'Bob',
+      );
+
+      expect(user.avatarUrl, isNull);
+    });
+
+    test('equality based on all fields', () {
+      const a = KoheraUserSummary(
+        userId: '@alice:example.com',
+        displayname: 'Alice',
+        avatarUrl: 'mxc://example.com/abc',
+      );
+      const b = KoheraUserSummary(
+        userId: '@alice:example.com',
+        displayname: 'Alice',
+        avatarUrl: 'mxc://example.com/abc',
+      );
+      const c = KoheraUserSummary(
+        userId: '@alice:example.com',
+        displayname: 'Alicia',
+        avatarUrl: 'mxc://example.com/abc',
+      );
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a == c, isFalse);
+    });
+
+    test('copyWith updates fields', () {
+      const user = KoheraUserSummary(
+        userId: '@alice:example.com',
+        displayname: 'Alice',
+        avatarUrl: 'mxc://example.com/old',
+      );
+
+      final updated = user.copyWith(
+        displayname: 'Alicia',
+        avatarUrl: 'mxc://example.com/new',
+      );
+
+      expect(updated.userId, '@alice:example.com');
+      expect(updated.displayname, 'Alicia');
+      expect(updated.avatarUrl, 'mxc://example.com/new');
+    });
+
+    test('copyWith preserves unchanged fields', () {
+      const user = KoheraUserSummary(
+        userId: '@alice:example.com',
+        displayname: 'Alice',
+        avatarUrl: 'mxc://example.com/abc',
+      );
+
+      final updated = user.copyWith(displayname: 'Alicia');
+
+      expect(updated.userId, '@alice:example.com');
+      expect(updated.displayname, 'Alicia');
+      expect(updated.avatarUrl, 'mxc://example.com/abc');
+    });
+
+    test('toString contains all fields', () {
+      const user = KoheraUserSummary(
+        userId: '@alice:example.com',
+        displayname: 'Alice',
+        avatarUrl: 'mxc://example.com/abc',
+      );
+
+      final str = user.toString();
+      expect(str, contains('@alice:example.com'));
+      expect(str, contains('Alice'));
+      expect(str, contains('mxc://example.com/abc'));
+    });
+  });
+}

--- a/test/screens/chat_search_test.mocks.dart
+++ b/test/screens/chat_search_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i23;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i24;
 
-import 'package:flutter/services.dart' as _i24;
-import 'package:flutter/widgets.dart' as _i25;
+import 'package:flutter/services.dart' as _i25;
+import 'package:flutter/widgets.dart' as _i26;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i22;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i23;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,14 +28,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i19;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i18;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i26;
+import 'package:matrix/src/utils/space_child.dart' as _i27;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i20;
+import 'package:mockito/src/dummies.dart' as _i21;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -860,9 +861,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -871,8 +872,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,9 +883,19 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_78(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,8 +904,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,8 +914,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -912,8 +924,8 @@ class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_81 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_81(
+class _FakeRoom_82 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -922,9 +934,9 @@ class _FakeRoom_81 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_82 extends _i1.SmartFake
-    implements _i18.TimelineChunk {
-  _FakeTimelineChunk_82(
+class _FakeTimelineChunk_83 extends _i1.SmartFake
+    implements _i19.TimelineChunk {
+  _FakeTimelineChunk_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -951,12 +963,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i19.KeyVerificationMethod> get verificationMethods =>
+  Set<_i20.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i19.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
-      ) as Set<_i19.KeyVerificationMethod>);
+        returnValue: <_i20.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
+      ) as Set<_i20.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1076,11 +1088,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1117,11 +1129,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1151,11 +1163,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1164,11 +1176,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1454,34 +1466,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i20.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i19.KeyVerification>
+  _i3.CachedStreamController<_i20.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i19.KeyVerification>(
+                _FakeCachedStreamController_6<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i19.KeyVerification>);
+          ) as _i3.CachedStreamController<_i20.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1637,7 +1649,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1926,14 +1938,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2321,8 +2333,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValue: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2338,8 +2350,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2380,7 +2392,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2396,7 +2408,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2445,7 +2457,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2466,7 +2478,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2569,7 +2581,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2587,7 +2599,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3106,7 +3118,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3458,7 +3470,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3472,7 +3484,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3623,7 +3635,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5001,7 +5013,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5023,7 +5035,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5517,7 +5529,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5529,7 +5541,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6537,7 +6549,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6548,7 +6560,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6796,7 +6808,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6808,7 +6820,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7068,7 +7080,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7081,7 +7093,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7148,7 +7160,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7161,7 +7173,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7209,7 +7221,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7221,7 +7233,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7469,7 +7481,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7480,7 +7492,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7742,7 +7754,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7769,7 +7781,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7799,11 +7811,11 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7941,17 +7953,30 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8060,7 +8085,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8113,7 +8147,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i24.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8209,7 +8243,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8218,7 +8252,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8237,7 +8271,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i25.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8248,7 +8282,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i25.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8296,7 +8330,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i25.RouteInformation? routeInformation) =>
+          _i26.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8334,7 +8368,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i24.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8343,7 +8377,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i24.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8352,16 +8386,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i24.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
-      ) as _i5.Future<_i23.AppExitResponse>);
+            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
+      ) as _i5.Future<_i24.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8389,11 +8423,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8423,11 +8457,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -8480,11 +8514,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8520,11 +8554,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8540,11 +8574,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8553,11 +8587,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8600,11 +8634,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8647,11 +8681,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8870,18 +8904,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i27.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i26.SpaceParent>[],
-        returnValueForMissingStub: <_i26.SpaceParent>[],
-      ) as List<_i26.SpaceParent>);
+        returnValue: <_i27.SpaceParent>[],
+        returnValueForMissingStub: <_i27.SpaceParent>[],
+      ) as List<_i27.SpaceParent>);
 
   @override
-  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i27.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i26.SpaceChild>[],
-        returnValueForMissingStub: <_i26.SpaceChild>[],
-      ) as List<_i26.SpaceChild>);
+        returnValue: <_i27.SpaceChild>[],
+        returnValueForMissingStub: <_i27.SpaceChild>[],
+      ) as List<_i27.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9048,14 +9082,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9103,7 +9137,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9111,7 +9145,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9126,7 +9160,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9134,7 +9168,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9228,7 +9262,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9236,7 +9270,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9478,7 +9512,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9489,7 +9523,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9578,15 +9612,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i18.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i18.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i18.TimelineChunk?>.value(),
-      ) as _i5.Future<_i18.TimelineChunk?>);
+        returnValue: _i5.Future<_i19.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i19.TimelineChunk?>.value(),
+      ) as _i5.Future<_i19.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9627,7 +9661,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9644,7 +9678,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9708,14 +9742,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9731,14 +9765,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9794,7 +9828,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9802,7 +9836,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10114,11 +10148,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -10168,17 +10202,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i18.TimelineChunk get chunk => (super.noSuchMethod(
+  _i19.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_82(
+        returnValue: _FakeTimelineChunk_83(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_82(
+        returnValueForMissingStub: _FakeTimelineChunk_83(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i18.TimelineChunk);
+      ) as _i19.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10281,7 +10315,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i18.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i19.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,

--- a/test/screens/devices_screen_test.mocks.dart
+++ b/test/screens/devices_screen_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,12 +28,13 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -858,9 +859,20 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -887,12 +899,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1012,11 +1024,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1053,11 +1065,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1087,11 +1099,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1100,11 +1112,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1390,34 +1402,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1573,7 +1585,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1862,14 +1874,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2257,8 +2269,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2274,8 +2286,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2316,7 +2328,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2332,7 +2344,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2381,7 +2393,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2402,7 +2414,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2505,7 +2517,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2523,7 +2535,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3042,7 +3054,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3394,7 +3406,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3408,7 +3420,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3559,7 +3571,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4937,7 +4949,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4959,7 +4971,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5453,7 +5465,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5465,7 +5477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6473,7 +6485,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6484,7 +6496,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6732,7 +6744,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6744,7 +6756,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7004,7 +7016,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7017,7 +7029,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7084,7 +7096,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7097,7 +7109,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7145,7 +7157,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7157,7 +7169,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7405,7 +7417,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7416,7 +7428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7678,7 +7690,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7705,7 +7717,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7735,11 +7747,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7877,17 +7889,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7996,7 +8021,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8049,7 +8083,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8145,7 +8179,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8154,7 +8188,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8173,7 +8207,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8184,7 +8218,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8232,7 +8266,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8270,7 +8304,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8279,7 +8313,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8288,16 +8322,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8437,7 +8471,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> runKeyRecovery({_i18.OpenSSSS? ssssKey}) =>
+  _i5.Future<void> runKeyRecovery({_i19.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
@@ -8491,7 +8525,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8500,7 +8534,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/screens/room_permissions_screen_test.mocks.dart
+++ b/test/screens/room_permissions_screen_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,14 +28,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i26;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i27;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i25;
+import 'package:matrix/src/utils/space_child.dart' as _i26;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -860,9 +861,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -871,8 +872,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,9 +883,19 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_78(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,8 +904,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,8 +914,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -912,8 +924,8 @@ class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_81 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_81(
+class _FakeRoom_82 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -922,8 +934,8 @@ class _FakeRoom_81 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeMatrixFile_82 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_82(
+class _FakeMatrixFile_83 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -932,8 +944,8 @@ class _FakeMatrixFile_82 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_83 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_83(
+class _FakeEvent_84 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -960,12 +972,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1085,11 +1097,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1126,11 +1138,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1160,11 +1172,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1173,11 +1185,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1463,34 +1475,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1646,7 +1658,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1935,14 +1947,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2330,8 +2342,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2347,8 +2359,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2389,7 +2401,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2405,7 +2417,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2454,7 +2466,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2475,7 +2487,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2578,7 +2590,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2596,7 +2608,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3115,7 +3127,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3467,7 +3479,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3481,7 +3493,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3632,7 +3644,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5010,7 +5022,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5032,7 +5044,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5526,7 +5538,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5538,7 +5550,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6546,7 +6558,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6557,7 +6569,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6805,7 +6817,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6817,7 +6829,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7077,7 +7089,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7090,7 +7102,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7157,7 +7169,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7170,7 +7182,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7218,7 +7230,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7230,7 +7242,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7478,7 +7490,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7489,7 +7501,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7751,7 +7763,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7778,7 +7790,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7808,11 +7820,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7950,17 +7962,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8069,7 +8094,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8122,7 +8156,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8218,7 +8252,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8227,7 +8261,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8246,7 +8280,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8257,7 +8291,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8305,7 +8339,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8343,7 +8377,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8352,7 +8386,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8361,16 +8395,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8398,11 +8432,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8432,11 +8466,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -8489,11 +8523,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8529,11 +8563,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8549,11 +8583,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8562,11 +8596,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8609,11 +8643,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8656,11 +8690,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8879,18 +8913,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i25.SpaceParent>[],
-        returnValueForMissingStub: <_i25.SpaceParent>[],
-      ) as List<_i25.SpaceParent>);
+        returnValue: <_i26.SpaceParent>[],
+        returnValueForMissingStub: <_i26.SpaceParent>[],
+      ) as List<_i26.SpaceParent>);
 
   @override
-  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i25.SpaceChild>[],
-        returnValueForMissingStub: <_i25.SpaceChild>[],
-      ) as List<_i25.SpaceChild>);
+        returnValue: <_i26.SpaceChild>[],
+        returnValueForMissingStub: <_i26.SpaceChild>[],
+      ) as List<_i26.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9057,14 +9091,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9112,7 +9146,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9120,7 +9154,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9135,7 +9169,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9143,7 +9177,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9237,7 +9271,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9245,7 +9279,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9487,7 +9521,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9498,7 +9532,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9587,15 +9621,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i26.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i27.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i26.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i26.TimelineChunk?>.value(),
-      ) as _i5.Future<_i26.TimelineChunk?>);
+        returnValue: _i5.Future<_i27.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i27.TimelineChunk?>.value(),
+      ) as _i5.Future<_i27.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9636,7 +9670,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9653,7 +9687,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9717,14 +9751,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9740,14 +9774,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9803,7 +9837,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9811,7 +9845,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10123,11 +10157,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.getter(#sender),
         ),
@@ -10136,11 +10170,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10149,11 +10183,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -10176,11 +10210,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10189,11 +10223,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10202,11 +10236,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10215,11 +10249,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10228,11 +10262,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10241,11 +10275,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10310,11 +10344,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10323,11 +10357,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10380,11 +10414,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10469,11 +10503,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10491,11 +10525,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10706,7 +10740,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i20.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i21.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10721,7 +10755,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_82(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_83(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10735,7 +10769,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_82(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_83(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10771,7 +10805,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10786,7 +10820,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10823,7 +10857,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10837,7 +10871,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10874,7 +10908,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10888,7 +10922,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10922,7 +10956,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10935,7 +10969,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11011,14 +11045,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_83(
+        returnValue: _FakeEvent_84(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_83(
+        returnValueForMissingStub: _FakeEvent_84(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11035,11 +11069,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -11048,11 +11082,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11118,11 +11152,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11147,11 +11181,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11169,11 +11203,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11220,7 +11254,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11232,7 +11266,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11302,7 +11336,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11315,7 +11349,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/services/chat_message_actions_test.mocks.dart
+++ b/test/services/chat_message_actions_test.mocks.dart
@@ -4,20 +4,20 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i6;
-import 'dart:typed_data' as _i25;
-import 'dart:ui' as _i28;
+import 'dart:typed_data' as _i26;
+import 'dart:ui' as _i29;
 
-import 'package:flutter/scheduler.dart' as _i22;
-import 'package:flutter/services.dart' as _i29;
-import 'package:flutter/src/foundation/assertions.dart' as _i32;
-import 'package:flutter/src/foundation/diagnostics.dart' as _i21;
-import 'package:flutter/src/material/banner.dart' as _i31;
-import 'package:flutter/src/material/scaffold.dart' as _i19;
-import 'package:flutter/src/material/snack_bar.dart' as _i30;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/scheduler.dart' as _i23;
+import 'package:flutter/services.dart' as _i30;
+import 'package:flutter/src/foundation/assertions.dart' as _i33;
+import 'package:flutter/src/foundation/diagnostics.dart' as _i22;
+import 'package:flutter/src/material/banner.dart' as _i32;
+import 'package:flutter/src/material/scaffold.dart' as _i20;
+import 'package:flutter/src/material/snack_bar.dart' as _i31;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i5;
-import 'package:kohera/core/services/matrix_service.dart' as _i27;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
+import 'package:kohera/core/services/matrix_service.dart' as _i28;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i19;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i11;
@@ -34,14 +34,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i8;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i9;
-import 'package:matrix/encryption.dart' as _i26;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i18;
+import 'package:matrix/encryption.dart' as _i27;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i7;
 import 'package:matrix/src/models/timeline_chunk.dart' as _i4;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i24;
+import 'package:matrix/src/utils/space_child.dart' as _i25;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i23;
+import 'package:mockito/src/dummies.dart' as _i24;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -947,9 +948,9 @@ class _FakeOutboxService_83 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_84 extends _i1.SmartFake
-    implements _i18.StickerPackService {
-  _FakeStickerPackService_84(
+class _FakeAvatarResolver_84 extends _i1.SmartFake
+    implements _i18.AvatarResolver {
+  _FakeAvatarResolver_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -958,24 +959,9 @@ class _FakeStickerPackService_84 extends _i1.SmartFake
         );
 }
 
-class _FakeScaffoldMessenger_85 extends _i1.SmartFake
-    implements _i19.ScaffoldMessenger {
-  _FakeScaffoldMessenger_85(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-
-  @override
-  String toString(
-          {_i20.DiagnosticLevel? minLevel = _i20.DiagnosticLevel.info}) =>
-      super.toString();
-}
-
-class _FakeBuildContext_86 extends _i1.SmartFake implements _i20.BuildContext {
-  _FakeBuildContext_86(
+class _FakeStickerPackService_85 extends _i1.SmartFake
+    implements _i19.StickerPackService {
+  _FakeStickerPackService_85(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -984,19 +970,9 @@ class _FakeBuildContext_86 extends _i1.SmartFake implements _i20.BuildContext {
         );
 }
 
-class _FakeScaffoldFeatureController_87<T extends _i20.Widget, U>
-    extends _i1.SmartFake implements _i19.ScaffoldFeatureController<T, U> {
-  _FakeScaffoldFeatureController_87(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeWidget_88 extends _i1.SmartFake implements _i20.Widget {
-  _FakeWidget_88(
+class _FakeScaffoldMessenger_86 extends _i1.SmartFake
+    implements _i20.ScaffoldMessenger {
+  _FakeScaffoldMessenger_86(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1006,13 +982,49 @@ class _FakeWidget_88 extends _i1.SmartFake implements _i20.Widget {
 
   @override
   String toString(
-          {_i20.DiagnosticLevel? minLevel = _i20.DiagnosticLevel.info}) =>
+          {_i21.DiagnosticLevel? minLevel = _i21.DiagnosticLevel.info}) =>
       super.toString();
 }
 
-class _FakeDiagnosticsNode_89 extends _i1.SmartFake
-    implements _i20.DiagnosticsNode {
-  _FakeDiagnosticsNode_89(
+class _FakeBuildContext_87 extends _i1.SmartFake implements _i21.BuildContext {
+  _FakeBuildContext_87(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeScaffoldFeatureController_88<T extends _i21.Widget, U>
+    extends _i1.SmartFake implements _i20.ScaffoldFeatureController<T, U> {
+  _FakeScaffoldFeatureController_88(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeWidget_89 extends _i1.SmartFake implements _i21.Widget {
+  _FakeWidget_89(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+
+  @override
+  String toString(
+          {_i21.DiagnosticLevel? minLevel = _i21.DiagnosticLevel.info}) =>
+      super.toString();
+}
+
+class _FakeDiagnosticsNode_90 extends _i1.SmartFake
+    implements _i21.DiagnosticsNode {
+  _FakeDiagnosticsNode_90(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1022,14 +1034,14 @@ class _FakeDiagnosticsNode_89 extends _i1.SmartFake
 
   @override
   String toString({
-    _i21.TextTreeConfiguration? parentConfiguration,
-    _i20.DiagnosticLevel? minLevel = _i20.DiagnosticLevel.info,
+    _i22.TextTreeConfiguration? parentConfiguration,
+    _i21.DiagnosticLevel? minLevel = _i21.DiagnosticLevel.info,
   }) =>
       super.toString();
 }
 
-class _FakeTicker_90 extends _i1.SmartFake implements _i22.Ticker {
-  _FakeTicker_90(
+class _FakeTicker_91 extends _i1.SmartFake implements _i23.Ticker {
+  _FakeTicker_91(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1048,11 +1060,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1139,11 +1151,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -1179,11 +1191,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1199,11 +1211,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1212,11 +1224,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1259,11 +1271,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1529,18 +1541,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i24.SpaceParent>[],
-        returnValueForMissingStub: <_i24.SpaceParent>[],
-      ) as List<_i24.SpaceParent>);
+        returnValue: <_i25.SpaceParent>[],
+        returnValueForMissingStub: <_i25.SpaceParent>[],
+      ) as List<_i25.SpaceParent>);
 
   @override
-  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i24.SpaceChild>[],
-        returnValueForMissingStub: <_i24.SpaceChild>[],
-      ) as List<_i24.SpaceChild>);
+        returnValue: <_i25.SpaceChild>[],
+        returnValueForMissingStub: <_i25.SpaceChild>[],
+      ) as List<_i25.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -1707,14 +1719,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -1762,7 +1774,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -1770,7 +1782,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -1785,7 +1797,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -1793,7 +1805,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -1887,7 +1899,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -1895,7 +1907,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2137,7 +2149,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2148,7 +2160,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2453,7 +2465,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2461,7 +2473,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2839,11 +2851,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -2852,11 +2864,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -2865,11 +2877,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -2878,11 +2890,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -2891,11 +2903,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -2960,11 +2972,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -2973,11 +2985,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -3030,11 +3042,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -3119,11 +3131,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -3141,11 +3153,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -3356,7 +3368,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i6.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i6.Future<_i25.Uint8List> Function(Uri)? downloadCallback,
+    _i6.Future<_i26.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -3421,7 +3433,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -3436,7 +3448,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -3473,7 +3485,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -3487,7 +3499,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -3524,7 +3536,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -3538,7 +3550,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -3572,7 +3584,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -3585,7 +3597,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -4062,12 +4074,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i26.KeyVerificationMethod> get verificationMethods =>
+  Set<_i27.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i26.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i26.KeyVerificationMethod>{},
-      ) as Set<_i26.KeyVerificationMethod>);
+        returnValue: <_i27.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i27.KeyVerificationMethod>{},
+      ) as Set<_i27.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -4187,11 +4199,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -4228,11 +4240,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -4262,11 +4274,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -4275,11 +4287,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -4566,34 +4578,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i26.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i27.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_1<_i26.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_1<_i27.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_1<_i26.RoomKeyRequest>(
+            _FakeCachedStreamController_1<_i27.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i26.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i27.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i26.KeyVerification>
+  _i3.CachedStreamController<_i27.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_1<_i26.KeyVerification>(
+            returnValue: _FakeCachedStreamController_1<_i27.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_1<_i26.KeyVerification>(
+                _FakeCachedStreamController_1<_i27.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i26.KeyVerification>);
+          ) as _i3.CachedStreamController<_i27.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -4749,7 +4761,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i26.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i27.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -5038,14 +5050,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -5433,8 +5445,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i23.ifNotNull(
-              _i23.dummyValueOrNull<T>(
+        returnValue: _i24.ifNotNull(
+              _i24.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -5450,8 +5462,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i23.ifNotNull(
-              _i23.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i24.ifNotNull(
+              _i24.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -5492,7 +5504,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -5508,7 +5520,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -5557,7 +5569,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -5578,7 +5590,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -5681,7 +5693,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -5699,7 +5711,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -6221,7 +6233,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i6.Future<Uri> uploadContent(
-    _i25.Uint8List? file, {
+    _i26.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -6573,7 +6585,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -6587,7 +6599,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -6738,7 +6750,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i5.BaseResponse? response,
-    _i25.Uint8List? body,
+    _i26.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8116,7 +8128,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -8138,7 +8150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -8632,7 +8644,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -8644,7 +8656,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -9652,7 +9664,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -9663,7 +9675,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -9911,7 +9923,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9923,7 +9935,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -10183,7 +10195,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -10196,7 +10208,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -10263,7 +10275,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -10276,7 +10288,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -10324,7 +10336,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -10336,7 +10348,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -10584,7 +10596,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -10595,7 +10607,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i23.dummyValue<String>(
+            _i6.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -10857,7 +10869,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i6.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i25.Uint8List? body, {
+    _i26.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10884,7 +10896,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i27.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i28.MatrixService {
   @override
   _i8.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -10914,11 +10926,11 @@ class MockMatrixService extends _i1.Mock implements _i27.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -11056,17 +11068,30 @@ class MockMatrixService extends _i1.Mock implements _i27.MatrixService {
       ) as _i17.OutboxService);
 
   @override
-  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i18.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_84(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_84(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i18.AvatarResolver);
+
+  @override
+  _i19.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_84(
+        returnValue: _FakeStickerPackService_85(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_84(
+        returnValueForMissingStub: _FakeStickerPackService_85(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i18.StickerPackService);
+      ) as _i19.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -11175,7 +11200,16 @@ class MockMatrixService extends _i1.Mock implements _i27.MatrixService {
       );
 
   @override
-  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i18.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i19.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -11228,7 +11262,7 @@ class MockMatrixService extends _i1.Mock implements _i27.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i28.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i29.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -11324,7 +11358,7 @@ class MockMatrixService extends _i1.Mock implements _i27.MatrixService {
       ) as _i6.Future<void>);
 
   @override
-  void addListener(_i28.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i29.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -11333,7 +11367,7 @@ class MockMatrixService extends _i1.Mock implements _i27.MatrixService {
       );
 
   @override
-  void removeListener(_i28.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i29.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -11352,7 +11386,7 @@ class MockMatrixService extends _i1.Mock implements _i27.MatrixService {
       ) as _i6.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i29.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i30.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -11363,7 +11397,7 @@ class MockMatrixService extends _i1.Mock implements _i27.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i29.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i30.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -11411,7 +11445,7 @@ class MockMatrixService extends _i1.Mock implements _i27.MatrixService {
 
   @override
   _i6.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -11449,7 +11483,7 @@ class MockMatrixService extends _i1.Mock implements _i27.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i28.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i29.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -11458,7 +11492,7 @@ class MockMatrixService extends _i1.Mock implements _i27.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i28.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i29.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -11467,16 +11501,16 @@ class MockMatrixService extends _i1.Mock implements _i27.MatrixService {
       );
 
   @override
-  _i6.Future<_i28.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i6.Future<_i29.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i6.Future<_i28.AppExitResponse>.value(_i28.AppExitResponse.exit),
+            _i6.Future<_i29.AppExitResponse>.value(_i29.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i6.Future<_i28.AppExitResponse>.value(_i28.AppExitResponse.exit),
-      ) as _i6.Future<_i28.AppExitResponse>);
+            _i6.Future<_i29.AppExitResponse>.value(_i29.AppExitResponse.exit),
+      ) as _i6.Future<_i29.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -11501,32 +11535,32 @@ class MockMatrixService extends _i1.Mock implements _i27.MatrixService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockScaffoldMessengerState extends _i1.Mock
-    implements _i19.ScaffoldMessengerState {
+    implements _i20.ScaffoldMessengerState {
   @override
-  _i19.ScaffoldMessenger get widget => (super.noSuchMethod(
+  _i20.ScaffoldMessenger get widget => (super.noSuchMethod(
         Invocation.getter(#widget),
-        returnValue: _FakeScaffoldMessenger_85(
+        returnValue: _FakeScaffoldMessenger_86(
           this,
           Invocation.getter(#widget),
         ),
-        returnValueForMissingStub: _FakeScaffoldMessenger_85(
+        returnValueForMissingStub: _FakeScaffoldMessenger_86(
           this,
           Invocation.getter(#widget),
         ),
-      ) as _i19.ScaffoldMessenger);
+      ) as _i20.ScaffoldMessenger);
 
   @override
-  _i20.BuildContext get context => (super.noSuchMethod(
+  _i21.BuildContext get context => (super.noSuchMethod(
         Invocation.getter(#context),
-        returnValue: _FakeBuildContext_86(
+        returnValue: _FakeBuildContext_87(
           this,
           Invocation.getter(#context),
         ),
-        returnValueForMissingStub: _FakeBuildContext_86(
+        returnValueForMissingStub: _FakeBuildContext_87(
           this,
           Invocation.getter(#context),
         ),
-      ) as _i20.BuildContext);
+      ) as _i21.BuildContext);
 
   @override
   bool get mounted => (super.noSuchMethod(
@@ -11545,10 +11579,10 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  _i19.ScaffoldFeatureController<_i30.SnackBar, _i30.SnackBarClosedReason>
+  _i20.ScaffoldFeatureController<_i31.SnackBar, _i31.SnackBarClosedReason>
       showSnackBar(
-    _i30.SnackBar? snackBar, {
-    _i20.AnimationStyle? snackBarAnimationStyle,
+    _i31.SnackBar? snackBar, {
+    _i21.AnimationStyle? snackBarAnimationStyle,
   }) =>
           (super.noSuchMethod(
             Invocation.method(
@@ -11556,8 +11590,8 @@ class MockScaffoldMessengerState extends _i1.Mock
               [snackBar],
               {#snackBarAnimationStyle: snackBarAnimationStyle},
             ),
-            returnValue: _FakeScaffoldFeatureController_87<_i30.SnackBar,
-                _i30.SnackBarClosedReason>(
+            returnValue: _FakeScaffoldFeatureController_88<_i31.SnackBar,
+                _i31.SnackBarClosedReason>(
               this,
               Invocation.method(
                 #showSnackBar,
@@ -11565,8 +11599,8 @@ class MockScaffoldMessengerState extends _i1.Mock
                 {#snackBarAnimationStyle: snackBarAnimationStyle},
               ),
             ),
-            returnValueForMissingStub: _FakeScaffoldFeatureController_87<
-                _i30.SnackBar, _i30.SnackBarClosedReason>(
+            returnValueForMissingStub: _FakeScaffoldFeatureController_88<
+                _i31.SnackBar, _i31.SnackBarClosedReason>(
               this,
               Invocation.method(
                 #showSnackBar,
@@ -11574,13 +11608,13 @@ class MockScaffoldMessengerState extends _i1.Mock
                 {#snackBarAnimationStyle: snackBarAnimationStyle},
               ),
             ),
-          ) as _i19.ScaffoldFeatureController<_i30.SnackBar,
-              _i30.SnackBarClosedReason>);
+          ) as _i20.ScaffoldFeatureController<_i31.SnackBar,
+              _i31.SnackBarClosedReason>);
 
   @override
   void removeCurrentSnackBar(
-          {_i30.SnackBarClosedReason? reason =
-              _i30.SnackBarClosedReason.remove}) =>
+          {_i31.SnackBarClosedReason? reason =
+              _i31.SnackBarClosedReason.remove}) =>
       super.noSuchMethod(
         Invocation.method(
           #removeCurrentSnackBar,
@@ -11592,8 +11626,8 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   void hideCurrentSnackBar(
-          {_i30.SnackBarClosedReason? reason =
-              _i30.SnackBarClosedReason.hide}) =>
+          {_i31.SnackBarClosedReason? reason =
+              _i31.SnackBarClosedReason.hide}) =>
       super.noSuchMethod(
         Invocation.method(
           #hideCurrentSnackBar,
@@ -11613,37 +11647,37 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  _i19.ScaffoldFeatureController<_i31.MaterialBanner,
-      _i31.MaterialBannerClosedReason> showMaterialBanner(
-          _i31.MaterialBanner? materialBanner) =>
+  _i20.ScaffoldFeatureController<_i32.MaterialBanner,
+      _i32.MaterialBannerClosedReason> showMaterialBanner(
+          _i32.MaterialBanner? materialBanner) =>
       (super.noSuchMethod(
         Invocation.method(
           #showMaterialBanner,
           [materialBanner],
         ),
-        returnValue: _FakeScaffoldFeatureController_87<_i31.MaterialBanner,
-            _i31.MaterialBannerClosedReason>(
+        returnValue: _FakeScaffoldFeatureController_88<_i32.MaterialBanner,
+            _i32.MaterialBannerClosedReason>(
           this,
           Invocation.method(
             #showMaterialBanner,
             [materialBanner],
           ),
         ),
-        returnValueForMissingStub: _FakeScaffoldFeatureController_87<
-            _i31.MaterialBanner, _i31.MaterialBannerClosedReason>(
+        returnValueForMissingStub: _FakeScaffoldFeatureController_88<
+            _i32.MaterialBanner, _i32.MaterialBannerClosedReason>(
           this,
           Invocation.method(
             #showMaterialBanner,
             [materialBanner],
           ),
         ),
-      ) as _i19.ScaffoldFeatureController<_i31.MaterialBanner,
-          _i31.MaterialBannerClosedReason>);
+      ) as _i20.ScaffoldFeatureController<_i32.MaterialBanner,
+          _i32.MaterialBannerClosedReason>);
 
   @override
   void removeCurrentMaterialBanner(
-          {_i31.MaterialBannerClosedReason? reason =
-              _i31.MaterialBannerClosedReason.remove}) =>
+          {_i32.MaterialBannerClosedReason? reason =
+              _i32.MaterialBannerClosedReason.remove}) =>
       super.noSuchMethod(
         Invocation.method(
           #removeCurrentMaterialBanner,
@@ -11655,8 +11689,8 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   void hideCurrentMaterialBanner(
-          {_i31.MaterialBannerClosedReason? reason =
-              _i31.MaterialBannerClosedReason.hide}) =>
+          {_i32.MaterialBannerClosedReason? reason =
+              _i32.MaterialBannerClosedReason.hide}) =>
       super.noSuchMethod(
         Invocation.method(
           #hideCurrentMaterialBanner,
@@ -11676,26 +11710,26 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  _i20.Widget build(_i20.BuildContext? context) => (super.noSuchMethod(
+  _i21.Widget build(_i21.BuildContext? context) => (super.noSuchMethod(
         Invocation.method(
           #build,
           [context],
         ),
-        returnValue: _FakeWidget_88(
+        returnValue: _FakeWidget_89(
           this,
           Invocation.method(
             #build,
             [context],
           ),
         ),
-        returnValueForMissingStub: _FakeWidget_88(
+        returnValueForMissingStub: _FakeWidget_89(
           this,
           Invocation.method(
             #build,
             [context],
           ),
         ),
-      ) as _i20.Widget);
+      ) as _i21.Widget);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -11716,7 +11750,7 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  void didUpdateWidget(_i19.ScaffoldMessenger? oldWidget) => super.noSuchMethod(
+  void didUpdateWidget(_i20.ScaffoldMessenger? oldWidget) => super.noSuchMethod(
         Invocation.method(
           #didUpdateWidget,
           [oldWidget],
@@ -11734,7 +11768,7 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  void setState(_i28.VoidCallback? fn) => super.noSuchMethod(
+  void setState(_i29.VoidCallback? fn) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [fn],
@@ -11761,7 +11795,7 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  void debugFillProperties(_i32.DiagnosticPropertiesBuilder? properties) =>
+  void debugFillProperties(_i33.DiagnosticPropertiesBuilder? properties) =>
       super.noSuchMethod(
         Invocation.method(
           #debugFillProperties,
@@ -11772,7 +11806,7 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   String toString(
-          {_i20.DiagnosticLevel? minLevel = _i20.DiagnosticLevel.info}) =>
+          {_i21.DiagnosticLevel? minLevel = _i21.DiagnosticLevel.info}) =>
       super.toString();
 
   @override
@@ -11781,14 +11815,14 @@ class MockScaffoldMessengerState extends _i1.Mock
           #toStringShort,
           [],
         ),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.method(
             #toStringShort,
             [],
           ),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.method(
             #toStringShort,
@@ -11798,9 +11832,9 @@ class MockScaffoldMessengerState extends _i1.Mock
       ) as String);
 
   @override
-  _i20.DiagnosticsNode toDiagnosticsNode({
+  _i21.DiagnosticsNode toDiagnosticsNode({
     String? name,
-    _i32.DiagnosticsTreeStyle? style,
+    _i33.DiagnosticsTreeStyle? style,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11811,7 +11845,7 @@ class MockScaffoldMessengerState extends _i1.Mock
             #style: style,
           },
         ),
-        returnValue: _FakeDiagnosticsNode_89(
+        returnValue: _FakeDiagnosticsNode_90(
           this,
           Invocation.method(
             #toDiagnosticsNode,
@@ -11822,7 +11856,7 @@ class MockScaffoldMessengerState extends _i1.Mock
             },
           ),
         ),
-        returnValueForMissingStub: _FakeDiagnosticsNode_89(
+        returnValueForMissingStub: _FakeDiagnosticsNode_90(
           this,
           Invocation.method(
             #toDiagnosticsNode,
@@ -11833,27 +11867,27 @@ class MockScaffoldMessengerState extends _i1.Mock
             },
           ),
         ),
-      ) as _i20.DiagnosticsNode);
+      ) as _i21.DiagnosticsNode);
 
   @override
-  _i22.Ticker createTicker(_i22.TickerCallback? onTick) => (super.noSuchMethod(
+  _i23.Ticker createTicker(_i23.TickerCallback? onTick) => (super.noSuchMethod(
         Invocation.method(
           #createTicker,
           [onTick],
         ),
-        returnValue: _FakeTicker_90(
+        returnValue: _FakeTicker_91(
           this,
           Invocation.method(
             #createTicker,
             [onTick],
           ),
         ),
-        returnValueForMissingStub: _FakeTicker_90(
+        returnValueForMissingStub: _FakeTicker_91(
           this,
           Invocation.method(
             #createTicker,
             [onTick],
           ),
         ),
-      ) as _i22.Ticker);
+      ) as _i23.Ticker);
 }

--- a/test/services/ios_voip_push_service_test.mocks.dart
+++ b/test/services/ios_voip_push_service_test.mocks.dart
@@ -3,17 +3,17 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i16;
-import 'dart:typed_data' as _i26;
-import 'dart:ui' as _i22;
+import 'dart:async' as _i17;
+import 'dart:typed_data' as _i27;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
-import 'package:http/http.dart' as _i15;
-import 'package:kohera/core/services/call_service.dart' as _i27;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/preferences_service.dart' as _i19;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i13;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
+import 'package:http/http.dart' as _i16;
+import 'package:kohera/core/services/call_service.dart' as _i28;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/preferences_service.dart' as _i20;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -25,26 +25,27 @@ import 'package:kohera/core/services/sub_services/space_access_service.dart'
     as _i9;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
-import 'package:kohera/features/calling/models/call_participant.dart' as _i30;
-import 'package:kohera/features/calling/models/call_state.dart' as _i32;
-import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i31;
-import 'package:kohera/features/calling/services/livekit_service.dart' as _i28;
-import 'package:kohera/features/calling/services/ringtone_service.dart' as _i33;
+import 'package:kohera/features/calling/models/call_participant.dart' as _i31;
+import 'package:kohera/features/calling/models/call_state.dart' as _i33;
+import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i32;
+import 'package:kohera/features/calling/services/livekit_service.dart' as _i29;
+import 'package:kohera/features/calling/services/ringtone_service.dart' as _i34;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
 import 'package:kohera/features/notifications/services/notification_service.dart'
-    as _i34;
-import 'package:livekit_client/livekit_client.dart' as _i29;
-import 'package:matrix/encryption.dart' as _i25;
+    as _i35;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i13;
+import 'package:livekit_client/livekit_client.dart' as _i30;
+import 'package:matrix/encryption.dart' as _i26;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i17;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i20;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i14;
-import 'package:matrix/src/utils/space_child.dart' as _i35;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i18;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i15;
+import 'package:matrix/src/utils/space_child.dart' as _i36;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i21;
+import 'package:mockito/src/dummies.dart' as _i22;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -178,9 +179,9 @@ class _FakeOutboxService_10 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_11 extends _i1.SmartFake
-    implements _i13.StickerPackService {
-  _FakeStickerPackService_11(
+class _FakeAvatarResolver_11 extends _i1.SmartFake
+    implements _i13.AvatarResolver {
+  _FakeAvatarResolver_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -189,8 +190,9 @@ class _FakeStickerPackService_11 extends _i1.SmartFake
         );
 }
 
-class _FakeDatabaseApi_12 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_12(
+class _FakeStickerPackService_12 extends _i1.SmartFake
+    implements _i14.StickerPackService {
+  _FakeStickerPackService_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -199,8 +201,8 @@ class _FakeDatabaseApi_12 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_13 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_13(
+class _FakeDatabaseApi_13 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -209,9 +211,19 @@ class _FakeFilter_13 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_14 extends _i1.SmartFake
+class _FakeFilter_14 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_14(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNativeImplementations_15 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_14(
+  _FakeNativeImplementations_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -220,8 +232,8 @@ class _FakeNativeImplementations_14 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_15 extends _i1.SmartFake implements Duration {
-  _FakeDuration_15(
+class _FakeDuration_16 extends _i1.SmartFake implements Duration {
+  _FakeDuration_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -230,9 +242,9 @@ class _FakeDuration_15 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_16 extends _i1.SmartFake
+class _FakePushruleEvaluator_17 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_16(
+  _FakePushruleEvaluator_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -241,8 +253,8 @@ class _FakePushruleEvaluator_16 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_17 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_17(
+class _FakeProfile_18 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -251,9 +263,9 @@ class _FakeProfile_17 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_18<T> extends _i1.SmartFake
-    implements _i14.CachedStreamController<T> {
-  _FakeCachedStreamController_18(
+class _FakeCachedStreamController_19<T> extends _i1.SmartFake
+    implements _i15.CachedStreamController<T> {
+  _FakeCachedStreamController_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -262,8 +274,8 @@ class _FakeCachedStreamController_18<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_19 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_19(
+class _FakeDateTime_20 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -272,8 +284,8 @@ class _FakeDateTime_19 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_20 extends _i1.SmartFake implements _i15.Client {
-  _FakeClient_20(
+class _FakeClient_21 extends _i1.SmartFake implements _i16.Client {
+  _FakeClient_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -282,9 +294,9 @@ class _FakeClient_20 extends _i1.SmartFake implements _i15.Client {
         );
 }
 
-class _FakeDiscoveryInformation_21 extends _i1.SmartFake
+class _FakeDiscoveryInformation_22 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_21(
+  _FakeDiscoveryInformation_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -293,9 +305,9 @@ class _FakeDiscoveryInformation_21 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_22 extends _i1.SmartFake
+class _FakeGetVersionsResponse_23 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_22(
+  _FakeGetVersionsResponse_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -304,9 +316,9 @@ class _FakeGetVersionsResponse_22 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_23 extends _i1.SmartFake
+class _FakeRegisterResponse_24 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_23(
+  _FakeRegisterResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -315,8 +327,8 @@ class _FakeRegisterResponse_23 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_24 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_24(
+class _FakeLoginResponse_25 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -325,9 +337,9 @@ class _FakeLoginResponse_24 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_25 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_25(
+  _FakeGetAuthMetadataResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -336,8 +348,8 @@ class _FakeGetAuthMetadataResponse_25 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_26<T1> extends _i1.SmartFake implements _i16.Future<T1> {
-  _FakeFuture_26(
+class _FakeFuture_27<T1> extends _i1.SmartFake implements _i17.Future<T1> {
+  _FakeFuture_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -346,8 +358,8 @@ class _FakeFuture_26<T1> extends _i1.SmartFake implements _i16.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_27 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_27(
+class _FakeSyncUpdate_28 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -356,9 +368,9 @@ class _FakeSyncUpdate_27 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_28 extends _i1.SmartFake
+class _FakeCachedProfileInformation_29 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_28(
+  _FakeCachedProfileInformation_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -367,8 +379,8 @@ class _FakeCachedProfileInformation_28 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_29 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_29(
+class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -377,8 +389,8 @@ class _FakeMediaConfig_29 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_30 extends _i1.SmartFake implements _i17.FileResponse {
-  _FakeFileResponse_30(
+class _FakeFileResponse_31 extends _i1.SmartFake implements _i18.FileResponse {
+  _FakeFileResponse_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -387,8 +399,8 @@ class _FakeFileResponse_30 extends _i1.SmartFake implements _i17.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_31(
+class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -397,8 +409,8 @@ class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_32 extends _i1.SmartFake implements Uri {
-  _FakeUri_32(
+class _FakeUri_33 extends _i1.SmartFake implements Uri {
+  _FakeUri_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -407,9 +419,9 @@ class _FakeUri_32 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_33 extends _i1.SmartFake
+class _FakeCachedPresence_34 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_33(
+  _FakeCachedPresence_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -418,9 +430,9 @@ class _FakeCachedPresence_33 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_34 extends _i1.SmartFake
+class _FakeTurnServerCredentials_35 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_34(
+  _FakeTurnServerCredentials_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -429,9 +441,9 @@ class _FakeTurnServerCredentials_34 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_35(
+  _FakeRoomKeysUpdateResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -440,8 +452,8 @@ class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_36(
+class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -450,9 +462,9 @@ class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_37(
+  _FakeGetWellknownSupportResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -461,9 +473,9 @@ class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_38(
+  _FakeGenerateLoginTokenResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -472,9 +484,9 @@ class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_39(
+  _FakeGetRoomSummaryResponse$3_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -483,9 +495,9 @@ class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_40(
+  _FakeGetSpaceHierarchyResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -494,9 +506,9 @@ class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_41(
+  _FakeGetRelatingEventsResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -505,9 +517,9 @@ class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_42(
+  _FakeGetRelatingEventsWithRelTypeResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -516,9 +528,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -527,9 +539,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_44(
+  _FakeGetThreadRootsResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -538,9 +550,9 @@ class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_45(
+  _FakeGetEventByTimestampResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -549,9 +561,9 @@ class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_46 extends _i1.SmartFake
+class _FakeRequestTokenResponse_47 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_46(
+  _FakeRequestTokenResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -560,9 +572,9 @@ class _FakeRequestTokenResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_47(
+  _FakeTokenOwnerInfo_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -571,8 +583,8 @@ class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_48(
+class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -581,8 +593,8 @@ class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_49(
+class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -591,8 +603,8 @@ class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_50(
+class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -601,9 +613,9 @@ class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_51(
+  _FakeGetRoomIdByAliasResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -612,9 +624,9 @@ class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_52 extends _i1.SmartFake
+class _FakeGetEventsResponse_53 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_52(
+  _FakeGetEventsResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -623,9 +635,9 @@ class _FakeGetEventsResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_53 extends _i1.SmartFake
+class _FakePeekEventsResponse_54 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_53(
+  _FakePeekEventsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -634,8 +646,8 @@ class _FakePeekEventsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_54(
+class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -644,9 +656,9 @@ class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_55(
+  _FakeGetKeysChangesResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -655,9 +667,9 @@ class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_56 extends _i1.SmartFake
+class _FakeClaimKeysResponse_57 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_56(
+  _FakeClaimKeysResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -666,9 +678,9 @@ class _FakeClaimKeysResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_57 extends _i1.SmartFake
+class _FakeQueryKeysResponse_58 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_57(
+  _FakeQueryKeysResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -677,9 +689,9 @@ class _FakeQueryKeysResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_58(
+  _FakeGetNotificationsResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -688,9 +700,9 @@ class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_59 extends _i1.SmartFake
+class _FakeGetPresenceResponse_60 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_59(
+  _FakeGetPresenceResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -699,9 +711,9 @@ class _FakeGetPresenceResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_60(
+  _FakeGetPublicRoomsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -710,9 +722,9 @@ class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_61(
+  _FakeQueryPublicRoomsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -721,8 +733,8 @@ class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_62(
+class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -731,9 +743,9 @@ class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_63(
+  _FakeGetPushRulesGlobalResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -742,8 +754,8 @@ class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_64(
+class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -752,9 +764,9 @@ class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_65 extends _i1.SmartFake
+class _FakeRefreshResponse_66 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_65(
+  _FakeRefreshResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -763,8 +775,8 @@ class _FakeRefreshResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_66(
+class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -773,8 +785,8 @@ class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_67(
+class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -783,9 +795,9 @@ class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_68(
+  _FakeGetRoomKeysVersionCurrentResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -794,9 +806,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_69(
+  _FakeGetRoomKeysVersionResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -805,8 +817,8 @@ class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_70(
+class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -815,9 +827,9 @@ class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_71(
+  _FakeGetRoomEventsResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -826,8 +838,8 @@ class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_72(
+class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -836,9 +848,9 @@ class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_73(
+  _FakeGetProtocolMetadataResponse$2_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -847,9 +859,9 @@ class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_74 extends _i1.SmartFake
+class _FakeOpenIdCredentials_75 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_74(
+  _FakeOpenIdCredentials_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -858,9 +870,9 @@ class _FakeOpenIdCredentials_74 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_75(
+  _FakeSearchUserDirectoryResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -869,9 +881,9 @@ class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_76 extends _i1.SmartFake
+class _FakeCreateContentResponse_77 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_76(
+  _FakeCreateContentResponse_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,8 +892,8 @@ class _FakeCreateContentResponse_76 extends _i1.SmartFake
         );
 }
 
-class _FakeResponse_77 extends _i1.SmartFake implements _i15.Response {
-  _FakeResponse_77(
+class _FakeResponse_78 extends _i1.SmartFake implements _i16.Response {
+  _FakeResponse_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -890,9 +902,9 @@ class _FakeResponse_77 extends _i1.SmartFake implements _i15.Response {
         );
 }
 
-class _FakeMatrixService_78 extends _i1.SmartFake
-    implements _i18.MatrixService {
-  _FakeMatrixService_78(
+class _FakeMatrixService_79 extends _i1.SmartFake
+    implements _i19.MatrixService {
+  _FakeMatrixService_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -901,9 +913,9 @@ class _FakeMatrixService_78 extends _i1.SmartFake
         );
 }
 
-class _FakePreferencesService_79 extends _i1.SmartFake
-    implements _i19.PreferencesService {
-  _FakePreferencesService_79(
+class _FakePreferencesService_80 extends _i1.SmartFake
+    implements _i20.PreferencesService {
+  _FakePreferencesService_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -912,8 +924,8 @@ class _FakePreferencesService_79 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_80 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_80(
+class _FakeRoomSummary_81 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -922,9 +934,9 @@ class _FakeRoomSummary_80 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_81 extends _i1.SmartFake
+class _FakeLatestReceiptState_82 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_81(
+  _FakeLatestReceiptState_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -933,8 +945,8 @@ class _FakeLatestReceiptState_81 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_82 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_82(
+class _FakeTimeline_83 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -943,8 +955,8 @@ class _FakeTimeline_82 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_83 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_83(
+class _FakeUser_84 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -953,8 +965,8 @@ class _FakeUser_83 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeRoom_84 extends _i1.SmartFake implements _i4.Room {
-  _FakeRoom_84(
+class _FakeRoom_85 extends _i1.SmartFake implements _i4.Room {
+  _FakeRoom_85(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -963,9 +975,9 @@ class _FakeRoom_84 extends _i1.SmartFake implements _i4.Room {
         );
 }
 
-class _FakeTimelineChunk_85 extends _i1.SmartFake
-    implements _i20.TimelineChunk {
-  _FakeTimelineChunk_85(
+class _FakeTimelineChunk_86 extends _i1.SmartFake
+    implements _i21.TimelineChunk {
+  _FakeTimelineChunk_86(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -977,7 +989,7 @@ class _FakeTimelineChunk_85 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -1007,11 +1019,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1149,17 +1161,30 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i12.OutboxService);
 
   @override
-  _i13.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i13.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i13.AvatarResolver);
+
+  @override
+  _i14.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_11(
+        returnValue: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_11(
+        returnValueForMissingStub: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i13.StickerPackService);
+      ) as _i14.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1268,7 +1293,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set stickerPacks(_i13.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i13.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i14.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -1284,14 +1318,14 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  _i16.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i17.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1321,7 +1355,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1331,18 +1365,18 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i17.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<bool> login({
+  _i17.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1359,12 +1393,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> completeSsoLogin({
+  _i17.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1377,12 +1411,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> completeRegistration(
+  _i17.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1392,32 +1426,32 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> logout() => (super.noSuchMethod(
+  _i17.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i17.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1426,7 +1460,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1435,17 +1469,17 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i17.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1456,7 +1490,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1493,26 +1527,26 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i17.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+  _i17.Future<bool> didPushRouteInformation(
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1542,7 +1576,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1551,7 +1585,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1560,16 +1594,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i17.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i16.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i17.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i16.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i16.Future<_i22.AppExitResponse>);
+            _i17.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i17.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1597,23 +1631,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_12(
+        returnValue: _FakeDatabaseApi_13(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_12(
+        returnValueForMissingStub: _FakeDatabaseApi_13(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i25.KeyVerificationMethod> get verificationMethods =>
+  Set<_i26.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i25.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i25.KeyVerificationMethod>{},
-      ) as Set<_i25.KeyVerificationMethod>);
+        returnValue: <_i26.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i26.KeyVerificationMethod>{},
+      ) as Set<_i26.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1674,11 +1708,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_13(
+        returnValue: _FakeFilter_14(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_13(
+        returnValueForMissingStub: _FakeFilter_14(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -1687,11 +1721,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_14(
+        returnValue: _FakeNativeImplementations_15(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_14(
+        returnValueForMissingStub: _FakeNativeImplementations_15(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -1707,11 +1741,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_15(
+        returnValue: _FakeDuration_16(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_15(
+        returnValueForMissingStub: _FakeDuration_16(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1720,11 +1754,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_15(
+        returnValue: _FakeDuration_16(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_15(
+        returnValueForMissingStub: _FakeDuration_16(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1733,11 +1767,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1774,11 +1808,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1808,11 +1842,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1821,11 +1855,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1848,11 +1882,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_16(
+        returnValue: _FakePushruleEvaluator_17(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_16(
+        returnValueForMissingStub: _FakePushruleEvaluator_17(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -1873,332 +1907,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i16.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i17.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_17(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_17(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i14.CachedStreamController<String> get onUserProfileUpdate =>
+  _i15.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_18<String>(
+        returnValue: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i16.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i17.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i16.Future<List<_i4.Room>>);
+            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i17.Future<List<_i4.Room>>);
 
   @override
-  _i14.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i15.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_18<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_19<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.EventUpdate>(
+            _FakeCachedStreamController_19<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.EventUpdate>);
+      ) as _i15.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i15.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_18<_i4.Event>(
+        returnValue: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i15.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_18<_i4.Event>(
+        returnValue: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onNotification =>
+  _i15.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_18<_i4.Event>(
+        returnValue: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i15.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_18<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_19<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_19<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i15.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i14.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i15.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_18<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_19<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_18<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_19<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i14.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i15.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i14.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i15.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_18<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_19<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.LoginState>(
+            _FakeCachedStreamController_19<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i14.CachedStreamController<_i4.LoginState>);
+      ) as _i15.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i14.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i15.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_18<bool>(
+        returnValue: _FakeCachedStreamController_19<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i14.CachedStreamController<bool>);
+      ) as _i15.CachedStreamController<bool>);
 
   @override
-  _i14.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i15.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_18<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_19<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i14.CachedStreamController<_i4.SdkError>);
+      ) as _i15.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i14.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i15.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_18<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_19<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.SyncUpdate>(
+            _FakeCachedStreamController_19<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i14.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i15.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i15.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_18<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_19<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_19<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i14.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i15.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.Presence> get onPresence =>
+  _i15.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_18<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_19<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i14.CachedStreamController<_i4.Presence>);
+      ) as _i15.CachedStreamController<_i4.Presence>);
 
   @override
-  _i14.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i15.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_18<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_19<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.CachedPresence>(
+            _FakeCachedStreamController_19<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i14.CachedStreamController<_i4.CachedPresence>);
+      ) as _i15.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i14.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i15.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_18<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_19<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.BasicEvent>(
+            _FakeCachedStreamController_19<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i14.CachedStreamController<_i4.BasicEvent>);
+      ) as _i15.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i14.CachedStreamController<_i25.RoomKeyRequest> get onRoomKeyRequest =>
+  _i15.CachedStreamController<_i26.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_18<_i25.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_19<_i26.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i25.RoomKeyRequest>(
+            _FakeCachedStreamController_19<_i26.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i14.CachedStreamController<_i25.RoomKeyRequest>);
+      ) as _i15.CachedStreamController<_i26.RoomKeyRequest>);
 
   @override
-  _i14.CachedStreamController<_i25.KeyVerification>
+  _i15.CachedStreamController<_i26.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_18<_i25.KeyVerification>(
+            returnValue: _FakeCachedStreamController_19<_i26.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_18<_i25.KeyVerification>(
+                _FakeCachedStreamController_19<_i26.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i14.CachedStreamController<_i25.KeyVerification>);
+          ) as _i15.CachedStreamController<_i26.KeyVerification>);
 
   @override
-  _i14.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i15.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_18<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_19<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_19<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i14.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i15.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i15.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_18<_i4.Event>(
+        returnValue: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<String> get onCancelSendEvent =>
+  _i15.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_18<String>(
+        returnValue: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i14.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i15.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_18<
+            returnValue: _FakeCachedStreamController_19<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_18<
+            returnValueForMissingStub: _FakeCachedStreamController_19<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i14.CachedStreamController<
+          ) as _i15.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2218,11 +2252,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_19(
+        returnValue: _FakeDateTime_20(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_19(
+        returnValueForMissingStub: _FakeDateTime_20(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2295,7 +2329,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i25.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i26.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2350,7 +2384,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i16.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i17.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2361,7 +2395,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i16.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i17.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -2472,7 +2506,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2481,7 +2515,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2490,7 +2524,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2517,20 +2551,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i15.Client get httpClient => (super.noSuchMethod(
+  _i16.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_20(
+        returnValue: _FakeClient_21(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_20(
+        returnValueForMissingStub: _FakeClient_21(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i15.Client);
+      ) as _i16.Client);
 
   @override
-  set httpClient(_i15.Client? value) => super.noSuchMethod(
+  set httpClient(_i16.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2557,7 +2591,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<void> refreshAccessToken(
+  _i17.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2565,9 +2599,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2585,14 +2619,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2629,33 +2663,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i16.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i17.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_21(
+        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_22(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_21(
+        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_22(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i16.Future<_i4.DiscoveryInformation>);
+      ) as _i17.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i16.Future<
+  _i17.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -2677,7 +2711,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i16.Future<
+        returnValue: _i17.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2685,7 +2719,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_22(
+          _FakeGetVersionsResponse_23(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2700,7 +2734,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i16.Future<
+        returnValueForMissingStub: _i17.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2708,7 +2742,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_22(
+          _FakeGetVersionsResponse_23(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2723,7 +2757,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i16.Future<
+      ) as _i17.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -2732,7 +2766,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i16.Future<_i4.DiscoveryInformation> getWellknown({
+  _i17.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2745,8 +2779,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_21(
+        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_22(
           this,
           Invocation.method(
             #getWellknown,
@@ -2757,8 +2791,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_21(
+        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_22(
           this,
           Invocation.method(
             #getWellknown,
@@ -2769,10 +2803,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.DiscoveryInformation>);
+      ) as _i17.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i16.Future<_i4.RegisterResponse> register({
+  _i17.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -2800,7 +2834,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_23(
+            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_24(
           this,
           Invocation.method(
             #register,
@@ -2819,7 +2853,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_23(
+            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_24(
           this,
           Invocation.method(
             #register,
@@ -2837,10 +2871,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RegisterResponse>);
+      ) as _i17.Future<_i4.RegisterResponse>);
 
   @override
-  _i16.Future<_i4.LoginResponse> login(
+  _i17.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -2870,7 +2904,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_24(
+        returnValue: _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_25(
           this,
           Invocation.method(
             #login,
@@ -2890,7 +2924,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_24(
+            _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_25(
           this,
           Invocation.method(
             #login,
@@ -2909,10 +2943,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.LoginResponse>);
+      ) as _i17.Future<_i4.LoginResponse>);
 
   @override
-  _i16.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i17.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2925,8 +2959,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_25(
+        returnValue: _i17.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_26(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2938,8 +2972,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_25(
+            _i17.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_26(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2950,74 +2984,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i17.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i16.Future<void> logout() => (super.noSuchMethod(
+  _i17.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> logoutAll() => (super.noSuchMethod(
+  _i17.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<T> uiaRequestBackground<T>(
-          _i16.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i17.Future<T> uiaRequestBackground<T>(
+          _i17.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i21.ifNotNull(
-              _i21.dummyValueOrNull<T>(
+        returnValue: _i22.ifNotNull(
+              _i22.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i16.Future<T>.value(v),
+              (T v) => _i17.Future<T>.value(v),
             ) ??
-            _FakeFuture_26<T>(
+            _FakeFuture_27<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i21.ifNotNull(
-              _i21.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i22.ifNotNull(
+              _i22.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i16.Future<T>.value(v),
+              (T v) => _i17.Future<T>.value(v),
             ) ??
-            _FakeFuture_26<T>(
+            _FakeFuture_27<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i16.Future<T>);
+      ) as _i17.Future<T>);
 
   @override
-  _i16.Future<String> startDirectChat(
+  _i17.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -3039,7 +3073,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3055,7 +3089,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3070,10 +3104,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<String> createGroupChat({
+  _i17.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -3104,7 +3138,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3125,7 +3159,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3145,10 +3179,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i17.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3164,7 +3198,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3177,7 +3211,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3189,21 +3223,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i17.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<String> createSpace({
+  _i17.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3228,7 +3262,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3246,7 +3280,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3263,10 +3297,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i17.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3274,7 +3308,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_17(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3283,7 +3317,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_17(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3291,10 +3325,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i16.Future<_i4.Profile> fetchOwnProfile({
+  _i17.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3307,7 +3341,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_17(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3319,7 +3353,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_17(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3330,10 +3364,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i16.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i17.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3347,8 +3381,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i16.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_28(
+        returnValue: _i17.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_29(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3360,8 +3394,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_28(
+            _i17.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_29(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3372,10 +3406,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.CachedProfileInformation>);
+      ) as _i17.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i16.Future<_i4.Profile> getProfileFromUserId(
+  _i17.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3393,7 +3427,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_17(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3407,7 +3441,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_17(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3420,7 +3454,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3442,31 +3476,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i16.Future<List<_i4.Room>>);
+            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i17.Future<List<_i4.Room>>);
 
   @override
-  _i16.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i17.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i16.Future<List<_i4.ArchivedRoom>>);
+            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i17.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i16.Future<_i4.GetVersionsResponse> getVersions({
+  _i17.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3479,8 +3513,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_22(
+        returnValue: _i17.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_23(
           this,
           Invocation.method(
             #getVersions,
@@ -3491,8 +3525,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_22(
+        returnValueForMissingStub: _i17.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_23(
           this,
           Invocation.method(
             #getVersions,
@@ -3503,20 +3537,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetVersionsResponse>);
+      ) as _i17.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i16.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i17.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.MediaConfig> getConfig({
+  _i17.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3529,7 +3563,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
+        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfig,
@@ -3541,7 +3575,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
+            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfig,
@@ -3552,10 +3586,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.MediaConfig>);
+      ) as _i17.Future<_i4.MediaConfig>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContent(
+  _i17.Future<_i18.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3575,7 +3609,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContent,
@@ -3591,7 +3625,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContent,
@@ -3606,10 +3640,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentOverrideName(
+  _i17.Future<_i18.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3631,7 +3665,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3648,7 +3682,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3664,10 +3698,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentThumbnail(
+  _i17.Future<_i18.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -3695,7 +3729,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3715,7 +3749,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3734,10 +3768,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i17.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3747,7 +3781,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
+        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3756,7 +3790,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
+            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3764,11 +3798,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i16.Future<_i4.PreviewForUrl>);
+      ) as _i17.Future<_i4.PreviewForUrl>);
 
   @override
-  _i16.Future<Uri> uploadContent(
-    _i26.Uint8List? file, {
+  _i17.Future<Uri> uploadContent(
+    _i27.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3781,7 +3815,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i16.Future<Uri>.value(_FakeUri_32(
+        returnValue: _i17.Future<Uri>.value(_FakeUri_33(
           this,
           Invocation.method(
             #uploadContent,
@@ -3792,7 +3826,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_32(
+        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_33(
           this,
           Invocation.method(
             #uploadContent,
@@ -3803,10 +3837,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<Uri>);
+      ) as _i17.Future<Uri>);
 
   @override
-  _i16.Future<void> setTyping(
+  _i17.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -3822,42 +3856,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> exportDump() => (super.noSuchMethod(
+  _i17.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i17.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i17.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Event?> getEventByPushNotification(
+  _i17.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -3873,12 +3907,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
-  _i16.Future<void> init({
+  _i17.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -3913,9 +3947,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -3927,40 +3961,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<void> clear() => (super.noSuchMethod(
+  _i17.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i17.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ensureNotSoftLoggedOut(
+  _i17.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> handleSync(
+  _i17.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -3970,9 +4004,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -3985,29 +4019,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i16.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i17.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i17.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDevice(
+  _i17.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -4021,12 +4055,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDevicesOfUserIds(
+  _i17.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4042,12 +4076,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDeviceEncrypted(
+  _i17.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4067,12 +4101,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDeviceEncryptedChunked(
+  _i17.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -4086,23 +4120,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i17.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> joinRoom(
+  _i17.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -4120,7 +4154,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4134,7 +4168,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4147,10 +4181,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> changePassword(
+  _i17.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4166,22 +4200,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> clearCache() => (super.noSuchMethod(
+  _i17.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ignoreUser(
+  _i17.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4191,22 +4225,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i17.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i17.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4217,7 +4251,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4226,7 +4260,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4234,32 +4268,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i16.Future<_i4.CachedPresence>);
+      ) as _i17.Future<_i4.CachedPresence>);
 
   @override
-  _i16.Future<void> abortSync() => (super.noSuchMethod(
+  _i17.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i17.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEventWithMetadata(
+  _i17.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4279,14 +4313,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i15.BaseResponse? response,
-    _i26.Uint8List? body,
+    _i16.BaseResponse? response,
+    _i27.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4318,7 +4352,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i16.Future<Map<String, Object?>> request(
+  _i17.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4339,13 +4373,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> postPusher(
+  _i17.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4355,57 +4389,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i17.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i17.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i17.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i16.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_34(
+        returnValue: _i17.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_35(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_34(
+        returnValueForMissingStub: _i17.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_35(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.TurnServerCredentials>);
+      ) as _i17.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4419,8 +4453,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4432,8 +4466,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4444,10 +4478,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4463,8 +4497,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4477,8 +4511,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4490,10 +4524,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i17.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4507,7 +4541,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4519,7 +4553,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4530,17 +4564,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.KeyBackupData>);
+      ) as _i17.Future<_i4.KeyBackupData>);
 
   @override
-  _i16.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i17.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i16.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_37(
+        returnValue: _i17.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_38(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4548,18 +4582,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_37(
+            _i17.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_38(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i17.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i16.Future<int> pingAppservice(
+  _i17.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4569,12 +4603,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
-  _i16.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i17.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4582,8 +4616,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_38(
+        returnValue: _i17.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_39(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4592,8 +4626,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_38(
+            _i17.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_39(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4601,15 +4635,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i16.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i17.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i16.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i17.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
+        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4617,17 +4651,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
+            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.MediaConfig>);
+      ) as _i17.Future<_i4.MediaConfig>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentAuthed(
+  _i17.Future<_i18.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4641,7 +4675,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4653,7 +4687,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4664,10 +4698,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentOverrideNameAuthed(
+  _i17.Future<_i18.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4683,7 +4717,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4696,7 +4730,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4708,10 +4742,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i17.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4721,7 +4755,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
+        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4730,7 +4764,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
+            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4738,10 +4772,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i16.Future<_i4.PreviewForUrl>);
+      ) as _i17.Future<_i4.PreviewForUrl>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentThumbnailAuthed(
+  _i17.Future<_i18.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4765,7 +4799,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4783,7 +4817,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4800,21 +4834,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<bool> registrationTokenValidity(String? token) =>
+  _i17.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i17.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -4824,8 +4858,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_39(
+        returnValue: _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_40(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4834,8 +4868,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_39(
+            _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_40(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4843,10 +4877,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i17.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i16.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i17.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -4864,8 +4898,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_40(
+        returnValue: _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_41(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4879,8 +4913,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_40(
+            _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_41(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4893,10 +4927,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i17.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i17.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -4920,8 +4954,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i16.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_41(
+        returnValue: _i17.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_42(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4939,8 +4973,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_41(
+            _i17.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_42(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4957,10 +4991,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i17.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -4988,8 +5022,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_42(
+                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5008,8 +5042,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_42(
+                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5027,10 +5061,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i17.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -5059,9 +5093,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i16.Future<
+            returnValue: _i17.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5080,9 +5114,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i16.Future<
+            returnValueForMissingStub: _i17.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5101,11 +5135,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i16
+          ) as _i17
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i16.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i17.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -5121,8 +5155,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i16.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_44(
+        returnValue: _i17.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_45(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5135,8 +5169,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_44(
+            _i17.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_45(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5148,10 +5182,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetThreadRootsResponse>);
+      ) as _i17.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i16.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i17.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5165,8 +5199,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i16.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_45(
+        returnValue: _i17.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_46(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5178,8 +5212,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_45(
+            _i17.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_46(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5190,33 +5224,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i17.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i17.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i16.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i17.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i16.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i17.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i16.Future<Uri?>.value(),
-        returnValueForMissingStub: _i16.Future<Uri?>.value(),
-      ) as _i16.Future<Uri?>);
+        returnValue: _i17.Future<Uri?>.value(),
+        returnValueForMissingStub: _i17.Future<Uri?>.value(),
+      ) as _i17.Future<Uri?>);
 
   @override
-  _i16.Future<void> add3PID(
+  _i17.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5230,12 +5264,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> bind3PID(
+  _i17.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5251,12 +5285,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i17.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5270,14 +5304,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5299,8 +5333,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5316,8 +5350,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5333,10 +5367,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5360,8 +5394,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5378,8 +5412,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5396,10 +5430,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i17.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5413,14 +5447,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i17.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5435,14 +5469,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5464,8 +5498,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5481,8 +5515,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5498,10 +5532,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5525,8 +5559,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5543,8 +5577,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5561,16 +5595,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i17.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
+            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5578,22 +5612,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
+            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.TokenOwnerInfo>);
+      ) as _i17.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i16.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i17.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
+        returnValue: _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5601,22 +5635,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
+            _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i16.Future<_i4.WhoIsInfo>);
+      ) as _i17.Future<_i4.WhoIsInfo>);
 
   @override
-  _i16.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i17.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
+        returnValue: _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5624,17 +5658,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
+            _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.Capabilities>);
+      ) as _i17.Future<_i4.Capabilities>);
 
   @override
-  _i16.Future<String> createRoom({
+  _i17.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -5667,7 +5701,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5689,7 +5723,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5710,10 +5744,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> deleteDevices(
+  _i17.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5723,22 +5757,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.Device>?>.value(),
-      ) as _i16.Future<List<_i4.Device>?>);
+        returnValue: _i17.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.Device>?>.value(),
+      ) as _i17.Future<List<_i4.Device>?>);
 
   @override
-  _i16.Future<void> deleteDevice(
+  _i17.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5748,34 +5782,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i17.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i16.Future<_i4.Device>.value(_FakeDevice_50(
+        returnValue: _i17.Future<_i4.Device>.value(_FakeDevice_51(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.Device>.value(_FakeDevice_50(
+        returnValueForMissingStub: _i17.Future<_i4.Device>.value(_FakeDevice_51(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i16.Future<_i4.Device>);
+      ) as _i17.Future<_i4.Device>);
 
   @override
-  _i16.Future<void> updateDevice(
+  _i17.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5785,12 +5819,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i17.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -5805,24 +5839,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i17.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i16.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Visibility?>.value(),
-      ) as _i16.Future<_i4.Visibility?>);
+        returnValue: _i17.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Visibility?>.value(),
+      ) as _i17.Future<_i4.Visibility?>);
 
   @override
-  _i16.Future<void> setRoomVisibilityOnDirectory(
+  _i17.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -5832,30 +5866,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i17.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i17.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_51(
+        returnValue: _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_52(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -5863,18 +5897,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_51(
+            _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_52(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i17.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i16.Future<void> setRoomAlias(
+  _i17.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -5886,12 +5920,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetEventsResponse> getEvents({
+  _i17.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -5905,7 +5939,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
+            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
           this,
           Invocation.method(
             #getEvents,
@@ -5917,7 +5951,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
+            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
           this,
           Invocation.method(
             #getEvents,
@@ -5928,10 +5962,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetEventsResponse>);
+      ) as _i17.Future<_i4.GetEventsResponse>);
 
   @override
-  _i16.Future<_i4.PeekEventsResponse> peekEvents({
+  _i17.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -5946,8 +5980,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i16.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_53(
+        returnValue: _i17.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_54(
           this,
           Invocation.method(
             #peekEvents,
@@ -5959,8 +5993,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_53(
+        returnValueForMissingStub: _i17.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_54(
           this,
           Invocation.method(
             #peekEvents,
@@ -5972,16 +6006,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.PeekEventsResponse>);
+      ) as _i17.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i16.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i17.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneEvent,
@@ -5989,27 +6023,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i16.Future<_i4.MatrixEvent>);
+      ) as _i17.Future<_i4.MatrixEvent>);
 
   @override
-  _i16.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i17.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 
   @override
-  _i16.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i17.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -6021,8 +6055,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i16.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_55(
+        returnValue: _i17.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_56(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6033,8 +6067,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_55(
+            _i17.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_56(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6044,10 +6078,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.GetKeysChangesResponse>);
+      ) as _i17.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i16.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i17.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -6058,7 +6092,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
+            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
           this,
           Invocation.method(
             #claimKeys,
@@ -6067,7 +6101,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
+            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
           this,
           Invocation.method(
             #claimKeys,
@@ -6075,10 +6109,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i16.Future<_i4.ClaimKeysResponse>);
+      ) as _i17.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i16.Future<void> uploadCrossSigningKeys({
+  _i17.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -6095,12 +6129,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.QueryKeysResponse> queryKeys(
+  _i17.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -6111,7 +6145,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
+            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
           this,
           Invocation.method(
             #queryKeys,
@@ -6120,7 +6154,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
+            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
           this,
           Invocation.method(
             #queryKeys,
@@ -6128,10 +6162,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i16.Future<_i4.QueryKeysResponse>);
+      ) as _i17.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6139,14 +6173,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i16.Future<
+            returnValue: _i17.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i16.Future<
+            returnValueForMissingStub: _i17.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i16.Future<Map<String, int>> uploadKeys({
+  _i17.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6161,13 +6195,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i16.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i17.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i16.Future<Map<String, int>>);
+            _i17.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i17.Future<Map<String, int>>);
 
   @override
-  _i16.Future<String> knockRoom(
+  _i17.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6181,7 +6215,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6193,7 +6227,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6204,20 +6238,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i17.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i16.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i17.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i17.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i16.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i17.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6232,8 +6266,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i16.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_58(
+        returnValue: _i17.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_59(
           this,
           Invocation.method(
             #getNotifications,
@@ -6246,8 +6280,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_58(
+            _i17.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_59(
           this,
           Invocation.method(
             #getNotifications,
@@ -6259,35 +6293,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetNotificationsResponse>);
+      ) as _i17.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i16.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i17.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i16.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_59(
+        returnValue: _i17.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_60(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_59(
+        returnValueForMissingStub: _i17.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_60(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i16.Future<_i4.GetPresenceResponse>);
+      ) as _i17.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i16.Future<void> setPresence(
+  _i17.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6301,12 +6335,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, Object?>> deleteProfileField(
+  _i17.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6319,13 +6353,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getProfileField(
+  _i17.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6338,13 +6372,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<Map<String, Object?>> setProfileField(
+  _i17.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6359,13 +6393,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i17.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6380,8 +6414,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i16.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_60(
+        returnValue: _i17.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_61(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6394,8 +6428,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_60(
+            _i17.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_61(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6407,10 +6441,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i17.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i16.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i17.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6431,8 +6465,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i16.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_61(
+        returnValue: _i17.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_62(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6448,8 +6482,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_61(
+            _i17.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_62(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6464,25 +6498,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i17.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i16.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.Pusher>?>.value(),
-      ) as _i16.Future<List<_i4.Pusher>?>);
+        returnValue: _i17.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.Pusher>?>.value(),
+      ) as _i17.Future<List<_i4.Pusher>?>);
 
   @override
-  _i16.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i17.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
+        returnValue: _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
           this,
           Invocation.method(
             #getPushRules,
@@ -6490,24 +6524,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
+            _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.PushRuleSet>);
+      ) as _i17.Future<_i4.PushRuleSet>);
 
   @override
-  _i16.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i17.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_63(
+        returnValue: _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_64(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6515,18 +6549,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_63(
+            _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_64(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i17.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i16.Future<void> deletePushRule(
+  _i17.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6538,12 +6572,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.PushRule> getPushRule(
+  _i17.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6555,7 +6589,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<_i4.PushRule>.value(_FakePushRule_64(
+        returnValue: _i17.Future<_i4.PushRule>.value(_FakePushRule_65(
           this,
           Invocation.method(
             #getPushRule,
@@ -6566,7 +6600,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PushRule>.value(_FakePushRule_64(
+            _i17.Future<_i4.PushRule>.value(_FakePushRule_65(
           this,
           Invocation.method(
             #getPushRule,
@@ -6576,10 +6610,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.PushRule>);
+      ) as _i17.Future<_i4.PushRule>);
 
   @override
-  _i16.Future<void> setPushRule(
+  _i17.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -6603,12 +6637,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<Object?>> getPushRuleActions(
+  _i17.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6620,13 +6654,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i17.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i16.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i16.Future<List<Object?>>);
+            _i17.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i17.Future<List<Object?>>);
 
   @override
-  _i16.Future<void> setPushRuleActions(
+  _i17.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -6640,12 +6674,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<bool> isPushRuleEnabled(
+  _i17.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6657,12 +6691,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> setPushRuleEnabled(
+  _i17.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -6676,19 +6710,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i17.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
+            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
           this,
           Invocation.method(
             #refresh,
@@ -6696,28 +6730,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
+            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i16.Future<_i4.RefreshResponse>);
+      ) as _i17.Future<_i4.RefreshResponse>);
 
   @override
-  _i16.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i17.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i16.Future<bool?>.value(),
-        returnValueForMissingStub: _i16.Future<bool?>.value(),
-      ) as _i16.Future<bool?>);
+        returnValue: _i17.Future<bool?>.value(),
+        returnValueForMissingStub: _i17.Future<bool?>.value(),
+      ) as _i17.Future<bool?>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6739,8 +6773,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6756,8 +6790,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6773,10 +6807,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6800,8 +6834,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6818,8 +6852,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6836,17 +6870,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -6854,23 +6888,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i17.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
+        returnValue: _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -6878,17 +6912,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
+            _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeys>);
+      ) as _i17.Future<_i4.RoomKeys>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -6900,8 +6934,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6912,8 +6946,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6923,10 +6957,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6938,8 +6972,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6950,8 +6984,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6961,10 +6995,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6976,7 +7010,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
+        returnValue: _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6987,7 +7021,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
+            _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6997,10 +7031,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeyBackup>);
+      ) as _i17.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -7014,8 +7048,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7027,8 +7061,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7039,10 +7073,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7056,8 +7090,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7069,8 +7103,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7081,10 +7115,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i17.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7098,7 +7132,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7110,7 +7144,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7121,10 +7155,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.KeyBackupData>);
+      ) as _i17.Future<_i4.KeyBackupData>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7140,8 +7174,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7154,8 +7188,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7167,18 +7201,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_68(
+                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_69(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7186,18 +7220,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_68(
+                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_69(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i16.Future<String> postRoomKeysVersion(
+  _i17.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7209,7 +7243,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7220,7 +7254,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7230,29 +7264,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i17.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i17.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_69(
+        returnValue: _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_70(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7260,18 +7294,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_69(
+            _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_70(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i17.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i17.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7286,24 +7320,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i17.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 
   @override
-  _i16.Future<void> ban(
+  _i17.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7317,12 +7351,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.EventContext> getEventContext(
+  _i17.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7340,7 +7374,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<_i4.EventContext>.value(_FakeEventContext_70(
+        returnValue: _i17.Future<_i4.EventContext>.value(_FakeEventContext_71(
           this,
           Invocation.method(
             #getEventContext,
@@ -7355,7 +7389,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.EventContext>.value(_FakeEventContext_70(
+            _i17.Future<_i4.EventContext>.value(_FakeEventContext_71(
           this,
           Invocation.method(
             #getEventContext,
@@ -7369,10 +7403,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.EventContext>);
+      ) as _i17.Future<_i4.EventContext>);
 
   @override
-  _i16.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i17.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7384,7 +7418,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7395,7 +7429,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7405,20 +7439,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.MatrixEvent>);
+      ) as _i17.Future<_i4.MatrixEvent>);
 
   @override
-  _i16.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> inviteBy3PID(
+  _i17.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7430,12 +7464,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> inviteUser(
+  _i17.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7449,12 +7483,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> joinRoomById(
+  _i17.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7468,7 +7502,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7480,7 +7514,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7491,23 +7525,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i17.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i17.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i16.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i16.Future<Map<String, _i4.RoomMember>?>);
+            _i17.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i17.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i16.Future<void> kick(
+  _i17.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7521,12 +7555,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leaveRoom(
+  _i17.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7536,12 +7570,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i17.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -7557,12 +7591,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i16.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i16.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i17.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i17.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i16.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i17.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -7584,8 +7618,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_71(
+        returnValue: _i17.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_72(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7601,8 +7635,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_71(
+        returnValueForMissingStub: _i17.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_72(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7618,10 +7652,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomEventsResponse>);
+      ) as _i17.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i16.Future<void> setReadMarker(
+  _i17.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7637,12 +7671,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> postReceipt(
+  _i17.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -7658,12 +7692,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEvent(
+  _i17.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7679,12 +7713,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> reportRoom(
+  _i17.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7696,12 +7730,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> reportEvent(
+  _i17.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7719,12 +7753,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> sendMessage(
+  _i17.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7740,7 +7774,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7753,7 +7787,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7765,23 +7799,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i17.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i16.Future<List<_i4.MatrixEvent>>);
+            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i17.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i17.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -7798,13 +7832,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<String> setRoomStateWithKey(
+  _i17.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -7820,7 +7854,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7833,7 +7867,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7845,10 +7879,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> unban(
+  _i17.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7862,12 +7896,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> upgradeRoom(
+  _i17.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -7881,7 +7915,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7893,7 +7927,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7904,10 +7938,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.SearchResults> search(
+  _i17.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -7917,7 +7951,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
+        returnValue: _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
           this,
           Invocation.method(
             #search,
@@ -7926,7 +7960,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
+            _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
           this,
           Invocation.method(
             #search,
@@ -7934,10 +7968,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i16.Future<_i4.SearchResults>);
+      ) as _i17.Future<_i4.SearchResults>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> sync({
+  _i17.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -7958,7 +7992,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.method(
             #sync,
@@ -7974,7 +8008,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.method(
             #sync,
@@ -7989,22 +8023,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i17.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i16.Future<List<_i4.Location>>);
+            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i17.Future<List<_i4.Location>>);
 
   @override
-  _i16.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i17.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8014,21 +8048,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i16.Future<List<_i4.Location>>);
+            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i17.Future<List<_i4.Location>>);
 
   @override
-  _i16.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i17.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_73(
+        returnValue: _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_74(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -8036,45 +8070,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_73(
+            _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_74(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i16.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i17.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i16.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i17.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8085,13 +8119,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getAccountData(
+  _i17.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -8104,13 +8138,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> setAccountData(
+  _i17.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8124,12 +8158,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> defineFilter(
+  _i17.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -8141,7 +8175,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8152,7 +8186,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8162,10 +8196,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.Filter> getFilter(
+  _i17.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8177,7 +8211,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i16.Future<_i4.Filter>.value(_FakeFilter_13(
+        returnValue: _i17.Future<_i4.Filter>.value(_FakeFilter_14(
           this,
           Invocation.method(
             #getFilter,
@@ -8187,7 +8221,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.Filter>.value(_FakeFilter_13(
+        returnValueForMissingStub: _i17.Future<_i4.Filter>.value(_FakeFilter_14(
           this,
           Invocation.method(
             #getFilter,
@@ -8197,10 +8231,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.Filter>);
+      ) as _i17.Future<_i4.Filter>);
 
   @override
-  _i16.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i17.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8213,7 +8247,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
+            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8224,7 +8258,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
+            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8234,10 +8268,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.OpenIdCredentials>);
+      ) as _i17.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i16.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i17.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8252,13 +8286,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> setAccountDataPerRoom(
+  _i17.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8274,12 +8308,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i17.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8291,12 +8325,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i16.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i16.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i16.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i17.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i17.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i17.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i16.Future<void> deleteRoomTag(
+  _i17.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8310,12 +8344,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setRoomTag(
+  _i17.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8331,12 +8365,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i17.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8346,8 +8380,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i16.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_75(
+        returnValue: _i17.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_76(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8356,8 +8390,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_75(
+            _i17.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_76(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8365,10 +8399,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i16.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i17.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> reportUser(
+  _i17.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8381,40 +8415,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i17.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i16.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_76(
+        returnValue: _i17.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_77(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_76(
+        returnValueForMissingStub: _i17.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_77(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.CreateContentResponse>);
+      ) as _i17.Future<_i4.CreateContentResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> uploadContentToMXC(
+  _i17.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i26.Uint8List? body, {
+    _i27.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8432,16 +8466,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [CallService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCallService extends _i1.Mock implements _i27.CallService {
+class MockCallService extends _i1.Mock implements _i28.CallService {
   @override
   _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -8463,36 +8497,36 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       ) as bool);
 
   @override
-  _i28.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
+  _i29.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
         Invocation.getter(#httpPostForTest),
         returnValue: (
-          _i15.Client httpClient,
+          _i16.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i16.Future<_i15.Response>.value(_FakeResponse_77(
+            _i17.Future<_i16.Response>.value(_FakeResponse_78(
           this,
           Invocation.getter(#httpPostForTest),
         )),
         returnValueForMissingStub: (
-          _i15.Client httpClient,
+          _i16.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i16.Future<_i15.Response>.value(_FakeResponse_77(
+            _i17.Future<_i16.Response>.value(_FakeResponse_78(
           this,
           Invocation.getter(#httpPostForTest),
         )),
-      ) as _i28.HttpPostFunction);
+      ) as _i29.HttpPostFunction);
 
   @override
-  List<_i29.RemoteParticipant> get participants => (super.noSuchMethod(
+  List<_i30.RemoteParticipant> get participants => (super.noSuchMethod(
         Invocation.getter(#participants),
-        returnValue: <_i29.RemoteParticipant>[],
-        returnValueForMissingStub: <_i29.RemoteParticipant>[],
-      ) as List<_i29.RemoteParticipant>);
+        returnValue: <_i30.RemoteParticipant>[],
+        returnValueForMissingStub: <_i30.RemoteParticipant>[],
+      ) as List<_i30.RemoteParticipant>);
 
   @override
   bool get isMicEnabled => (super.noSuchMethod(
@@ -8523,14 +8557,14 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       ) as bool);
 
   @override
-  List<_i29.Participant<_i29.TrackPublication<_i29.Track>>>
+  List<_i30.Participant<_i30.TrackPublication<_i30.Track>>>
       get activeSpeakers => (super.noSuchMethod(
             Invocation.getter(#activeSpeakers),
-            returnValue: <_i29
-                .Participant<_i29.TrackPublication<_i29.Track>>>[],
-            returnValueForMissingStub: <_i29
-                .Participant<_i29.TrackPublication<_i29.Track>>>[],
-          ) as List<_i29.Participant<_i29.TrackPublication<_i29.Track>>>);
+            returnValue: <_i30
+                .Participant<_i30.TrackPublication<_i30.Track>>>[],
+            returnValueForMissingStub: <_i30
+                .Participant<_i30.TrackPublication<_i30.Track>>>[],
+          ) as List<_i30.Participant<_i30.TrackPublication<_i30.Track>>>);
 
   @override
   bool get isCallingAvailable => (super.noSuchMethod(
@@ -8540,11 +8574,11 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       ) as bool);
 
   @override
-  List<_i30.CallParticipant> get allParticipants => (super.noSuchMethod(
+  List<_i31.CallParticipant> get allParticipants => (super.noSuchMethod(
         Invocation.getter(#allParticipants),
-        returnValue: <_i30.CallParticipant>[],
-        returnValueForMissingStub: <_i30.CallParticipant>[],
-      ) as List<_i30.CallParticipant>);
+        returnValue: <_i31.CallParticipant>[],
+        returnValueForMissingStub: <_i31.CallParticipant>[],
+      ) as List<_i31.CallParticipant>);
 
   @override
   bool get isSpeakerOn => (super.noSuchMethod(
@@ -8554,29 +8588,29 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       ) as bool);
 
   @override
-  _i16.Stream<_i31.IncomingCallInfo> get incomingCallStream =>
+  _i17.Stream<_i32.IncomingCallInfo> get incomingCallStream =>
       (super.noSuchMethod(
         Invocation.getter(#incomingCallStream),
-        returnValue: _i16.Stream<_i31.IncomingCallInfo>.empty(),
-        returnValueForMissingStub: _i16.Stream<_i31.IncomingCallInfo>.empty(),
-      ) as _i16.Stream<_i31.IncomingCallInfo>);
+        returnValue: _i17.Stream<_i32.IncomingCallInfo>.empty(),
+        returnValueForMissingStub: _i17.Stream<_i32.IncomingCallInfo>.empty(),
+      ) as _i17.Stream<_i32.IncomingCallInfo>);
 
   @override
-  _i16.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
+  _i17.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
         Invocation.getter(#nativeAcceptedCallStream),
-        returnValue: _i16.Stream<String>.empty(),
-        returnValueForMissingStub: _i16.Stream<String>.empty(),
-      ) as _i16.Stream<String>);
+        returnValue: _i17.Stream<String>.empty(),
+        returnValueForMissingStub: _i17.Stream<String>.empty(),
+      ) as _i17.Stream<String>);
 
   @override
-  _i32.KoheraCallState get callState => (super.noSuchMethod(
+  _i33.KoheraCallState get callState => (super.noSuchMethod(
         Invocation.getter(#callState),
-        returnValue: _i32.KoheraCallState.idle,
-        returnValueForMissingStub: _i32.KoheraCallState.idle,
-      ) as _i32.KoheraCallState);
+        returnValue: _i33.KoheraCallState.idle,
+        returnValueForMissingStub: _i33.KoheraCallState.idle,
+      ) as _i33.KoheraCallState);
 
   @override
-  set preferencesService(_i19.PreferencesService? prefs) => super.noSuchMethod(
+  set preferencesService(_i20.PreferencesService? prefs) => super.noSuchMethod(
         Invocation.setter(
           #preferencesService,
           prefs,
@@ -8585,7 +8619,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  set ringtoneService(_i33.RingtoneService? service) => super.noSuchMethod(
+  set ringtoneService(_i34.RingtoneService? service) => super.noSuchMethod(
         Invocation.setter(
           #ringtoneService,
           service,
@@ -8594,7 +8628,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  set roomFactoryForTest(_i28.LiveKitRoomFactory? factory) =>
+  set roomFactoryForTest(_i29.LiveKitRoomFactory? factory) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomFactoryForTest,
@@ -8604,7 +8638,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  set httpPostForTest(_i28.HttpPostFunction? fn) => super.noSuchMethod(
+  set httpPostForTest(_i29.HttpPostFunction? fn) => super.noSuchMethod(
         Invocation.setter(
           #httpPostForTest,
           fn,
@@ -8638,27 +8672,27 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  _i16.Future<void> toggleMicrophone() => (super.noSuchMethod(
+  _i17.Future<void> toggleMicrophone() => (super.noSuchMethod(
         Invocation.method(
           #toggleMicrophone,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> toggleCamera() => (super.noSuchMethod(
+  _i17.Future<void> toggleCamera() => (super.noSuchMethod(
         Invocation.method(
           #toggleCamera,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> toggleScreenShare({
+  _i17.Future<void> toggleScreenShare({
     String? sourceId,
     bool? captureScreenAudio = false,
   }) =>
@@ -8671,39 +8705,39 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
             #captureScreenAudio: captureScreenAudio,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> toggleScreenAudio() => (super.noSuchMethod(
+  _i17.Future<void> toggleScreenAudio() => (super.noSuchMethod(
         Invocation.method(
           #toggleScreenAudio,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
+  _i17.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
         Invocation.method(
           #setOutputVolume,
           [volume],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> toggleSpeaker() => (super.noSuchMethod(
+  _i17.Future<void> toggleSpeaker() => (super.noSuchMethod(
         Invocation.method(
           #toggleSpeaker,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void setVoipPushHandlesCallKit(bool? value) => super.noSuchMethod(
@@ -8733,7 +8767,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8761,36 +8795,36 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  _i16.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #joinCall,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leaveCall() => (super.noSuchMethod(
+  _i17.Future<void> leaveCall() => (super.noSuchMethod(
         Invocation.method(
           #leaveCall,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> acceptCall({bool? withVideo = false}) =>
+  _i17.Future<void> acceptCall({bool? withVideo = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #acceptCall,
           [],
           {#withVideo: withVideo},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void declineCall() => super.noSuchMethod(
@@ -8812,9 +8846,9 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  _i16.Future<void> initiateCall(
+  _i17.Future<void> initiateCall(
     String? roomId, {
-    _i31.CallType? type = _i31.CallType.voice,
+    _i32.CallType? type = _i32.CallType.voice,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8822,9 +8856,9 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
           [roomId],
           {#type: type},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   bool roomHasActiveCall(String? roomId) => (super.noSuchMethod(
@@ -8917,7 +8951,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8926,7 +8960,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8935,17 +8969,17 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  _i16.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i17.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8956,7 +8990,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8993,26 +9027,26 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  _i16.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i17.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+  _i17.Future<bool> didPushRouteInformation(
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -9042,7 +9076,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -9051,7 +9085,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -9060,16 +9094,16 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  _i16.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i17.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i16.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i17.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i16.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i16.Future<_i22.AppExitResponse>);
+            _i17.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i17.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -9094,32 +9128,32 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockNotificationService extends _i1.Mock
-    implements _i34.NotificationService {
+    implements _i35.NotificationService {
   @override
-  _i18.MatrixService get matrixService => (super.noSuchMethod(
+  _i19.MatrixService get matrixService => (super.noSuchMethod(
         Invocation.getter(#matrixService),
-        returnValue: _FakeMatrixService_78(
+        returnValue: _FakeMatrixService_79(
           this,
           Invocation.getter(#matrixService),
         ),
-        returnValueForMissingStub: _FakeMatrixService_78(
+        returnValueForMissingStub: _FakeMatrixService_79(
           this,
           Invocation.getter(#matrixService),
         ),
-      ) as _i18.MatrixService);
+      ) as _i19.MatrixService);
 
   @override
-  _i19.PreferencesService get preferencesService => (super.noSuchMethod(
+  _i20.PreferencesService get preferencesService => (super.noSuchMethod(
         Invocation.getter(#preferencesService),
-        returnValue: _FakePreferencesService_79(
+        returnValue: _FakePreferencesService_80(
           this,
           Invocation.getter(#preferencesService),
         ),
-        returnValueForMissingStub: _FakePreferencesService_79(
+        returnValueForMissingStub: _FakePreferencesService_80(
           this,
           Invocation.getter(#preferencesService),
         ),
-      ) as _i19.PreferencesService);
+      ) as _i20.PreferencesService);
 
   @override
   bool get isAppResumed => (super.noSuchMethod(
@@ -9138,14 +9172,14 @@ class MockNotificationService extends _i1.Mock
       );
 
   @override
-  _i16.Future<void> init() => (super.noSuchMethod(
+  _i17.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void startListening() => super.noSuchMethod(
@@ -9166,7 +9200,7 @@ class MockNotificationService extends _i1.Mock
       );
 
   @override
-  _i16.Future<String?> downloadAvatarToTemp(
+  _i17.Future<String?> downloadAvatarToTemp(
     _i4.Client? client,
     Uri? avatarUrl,
     String? userId,
@@ -9180,9 +9214,9 @@ class MockNotificationService extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
   void navigateToRoom(String? roomId) => super.noSuchMethod(
@@ -9194,7 +9228,7 @@ class MockNotificationService extends _i1.Mock
       );
 
   @override
-  _i16.Future<void> showPushNotification({
+  _i17.Future<void> showPushNotification({
     required String? roomId,
     required String? title,
     required String? body,
@@ -9211,29 +9245,29 @@ class MockNotificationService extends _i1.Mock
             #senderName: senderName,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> cancelForRoom(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> cancelForRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #cancelForRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> cancelAll() => (super.noSuchMethod(
+  _i17.Future<void> cancelAll() => (super.noSuchMethod(
         Invocation.method(
           #cancelAll,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -9252,11 +9286,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -9286,11 +9320,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_80(
+        returnValue: _FakeRoomSummary_81(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_80(
+        returnValueForMissingStub: _FakeRoomSummary_81(
           this,
           Invocation.getter(#summary),
         ),
@@ -9320,11 +9354,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i16.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i17.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i16.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i16.Completer<dynamic>>[],
-      ) as List<_i16.Completer<dynamic>>);
+        returnValue: <_i17.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i17.Completer<dynamic>>[],
+      ) as List<_i17.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -9343,51 +9377,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i14.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i15.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_18<String>(
+        returnValue: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i14.CachedStreamController<String> get onSessionKeyReceived =>
+  _i15.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_18<String>(
+        returnValue: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -9403,11 +9437,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -9416,11 +9450,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -9463,11 +9497,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -9476,11 +9510,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_19(
+        returnValue: _FakeDateTime_20(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_19(
+        returnValueForMissingStub: _FakeDateTime_20(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -9510,11 +9544,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_81(
+        returnValue: _FakeLatestReceiptState_82(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_81(
+        returnValueForMissingStub: _FakeLatestReceiptState_82(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -9535,18 +9569,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i16.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i17.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -9733,18 +9767,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i35.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i36.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i35.SpaceParent>[],
-        returnValueForMissingStub: <_i35.SpaceParent>[],
-      ) as List<_i35.SpaceParent>);
+        returnValue: <_i36.SpaceParent>[],
+        returnValueForMissingStub: <_i36.SpaceParent>[],
+      ) as List<_i36.SpaceParent>);
 
   @override
-  List<_i35.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i36.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i35.SpaceChild>[],
-        returnValueForMissingStub: <_i35.SpaceChild>[],
-      ) as List<_i35.SpaceChild>);
+        returnValue: <_i36.SpaceChild>[],
+        returnValueForMissingStub: <_i36.SpaceChild>[],
+      ) as List<_i36.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -9857,14 +9891,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i16.Future<void> postLoad() => (super.noSuchMethod(
+  _i17.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -9892,15 +9926,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i16.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i17.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i16.Future<List<_i4.User>>);
+            _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i17.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -9911,14 +9945,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9928,18 +9962,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i16.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i17.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Event?> refreshLastEvent(
+  _i17.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9947,9 +9981,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -9961,12 +9995,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i16.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i17.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9974,22 +10008,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i17.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9997,17 +10031,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> addTag(
+  _i17.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -10017,27 +10051,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i17.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i17.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -10045,53 +10079,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i17.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i17.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+  _i17.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
         Invocation.method(
           #setLowPriority,
           [lowPriority],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i17.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -10099,14 +10133,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -10118,7 +10152,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i16.Future<String?> sendTextEvent(
+  _i17.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -10150,12 +10184,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendReaction(
+  _i17.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -10169,12 +10203,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendLocation(
+  _i17.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -10188,12 +10222,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendFileEvent(
+  _i17.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -10221,25 +10255,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i17.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i16.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i17.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i16.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i17.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i16.Future<_i4.EncryptionHealthState>);
+      ) as _i17.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i16.Future<String?> sendEvent(
+  _i17.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -10263,73 +10297,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i17.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leave() => (super.noSuchMethod(
+  _i17.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> forget() => (super.noSuchMethod(
+  _i17.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> setPower(
+  _i17.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -10341,7 +10375,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10352,7 +10386,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10362,10 +10396,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> invite(
+  _i17.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -10375,12 +10409,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<int> requestHistory({
+  _i17.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -10397,32 +10431,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
-  _i16.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i17.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setReadMarker(
+  _i17.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -10436,23 +10470,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i20.TimelineChunk?> getEventContext(String? eventId) =>
+  _i17.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i16.Future<_i20.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i16.Future<_i20.TimelineChunk?>.value(),
-      ) as _i16.Future<_i20.TimelineChunk?>);
+        returnValue: _i17.Future<_i21.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i17.Future<_i21.TimelineChunk?>.value(),
+      ) as _i17.Future<_i21.TimelineChunk?>);
 
   @override
-  _i16.Future<void> postReceipt(
+  _i17.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -10462,12 +10496,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Timeline> getTimeline({
+  _i17.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -10490,7 +10524,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i16.Future<_i4.Timeline>.value(_FakeTimeline_82(
+        returnValue: _i17.Future<_i4.Timeline>.value(_FakeTimeline_83(
           this,
           Invocation.method(
             #getTimeline,
@@ -10507,7 +10541,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Timeline>.value(_FakeTimeline_82(
+            _i17.Future<_i4.Timeline>.value(_FakeTimeline_83(
           this,
           Invocation.method(
             #getTimeline,
@@ -10523,7 +10557,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Timeline>);
+      ) as _i17.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -10542,7 +10576,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i16.Future<List<_i4.User>> requestParticipants([
+  _i17.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -10560,10 +10594,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i16.Future<List<_i4.User>>);
+            _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i17.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -10571,14 +10605,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_83(
+        returnValue: _FakeUser_84(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_83(
+        returnValueForMissingStub: _FakeUser_84(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -10594,14 +10628,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_83(
+        returnValue: _FakeUser_84(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_83(
+        returnValueForMissingStub: _FakeUser_84(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -10611,7 +10645,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i16.Future<_i4.User?> requestUser(
+  _i17.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -10627,19 +10661,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i16.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.User?>.value(),
-      ) as _i16.Future<_i4.User?>);
+        returnValue: _i17.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.User?>.value(),
+      ) as _i17.Future<_i4.User?>);
 
   @override
-  _i16.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i17.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -10652,12 +10686,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i16.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i17.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i16.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10665,14 +10699,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i21.dummyValue<String>(
+            _i17.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -10695,14 +10729,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i16.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i17.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -10741,18 +10775,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i16.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i17.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEvent(
+  _i17.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -10766,12 +10800,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> setTyping(
+  _i17.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -10781,12 +10815,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setJoinRules(
+  _i17.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -10800,59 +10834,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i17.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setHistoryVisibility(
+  _i17.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i17.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i17.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i16.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i17.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i16.Future<List<_i4.DeviceKeys>>);
+            _i17.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i17.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i16.Future<void> requestSessionKey(
+  _i17.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -10864,12 +10898,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setSpaceChild(
+  _i17.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -10885,44 +10919,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i17.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i16.Future<Uri>.value(_FakeUri_32(
+        returnValue: _i17.Future<Uri>.value(_FakeUri_33(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_32(
+        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_33(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i16.Future<Uri>);
+      ) as _i17.Future<Uri>);
 
   @override
-  _i16.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<
+  _i17.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -10949,21 +10983,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i16.Future<
+        returnValue: _i17.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i16.Future<
+        returnValueForMissingStub: _i17.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i16.Future<
+      ) as _i17.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -10978,11 +11012,11 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
   @override
   _i4.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_84(
+        returnValue: _FakeRoom_85(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_84(
+        returnValueForMissingStub: _FakeRoom_85(
           this,
           Invocation.getter(#room),
         ),
@@ -11032,17 +11066,17 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       ) as bool);
 
   @override
-  _i20.TimelineChunk get chunk => (super.noSuchMethod(
+  _i21.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_85(
+        returnValue: _FakeTimelineChunk_86(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_85(
+        returnValueForMissingStub: _FakeTimelineChunk_86(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i20.TimelineChunk);
+      ) as _i21.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -11059,7 +11093,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       ) as bool);
 
   @override
-  set timelineSub(_i16.StreamSubscription<_i4.Event>? value) =>
+  set timelineSub(_i17.StreamSubscription<_i4.Event>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #timelineSub,
@@ -11069,7 +11103,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set historySub(_i16.StreamSubscription<_i4.Event>? value) =>
+  set historySub(_i17.StreamSubscription<_i4.Event>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #historySub,
@@ -11079,7 +11113,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set roomSub(_i16.StreamSubscription<_i4.SyncUpdate>? value) =>
+  set roomSub(_i17.StreamSubscription<_i4.SyncUpdate>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomSub,
@@ -11089,7 +11123,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set sessionIdReceivedSub(_i16.StreamSubscription<String>? value) =>
+  set sessionIdReceivedSub(_i17.StreamSubscription<String>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #sessionIdReceivedSub,
@@ -11099,7 +11133,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set cancelSendEventSub(_i16.StreamSubscription<String>? value) =>
+  set cancelSendEventSub(_i17.StreamSubscription<String>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #cancelSendEventSub,
@@ -11145,7 +11179,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set chunk(_i20.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i21.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -11154,17 +11188,17 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  _i16.Future<_i4.Event?> getEventById(String? id) => (super.noSuchMethod(
+  _i17.Future<_i4.Event?> getEventById(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [id],
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
-  _i16.Future<void> requestHistory({
+  _i17.Future<void> requestHistory({
     int? historyCount = 30,
     _i4.StateFilter? filter,
   }) =>
@@ -11177,12 +11211,12 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> requestFuture({
+  _i17.Future<void> requestFuture({
     int? historyCount = 30,
     _i4.StateFilter? filter,
   }) =>
@@ -11195,12 +11229,12 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<int> getRoomEvents({
+  _i17.Future<int> getRoomEvents({
     int? historyCount = 30,
     dynamic direction = _i4.Direction.b,
     _i4.StateFilter? filter,
@@ -11215,9 +11249,9 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
   void cancelSubscriptions() => super.noSuchMethod(
@@ -11246,7 +11280,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  _i16.Future<void> setReadMarker({
+  _i17.Future<void> setReadMarker({
     String? eventId,
     bool? public,
   }) =>
@@ -11259,9 +11293,9 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #public: public,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void addAggregatedEvent(_i4.Event? event) => super.noSuchMethod(
@@ -11282,7 +11316,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  _i16.Stream<List<_i4.Event>> searchEvent({
+  _i17.Stream<List<_i4.Event>> searchEvent({
     String? searchTerm,
     int? requestHistoryCount = 100,
     int? maxHistoryRequests = 10,
@@ -11303,12 +11337,12 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #searchFunc: searchFunc,
           },
         ),
-        returnValue: _i16.Stream<List<_i4.Event>>.empty(),
-        returnValueForMissingStub: _i16.Stream<List<_i4.Event>>.empty(),
-      ) as _i16.Stream<List<_i4.Event>>);
+        returnValue: _i17.Stream<List<_i4.Event>>.empty(),
+        returnValueForMissingStub: _i17.Stream<List<_i4.Event>>.empty(),
+      ) as _i17.Stream<List<_i4.Event>>);
 
   @override
-  _i16.Stream<(List<_i4.Event>, String?)> startSearch({
+  _i17.Stream<(List<_i4.Event>, String?)> startSearch({
     String? searchTerm,
     int? requestHistoryCount = 100,
     int? maxHistoryRequests = 10,
@@ -11331,8 +11365,8 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #searchFunc: searchFunc,
           },
         ),
-        returnValue: _i16.Stream<(List<_i4.Event>, String?)>.empty(),
+        returnValue: _i17.Stream<(List<_i4.Event>, String?)>.empty(),
         returnValueForMissingStub:
-            _i16.Stream<(List<_i4.Event>, String?)>.empty(),
-      ) as _i16.Stream<(List<_i4.Event>, String?)>);
+            _i17.Stream<(List<_i4.Event>, String?)>.empty(),
+      ) as _i17.Stream<(List<_i4.Event>, String?)>);
 }

--- a/test/services/notification_service_test.mocks.dart
+++ b/test/services/notification_service_test.mocks.dart
@@ -3,26 +3,26 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i16;
-import 'dart:typed_data' as _i24;
-import 'dart:ui' as _i20;
+import 'dart:async' as _i17;
+import 'dart:typed_data' as _i25;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:flutter_local_notifications/src/flutter_local_notifications_plugin.dart'
-    as _i27;
-import 'package:flutter_local_notifications/src/initialization_settings.dart'
     as _i28;
-import 'package:flutter_local_notifications/src/notification_details.dart'
-    as _i30;
-import 'package:flutter_local_notifications/src/platform_specifics/android/schedule_mode.dart'
-    as _i32;
-import 'package:flutter_local_notifications/src/types.dart' as _i33;
-import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart'
+import 'package:flutter_local_notifications/src/initialization_settings.dart'
     as _i29;
-import 'package:http/http.dart' as _i15;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i13;
+import 'package:flutter_local_notifications/src/notification_details.dart'
+    as _i31;
+import 'package:flutter_local_notifications/src/platform_specifics/android/schedule_mode.dart'
+    as _i33;
+import 'package:flutter_local_notifications/src/types.dart' as _i34;
+import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart'
+    as _i30;
+import 'package:http/http.dart' as _i16;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -38,15 +38,16 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i23;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i13;
+import 'package:matrix/encryption.dart' as _i24;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i17;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i26;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i14;
-import 'package:matrix/src/utils/space_child.dart' as _i25;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i18;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i27;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i15;
+import 'package:matrix/src/utils/space_child.dart' as _i26;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
-import 'package:timezone/timezone.dart' as _i31;
+import 'package:mockito/src/dummies.dart' as _i20;
+import 'package:timezone/timezone.dart' as _i32;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -180,9 +181,9 @@ class _FakeOutboxService_10 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_11 extends _i1.SmartFake
-    implements _i13.StickerPackService {
-  _FakeStickerPackService_11(
+class _FakeAvatarResolver_11 extends _i1.SmartFake
+    implements _i13.AvatarResolver {
+  _FakeAvatarResolver_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -191,8 +192,9 @@ class _FakeStickerPackService_11 extends _i1.SmartFake
         );
 }
 
-class _FakeDatabaseApi_12 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_12(
+class _FakeStickerPackService_12 extends _i1.SmartFake
+    implements _i14.StickerPackService {
+  _FakeStickerPackService_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -201,8 +203,8 @@ class _FakeDatabaseApi_12 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_13 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_13(
+class _FakeDatabaseApi_13 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -211,9 +213,19 @@ class _FakeFilter_13 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_14 extends _i1.SmartFake
+class _FakeFilter_14 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_14(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNativeImplementations_15 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_14(
+  _FakeNativeImplementations_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -222,8 +234,8 @@ class _FakeNativeImplementations_14 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_15 extends _i1.SmartFake implements Duration {
-  _FakeDuration_15(
+class _FakeDuration_16 extends _i1.SmartFake implements Duration {
+  _FakeDuration_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -232,9 +244,9 @@ class _FakeDuration_15 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_16 extends _i1.SmartFake
+class _FakePushruleEvaluator_17 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_16(
+  _FakePushruleEvaluator_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -243,8 +255,8 @@ class _FakePushruleEvaluator_16 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_17 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_17(
+class _FakeProfile_18 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -253,9 +265,9 @@ class _FakeProfile_17 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_18<T> extends _i1.SmartFake
-    implements _i14.CachedStreamController<T> {
-  _FakeCachedStreamController_18(
+class _FakeCachedStreamController_19<T> extends _i1.SmartFake
+    implements _i15.CachedStreamController<T> {
+  _FakeCachedStreamController_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -264,8 +276,8 @@ class _FakeCachedStreamController_18<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_19 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_19(
+class _FakeDateTime_20 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -274,8 +286,8 @@ class _FakeDateTime_19 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_20 extends _i1.SmartFake implements _i15.Client {
-  _FakeClient_20(
+class _FakeClient_21 extends _i1.SmartFake implements _i16.Client {
+  _FakeClient_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -284,9 +296,9 @@ class _FakeClient_20 extends _i1.SmartFake implements _i15.Client {
         );
 }
 
-class _FakeDiscoveryInformation_21 extends _i1.SmartFake
+class _FakeDiscoveryInformation_22 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_21(
+  _FakeDiscoveryInformation_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -295,9 +307,9 @@ class _FakeDiscoveryInformation_21 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_22 extends _i1.SmartFake
+class _FakeGetVersionsResponse_23 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_22(
+  _FakeGetVersionsResponse_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -306,9 +318,9 @@ class _FakeGetVersionsResponse_22 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_23 extends _i1.SmartFake
+class _FakeRegisterResponse_24 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_23(
+  _FakeRegisterResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -317,8 +329,8 @@ class _FakeRegisterResponse_23 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_24 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_24(
+class _FakeLoginResponse_25 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -327,9 +339,9 @@ class _FakeLoginResponse_24 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_25 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_25(
+  _FakeGetAuthMetadataResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -338,8 +350,8 @@ class _FakeGetAuthMetadataResponse_25 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_26<T1> extends _i1.SmartFake implements _i16.Future<T1> {
-  _FakeFuture_26(
+class _FakeFuture_27<T1> extends _i1.SmartFake implements _i17.Future<T1> {
+  _FakeFuture_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -348,8 +360,8 @@ class _FakeFuture_26<T1> extends _i1.SmartFake implements _i16.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_27 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_27(
+class _FakeSyncUpdate_28 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -358,9 +370,9 @@ class _FakeSyncUpdate_27 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_28 extends _i1.SmartFake
+class _FakeCachedProfileInformation_29 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_28(
+  _FakeCachedProfileInformation_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -369,8 +381,8 @@ class _FakeCachedProfileInformation_28 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_29 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_29(
+class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -379,8 +391,8 @@ class _FakeMediaConfig_29 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_30 extends _i1.SmartFake implements _i17.FileResponse {
-  _FakeFileResponse_30(
+class _FakeFileResponse_31 extends _i1.SmartFake implements _i18.FileResponse {
+  _FakeFileResponse_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -389,8 +401,8 @@ class _FakeFileResponse_30 extends _i1.SmartFake implements _i17.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_31(
+class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -399,8 +411,8 @@ class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_32 extends _i1.SmartFake implements Uri {
-  _FakeUri_32(
+class _FakeUri_33 extends _i1.SmartFake implements Uri {
+  _FakeUri_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -409,9 +421,9 @@ class _FakeUri_32 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_33 extends _i1.SmartFake
+class _FakeCachedPresence_34 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_33(
+  _FakeCachedPresence_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -420,9 +432,9 @@ class _FakeCachedPresence_33 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_34 extends _i1.SmartFake
+class _FakeTurnServerCredentials_35 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_34(
+  _FakeTurnServerCredentials_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -431,9 +443,9 @@ class _FakeTurnServerCredentials_34 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_35(
+  _FakeRoomKeysUpdateResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -442,8 +454,8 @@ class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_36(
+class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -452,9 +464,9 @@ class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_37(
+  _FakeGetWellknownSupportResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -463,9 +475,9 @@ class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_38(
+  _FakeGenerateLoginTokenResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -474,9 +486,9 @@ class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_39(
+  _FakeGetRoomSummaryResponse$3_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -485,9 +497,9 @@ class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_40(
+  _FakeGetSpaceHierarchyResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -496,9 +508,9 @@ class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_41(
+  _FakeGetRelatingEventsResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -507,9 +519,9 @@ class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_42(
+  _FakeGetRelatingEventsWithRelTypeResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -518,9 +530,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -529,9 +541,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_44(
+  _FakeGetThreadRootsResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -540,9 +552,9 @@ class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_45(
+  _FakeGetEventByTimestampResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -551,9 +563,9 @@ class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_46 extends _i1.SmartFake
+class _FakeRequestTokenResponse_47 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_46(
+  _FakeRequestTokenResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -562,9 +574,9 @@ class _FakeRequestTokenResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_47(
+  _FakeTokenOwnerInfo_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -573,8 +585,8 @@ class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_48(
+class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -583,8 +595,8 @@ class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_49(
+class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -593,8 +605,8 @@ class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_50(
+class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -603,9 +615,9 @@ class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_51(
+  _FakeGetRoomIdByAliasResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -614,9 +626,9 @@ class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_52 extends _i1.SmartFake
+class _FakeGetEventsResponse_53 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_52(
+  _FakeGetEventsResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -625,9 +637,9 @@ class _FakeGetEventsResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_53 extends _i1.SmartFake
+class _FakePeekEventsResponse_54 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_53(
+  _FakePeekEventsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -636,8 +648,8 @@ class _FakePeekEventsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_54(
+class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -646,9 +658,9 @@ class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_55(
+  _FakeGetKeysChangesResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -657,9 +669,9 @@ class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_56 extends _i1.SmartFake
+class _FakeClaimKeysResponse_57 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_56(
+  _FakeClaimKeysResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -668,9 +680,9 @@ class _FakeClaimKeysResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_57 extends _i1.SmartFake
+class _FakeQueryKeysResponse_58 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_57(
+  _FakeQueryKeysResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -679,9 +691,9 @@ class _FakeQueryKeysResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_58(
+  _FakeGetNotificationsResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -690,9 +702,9 @@ class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_59 extends _i1.SmartFake
+class _FakeGetPresenceResponse_60 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_59(
+  _FakeGetPresenceResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -701,9 +713,9 @@ class _FakeGetPresenceResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_60(
+  _FakeGetPublicRoomsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -712,9 +724,9 @@ class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_61(
+  _FakeQueryPublicRoomsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -723,8 +735,8 @@ class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_62(
+class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -733,9 +745,9 @@ class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_63(
+  _FakeGetPushRulesGlobalResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -744,8 +756,8 @@ class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_64(
+class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -754,9 +766,9 @@ class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_65 extends _i1.SmartFake
+class _FakeRefreshResponse_66 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_65(
+  _FakeRefreshResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -765,8 +777,8 @@ class _FakeRefreshResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_66(
+class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -775,8 +787,8 @@ class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_67(
+class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -785,9 +797,9 @@ class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_68(
+  _FakeGetRoomKeysVersionCurrentResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -796,9 +808,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_69(
+  _FakeGetRoomKeysVersionResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -807,8 +819,8 @@ class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_70(
+class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -817,9 +829,9 @@ class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_71(
+  _FakeGetRoomEventsResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -828,8 +840,8 @@ class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_72(
+class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -838,9 +850,9 @@ class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_73(
+  _FakeGetProtocolMetadataResponse$2_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -849,9 +861,9 @@ class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_74 extends _i1.SmartFake
+class _FakeOpenIdCredentials_75 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_74(
+  _FakeOpenIdCredentials_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -860,9 +872,9 @@ class _FakeOpenIdCredentials_74 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_75(
+  _FakeSearchUserDirectoryResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -871,9 +883,9 @@ class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_76 extends _i1.SmartFake
+class _FakeCreateContentResponse_77 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_76(
+  _FakeCreateContentResponse_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -882,8 +894,8 @@ class _FakeCreateContentResponse_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,9 +904,9 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -903,8 +915,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -913,8 +925,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -926,7 +938,7 @@ class _FakeUser_80 extends _i1.SmartFake implements _i4.User {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -956,11 +968,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1098,17 +1110,30 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i12.OutboxService);
 
   @override
-  _i13.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i13.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i13.AvatarResolver);
+
+  @override
+  _i14.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_11(
+        returnValue: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_11(
+        returnValueForMissingStub: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i13.StickerPackService);
+      ) as _i14.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1217,7 +1242,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set stickerPacks(_i13.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i13.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i14.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -1233,14 +1267,14 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  _i16.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i17.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1270,7 +1304,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1280,18 +1314,18 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i17.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<bool> login({
+  _i17.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1308,12 +1342,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> completeSsoLogin({
+  _i17.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1326,12 +1360,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> completeRegistration(
+  _i17.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1341,32 +1375,32 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> logout() => (super.noSuchMethod(
+  _i17.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i17.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1375,7 +1409,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1384,17 +1418,17 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i17.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1405,7 +1439,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1442,26 +1476,26 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i17.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+  _i17.Future<bool> didPushRouteInformation(
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1491,7 +1525,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1500,7 +1534,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1509,16 +1543,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i17.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i16.Future<_i20.AppExitResponse>);
+            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i17.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1546,23 +1580,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_12(
+        returnValue: _FakeDatabaseApi_13(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_12(
+        returnValueForMissingStub: _FakeDatabaseApi_13(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i23.KeyVerificationMethod> get verificationMethods =>
+  Set<_i24.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i23.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
-      ) as Set<_i23.KeyVerificationMethod>);
+        returnValue: <_i24.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i24.KeyVerificationMethod>{},
+      ) as Set<_i24.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1623,11 +1657,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_13(
+        returnValue: _FakeFilter_14(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_13(
+        returnValueForMissingStub: _FakeFilter_14(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -1636,11 +1670,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_14(
+        returnValue: _FakeNativeImplementations_15(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_14(
+        returnValueForMissingStub: _FakeNativeImplementations_15(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -1656,11 +1690,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_15(
+        returnValue: _FakeDuration_16(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_15(
+        returnValueForMissingStub: _FakeDuration_16(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1669,11 +1703,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_15(
+        returnValue: _FakeDuration_16(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_15(
+        returnValueForMissingStub: _FakeDuration_16(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1682,11 +1716,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1723,11 +1757,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1757,11 +1791,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1770,11 +1804,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1797,11 +1831,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_16(
+        returnValue: _FakePushruleEvaluator_17(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_16(
+        returnValueForMissingStub: _FakePushruleEvaluator_17(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -1822,332 +1856,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i16.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i17.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_17(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_17(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i14.CachedStreamController<String> get onUserProfileUpdate =>
+  _i15.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_18<String>(
+        returnValue: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i16.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i17.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i16.Future<List<_i4.Room>>);
+            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i17.Future<List<_i4.Room>>);
 
   @override
-  _i14.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i15.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_18<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_19<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.EventUpdate>(
+            _FakeCachedStreamController_19<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.EventUpdate>);
+      ) as _i15.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i15.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_18<_i4.Event>(
+        returnValue: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i15.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_18<_i4.Event>(
+        returnValue: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onNotification =>
+  _i15.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_18<_i4.Event>(
+        returnValue: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i15.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_18<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_19<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_19<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i15.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i14.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i15.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_18<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_19<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_18<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_19<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i14.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i15.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i14.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i15.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_18<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_19<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.LoginState>(
+            _FakeCachedStreamController_19<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i14.CachedStreamController<_i4.LoginState>);
+      ) as _i15.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i14.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i15.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_18<bool>(
+        returnValue: _FakeCachedStreamController_19<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i14.CachedStreamController<bool>);
+      ) as _i15.CachedStreamController<bool>);
 
   @override
-  _i14.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i15.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_18<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_19<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i14.CachedStreamController<_i4.SdkError>);
+      ) as _i15.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i14.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i15.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_18<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_19<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.SyncUpdate>(
+            _FakeCachedStreamController_19<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i14.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i15.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i15.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_18<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_19<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_19<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i14.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i15.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.Presence> get onPresence =>
+  _i15.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_18<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_19<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i14.CachedStreamController<_i4.Presence>);
+      ) as _i15.CachedStreamController<_i4.Presence>);
 
   @override
-  _i14.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i15.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_18<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_19<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.CachedPresence>(
+            _FakeCachedStreamController_19<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i14.CachedStreamController<_i4.CachedPresence>);
+      ) as _i15.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i14.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i15.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_18<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_19<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.BasicEvent>(
+            _FakeCachedStreamController_19<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i14.CachedStreamController<_i4.BasicEvent>);
+      ) as _i15.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i14.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
+  _i15.CachedStreamController<_i24.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_18<_i23.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_19<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i23.RoomKeyRequest>(
+            _FakeCachedStreamController_19<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i14.CachedStreamController<_i23.RoomKeyRequest>);
+      ) as _i15.CachedStreamController<_i24.RoomKeyRequest>);
 
   @override
-  _i14.CachedStreamController<_i23.KeyVerification>
+  _i15.CachedStreamController<_i24.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_18<_i23.KeyVerification>(
+            returnValue: _FakeCachedStreamController_19<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_18<_i23.KeyVerification>(
+                _FakeCachedStreamController_19<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i14.CachedStreamController<_i23.KeyVerification>);
+          ) as _i15.CachedStreamController<_i24.KeyVerification>);
 
   @override
-  _i14.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i15.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_18<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_19<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_19<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i14.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i15.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i15.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_18<_i4.Event>(
+        returnValue: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<String> get onCancelSendEvent =>
+  _i15.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_18<String>(
+        returnValue: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i14.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i15.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_18<
+            returnValue: _FakeCachedStreamController_19<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_18<
+            returnValueForMissingStub: _FakeCachedStreamController_19<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i14.CachedStreamController<
+          ) as _i15.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2167,11 +2201,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_19(
+        returnValue: _FakeDateTime_20(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_19(
+        returnValueForMissingStub: _FakeDateTime_20(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2244,7 +2278,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i24.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2299,7 +2333,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i16.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i17.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2310,7 +2344,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i16.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i17.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -2421,7 +2455,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2430,7 +2464,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2439,7 +2473,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2466,20 +2500,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i15.Client get httpClient => (super.noSuchMethod(
+  _i16.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_20(
+        returnValue: _FakeClient_21(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_20(
+        returnValueForMissingStub: _FakeClient_21(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i15.Client);
+      ) as _i16.Client);
 
   @override
-  set httpClient(_i15.Client? value) => super.noSuchMethod(
+  set httpClient(_i16.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2506,7 +2540,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<void> refreshAccessToken(
+  _i17.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2514,9 +2548,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2534,14 +2568,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2578,33 +2612,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i16.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i17.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_21(
+        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_22(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_21(
+        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_22(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i16.Future<_i4.DiscoveryInformation>);
+      ) as _i17.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i16.Future<
+  _i17.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -2626,7 +2660,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i16.Future<
+        returnValue: _i17.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2634,7 +2668,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_22(
+          _FakeGetVersionsResponse_23(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2649,7 +2683,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i16.Future<
+        returnValueForMissingStub: _i17.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2657,7 +2691,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_22(
+          _FakeGetVersionsResponse_23(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2672,7 +2706,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i16.Future<
+      ) as _i17.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -2681,7 +2715,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i16.Future<_i4.DiscoveryInformation> getWellknown({
+  _i17.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2694,8 +2728,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_21(
+        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_22(
           this,
           Invocation.method(
             #getWellknown,
@@ -2706,8 +2740,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_21(
+        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_22(
           this,
           Invocation.method(
             #getWellknown,
@@ -2718,10 +2752,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.DiscoveryInformation>);
+      ) as _i17.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i16.Future<_i4.RegisterResponse> register({
+  _i17.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -2749,7 +2783,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_23(
+            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_24(
           this,
           Invocation.method(
             #register,
@@ -2768,7 +2802,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_23(
+            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_24(
           this,
           Invocation.method(
             #register,
@@ -2786,10 +2820,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RegisterResponse>);
+      ) as _i17.Future<_i4.RegisterResponse>);
 
   @override
-  _i16.Future<_i4.LoginResponse> login(
+  _i17.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -2819,7 +2853,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_24(
+        returnValue: _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_25(
           this,
           Invocation.method(
             #login,
@@ -2839,7 +2873,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_24(
+            _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_25(
           this,
           Invocation.method(
             #login,
@@ -2858,10 +2892,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.LoginResponse>);
+      ) as _i17.Future<_i4.LoginResponse>);
 
   @override
-  _i16.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i17.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2874,8 +2908,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_25(
+        returnValue: _i17.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_26(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2887,8 +2921,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_25(
+            _i17.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_26(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2899,74 +2933,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i17.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i16.Future<void> logout() => (super.noSuchMethod(
+  _i17.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> logoutAll() => (super.noSuchMethod(
+  _i17.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<T> uiaRequestBackground<T>(
-          _i16.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i17.Future<T> uiaRequestBackground<T>(
+          _i17.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i16.Future<T>.value(v),
+              (T v) => _i17.Future<T>.value(v),
             ) ??
-            _FakeFuture_26<T>(
+            _FakeFuture_27<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i16.Future<T>.value(v),
+              (T v) => _i17.Future<T>.value(v),
             ) ??
-            _FakeFuture_26<T>(
+            _FakeFuture_27<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i16.Future<T>);
+      ) as _i17.Future<T>);
 
   @override
-  _i16.Future<String> startDirectChat(
+  _i17.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -2988,7 +3022,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3004,7 +3038,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3019,10 +3053,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<String> createGroupChat({
+  _i17.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -3053,7 +3087,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3074,7 +3108,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3094,10 +3128,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i17.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3113,7 +3147,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3126,7 +3160,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3138,21 +3172,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i17.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<String> createSpace({
+  _i17.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3177,7 +3211,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3195,7 +3229,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3212,10 +3246,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i17.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3223,7 +3257,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_17(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3232,7 +3266,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_17(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3240,10 +3274,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i16.Future<_i4.Profile> fetchOwnProfile({
+  _i17.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3256,7 +3290,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_17(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3268,7 +3302,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_17(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3279,10 +3313,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i16.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i17.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3296,8 +3330,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i16.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_28(
+        returnValue: _i17.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_29(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3309,8 +3343,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_28(
+            _i17.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_29(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3321,10 +3355,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.CachedProfileInformation>);
+      ) as _i17.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i16.Future<_i4.Profile> getProfileFromUserId(
+  _i17.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3342,7 +3376,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_17(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3356,7 +3390,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_17(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3369,7 +3403,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3391,31 +3425,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i16.Future<List<_i4.Room>>);
+            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i17.Future<List<_i4.Room>>);
 
   @override
-  _i16.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i17.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i16.Future<List<_i4.ArchivedRoom>>);
+            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i17.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i16.Future<_i4.GetVersionsResponse> getVersions({
+  _i17.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3428,8 +3462,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_22(
+        returnValue: _i17.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_23(
           this,
           Invocation.method(
             #getVersions,
@@ -3440,8 +3474,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_22(
+        returnValueForMissingStub: _i17.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_23(
           this,
           Invocation.method(
             #getVersions,
@@ -3452,20 +3486,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetVersionsResponse>);
+      ) as _i17.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i16.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i17.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.MediaConfig> getConfig({
+  _i17.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3478,7 +3512,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
+        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfig,
@@ -3490,7 +3524,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
+            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfig,
@@ -3501,10 +3535,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.MediaConfig>);
+      ) as _i17.Future<_i4.MediaConfig>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContent(
+  _i17.Future<_i18.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3524,7 +3558,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContent,
@@ -3540,7 +3574,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContent,
@@ -3555,10 +3589,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentOverrideName(
+  _i17.Future<_i18.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3580,7 +3614,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3597,7 +3631,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3613,10 +3647,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentThumbnail(
+  _i17.Future<_i18.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -3644,7 +3678,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3664,7 +3698,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3683,10 +3717,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i17.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3696,7 +3730,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
+        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3705,7 +3739,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
+            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3713,11 +3747,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i16.Future<_i4.PreviewForUrl>);
+      ) as _i17.Future<_i4.PreviewForUrl>);
 
   @override
-  _i16.Future<Uri> uploadContent(
-    _i24.Uint8List? file, {
+  _i17.Future<Uri> uploadContent(
+    _i25.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3730,7 +3764,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i16.Future<Uri>.value(_FakeUri_32(
+        returnValue: _i17.Future<Uri>.value(_FakeUri_33(
           this,
           Invocation.method(
             #uploadContent,
@@ -3741,7 +3775,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_32(
+        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_33(
           this,
           Invocation.method(
             #uploadContent,
@@ -3752,10 +3786,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<Uri>);
+      ) as _i17.Future<Uri>);
 
   @override
-  _i16.Future<void> setTyping(
+  _i17.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -3771,42 +3805,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> exportDump() => (super.noSuchMethod(
+  _i17.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i17.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i17.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Event?> getEventByPushNotification(
+  _i17.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -3822,12 +3856,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
-  _i16.Future<void> init({
+  _i17.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -3862,9 +3896,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -3876,40 +3910,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<void> clear() => (super.noSuchMethod(
+  _i17.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i17.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ensureNotSoftLoggedOut(
+  _i17.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> handleSync(
+  _i17.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -3919,9 +3953,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -3934,29 +3968,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i16.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i17.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i17.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDevice(
+  _i17.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -3970,12 +4004,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDevicesOfUserIds(
+  _i17.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3991,12 +4025,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDeviceEncrypted(
+  _i17.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4016,12 +4050,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDeviceEncryptedChunked(
+  _i17.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -4035,23 +4069,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i17.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> joinRoom(
+  _i17.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -4069,7 +4103,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4083,7 +4117,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4096,10 +4130,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> changePassword(
+  _i17.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4115,22 +4149,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> clearCache() => (super.noSuchMethod(
+  _i17.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ignoreUser(
+  _i17.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4140,22 +4174,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i17.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i17.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4166,7 +4200,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4175,7 +4209,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4183,32 +4217,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i16.Future<_i4.CachedPresence>);
+      ) as _i17.Future<_i4.CachedPresence>);
 
   @override
-  _i16.Future<void> abortSync() => (super.noSuchMethod(
+  _i17.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i17.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEventWithMetadata(
+  _i17.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4228,14 +4262,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i15.BaseResponse? response,
-    _i24.Uint8List? body,
+    _i16.BaseResponse? response,
+    _i25.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4267,7 +4301,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i16.Future<Map<String, Object?>> request(
+  _i17.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4288,13 +4322,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> postPusher(
+  _i17.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4304,57 +4338,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i17.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i17.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i17.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i16.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_34(
+        returnValue: _i17.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_35(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_34(
+        returnValueForMissingStub: _i17.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_35(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.TurnServerCredentials>);
+      ) as _i17.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4368,8 +4402,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4381,8 +4415,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4393,10 +4427,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4412,8 +4446,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4426,8 +4460,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4439,10 +4473,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i17.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4456,7 +4490,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4468,7 +4502,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4479,17 +4513,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.KeyBackupData>);
+      ) as _i17.Future<_i4.KeyBackupData>);
 
   @override
-  _i16.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i17.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i16.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_37(
+        returnValue: _i17.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_38(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4497,18 +4531,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_37(
+            _i17.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_38(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i17.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i16.Future<int> pingAppservice(
+  _i17.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4518,12 +4552,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
-  _i16.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i17.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4531,8 +4565,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_38(
+        returnValue: _i17.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_39(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4541,8 +4575,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_38(
+            _i17.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_39(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4550,15 +4584,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i16.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i17.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i16.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i17.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
+        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4566,17 +4600,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
+            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.MediaConfig>);
+      ) as _i17.Future<_i4.MediaConfig>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentAuthed(
+  _i17.Future<_i18.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4590,7 +4624,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4602,7 +4636,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4613,10 +4647,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentOverrideNameAuthed(
+  _i17.Future<_i18.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4632,7 +4666,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4645,7 +4679,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4657,10 +4691,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i17.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4670,7 +4704,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
+        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4679,7 +4713,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
+            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4687,10 +4721,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i16.Future<_i4.PreviewForUrl>);
+      ) as _i17.Future<_i4.PreviewForUrl>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentThumbnailAuthed(
+  _i17.Future<_i18.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4714,7 +4748,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4732,7 +4766,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4749,21 +4783,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<bool> registrationTokenValidity(String? token) =>
+  _i17.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i17.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -4773,8 +4807,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_39(
+        returnValue: _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_40(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4783,8 +4817,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_39(
+            _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_40(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4792,10 +4826,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i17.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i16.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i17.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -4813,8 +4847,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_40(
+        returnValue: _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_41(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4828,8 +4862,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_40(
+            _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_41(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4842,10 +4876,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i17.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i17.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -4869,8 +4903,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i16.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_41(
+        returnValue: _i17.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_42(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4888,8 +4922,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_41(
+            _i17.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_42(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4906,10 +4940,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i17.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -4937,8 +4971,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_42(
+                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4957,8 +4991,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_42(
+                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4976,10 +5010,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i17.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -5008,9 +5042,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i16.Future<
+            returnValue: _i17.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5029,9 +5063,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i16.Future<
+            returnValueForMissingStub: _i17.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5050,11 +5084,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i16
+          ) as _i17
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i16.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i17.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -5070,8 +5104,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i16.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_44(
+        returnValue: _i17.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_45(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5084,8 +5118,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_44(
+            _i17.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_45(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5097,10 +5131,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetThreadRootsResponse>);
+      ) as _i17.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i16.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i17.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5114,8 +5148,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i16.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_45(
+        returnValue: _i17.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_46(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5127,8 +5161,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_45(
+            _i17.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_46(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5139,33 +5173,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i17.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i17.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i16.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i17.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i16.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i17.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i16.Future<Uri?>.value(),
-        returnValueForMissingStub: _i16.Future<Uri?>.value(),
-      ) as _i16.Future<Uri?>);
+        returnValue: _i17.Future<Uri?>.value(),
+        returnValueForMissingStub: _i17.Future<Uri?>.value(),
+      ) as _i17.Future<Uri?>);
 
   @override
-  _i16.Future<void> add3PID(
+  _i17.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5179,12 +5213,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> bind3PID(
+  _i17.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5200,12 +5234,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i17.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5219,14 +5253,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5248,8 +5282,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5265,8 +5299,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5282,10 +5316,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5309,8 +5343,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5327,8 +5361,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5345,10 +5379,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i17.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5362,14 +5396,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i17.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5384,14 +5418,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5413,8 +5447,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5430,8 +5464,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5447,10 +5481,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5474,8 +5508,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5492,8 +5526,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5510,16 +5544,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i17.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
+            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5527,22 +5561,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
+            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.TokenOwnerInfo>);
+      ) as _i17.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i16.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i17.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
+        returnValue: _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5550,22 +5584,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
+            _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i16.Future<_i4.WhoIsInfo>);
+      ) as _i17.Future<_i4.WhoIsInfo>);
 
   @override
-  _i16.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i17.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
+        returnValue: _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5573,17 +5607,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
+            _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.Capabilities>);
+      ) as _i17.Future<_i4.Capabilities>);
 
   @override
-  _i16.Future<String> createRoom({
+  _i17.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -5616,7 +5650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5638,7 +5672,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5659,10 +5693,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> deleteDevices(
+  _i17.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5672,22 +5706,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.Device>?>.value(),
-      ) as _i16.Future<List<_i4.Device>?>);
+        returnValue: _i17.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.Device>?>.value(),
+      ) as _i17.Future<List<_i4.Device>?>);
 
   @override
-  _i16.Future<void> deleteDevice(
+  _i17.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5697,34 +5731,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i17.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i16.Future<_i4.Device>.value(_FakeDevice_50(
+        returnValue: _i17.Future<_i4.Device>.value(_FakeDevice_51(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.Device>.value(_FakeDevice_50(
+        returnValueForMissingStub: _i17.Future<_i4.Device>.value(_FakeDevice_51(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i16.Future<_i4.Device>);
+      ) as _i17.Future<_i4.Device>);
 
   @override
-  _i16.Future<void> updateDevice(
+  _i17.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5734,12 +5768,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i17.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -5754,24 +5788,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i17.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i16.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Visibility?>.value(),
-      ) as _i16.Future<_i4.Visibility?>);
+        returnValue: _i17.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Visibility?>.value(),
+      ) as _i17.Future<_i4.Visibility?>);
 
   @override
-  _i16.Future<void> setRoomVisibilityOnDirectory(
+  _i17.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -5781,30 +5815,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i17.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i17.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_51(
+        returnValue: _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_52(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -5812,18 +5846,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_51(
+            _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_52(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i17.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i16.Future<void> setRoomAlias(
+  _i17.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -5835,12 +5869,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetEventsResponse> getEvents({
+  _i17.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -5854,7 +5888,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
+            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
           this,
           Invocation.method(
             #getEvents,
@@ -5866,7 +5900,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
+            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
           this,
           Invocation.method(
             #getEvents,
@@ -5877,10 +5911,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetEventsResponse>);
+      ) as _i17.Future<_i4.GetEventsResponse>);
 
   @override
-  _i16.Future<_i4.PeekEventsResponse> peekEvents({
+  _i17.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -5895,8 +5929,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i16.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_53(
+        returnValue: _i17.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_54(
           this,
           Invocation.method(
             #peekEvents,
@@ -5908,8 +5942,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_53(
+        returnValueForMissingStub: _i17.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_54(
           this,
           Invocation.method(
             #peekEvents,
@@ -5921,16 +5955,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.PeekEventsResponse>);
+      ) as _i17.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i16.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i17.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneEvent,
@@ -5938,27 +5972,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i16.Future<_i4.MatrixEvent>);
+      ) as _i17.Future<_i4.MatrixEvent>);
 
   @override
-  _i16.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i17.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 
   @override
-  _i16.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i17.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -5970,8 +6004,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i16.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_55(
+        returnValue: _i17.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_56(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5982,8 +6016,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_55(
+            _i17.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_56(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5993,10 +6027,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.GetKeysChangesResponse>);
+      ) as _i17.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i16.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i17.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -6007,7 +6041,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
+            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
           this,
           Invocation.method(
             #claimKeys,
@@ -6016,7 +6050,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
+            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
           this,
           Invocation.method(
             #claimKeys,
@@ -6024,10 +6058,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i16.Future<_i4.ClaimKeysResponse>);
+      ) as _i17.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i16.Future<void> uploadCrossSigningKeys({
+  _i17.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -6044,12 +6078,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.QueryKeysResponse> queryKeys(
+  _i17.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -6060,7 +6094,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
+            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
           this,
           Invocation.method(
             #queryKeys,
@@ -6069,7 +6103,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
+            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
           this,
           Invocation.method(
             #queryKeys,
@@ -6077,10 +6111,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i16.Future<_i4.QueryKeysResponse>);
+      ) as _i17.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6088,14 +6122,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i16.Future<
+            returnValue: _i17.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i16.Future<
+            returnValueForMissingStub: _i17.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i16.Future<Map<String, int>> uploadKeys({
+  _i17.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6110,13 +6144,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i16.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i17.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i16.Future<Map<String, int>>);
+            _i17.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i17.Future<Map<String, int>>);
 
   @override
-  _i16.Future<String> knockRoom(
+  _i17.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6130,7 +6164,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6142,7 +6176,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6153,20 +6187,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i17.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i16.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i17.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i17.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i16.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i17.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6181,8 +6215,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i16.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_58(
+        returnValue: _i17.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_59(
           this,
           Invocation.method(
             #getNotifications,
@@ -6195,8 +6229,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_58(
+            _i17.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_59(
           this,
           Invocation.method(
             #getNotifications,
@@ -6208,35 +6242,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetNotificationsResponse>);
+      ) as _i17.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i16.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i17.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i16.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_59(
+        returnValue: _i17.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_60(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_59(
+        returnValueForMissingStub: _i17.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_60(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i16.Future<_i4.GetPresenceResponse>);
+      ) as _i17.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i16.Future<void> setPresence(
+  _i17.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6250,12 +6284,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, Object?>> deleteProfileField(
+  _i17.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6268,13 +6302,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getProfileField(
+  _i17.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6287,13 +6321,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<Map<String, Object?>> setProfileField(
+  _i17.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6308,13 +6342,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i17.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6329,8 +6363,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i16.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_60(
+        returnValue: _i17.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_61(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6343,8 +6377,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_60(
+            _i17.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_61(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6356,10 +6390,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i17.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i16.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i17.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6380,8 +6414,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i16.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_61(
+        returnValue: _i17.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_62(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6397,8 +6431,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_61(
+            _i17.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_62(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6413,25 +6447,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i17.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i16.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.Pusher>?>.value(),
-      ) as _i16.Future<List<_i4.Pusher>?>);
+        returnValue: _i17.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.Pusher>?>.value(),
+      ) as _i17.Future<List<_i4.Pusher>?>);
 
   @override
-  _i16.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i17.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
+        returnValue: _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
           this,
           Invocation.method(
             #getPushRules,
@@ -6439,24 +6473,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
+            _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.PushRuleSet>);
+      ) as _i17.Future<_i4.PushRuleSet>);
 
   @override
-  _i16.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i17.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_63(
+        returnValue: _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_64(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6464,18 +6498,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_63(
+            _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_64(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i17.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i16.Future<void> deletePushRule(
+  _i17.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6487,12 +6521,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.PushRule> getPushRule(
+  _i17.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6504,7 +6538,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<_i4.PushRule>.value(_FakePushRule_64(
+        returnValue: _i17.Future<_i4.PushRule>.value(_FakePushRule_65(
           this,
           Invocation.method(
             #getPushRule,
@@ -6515,7 +6549,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PushRule>.value(_FakePushRule_64(
+            _i17.Future<_i4.PushRule>.value(_FakePushRule_65(
           this,
           Invocation.method(
             #getPushRule,
@@ -6525,10 +6559,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.PushRule>);
+      ) as _i17.Future<_i4.PushRule>);
 
   @override
-  _i16.Future<void> setPushRule(
+  _i17.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -6552,12 +6586,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<Object?>> getPushRuleActions(
+  _i17.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6569,13 +6603,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i17.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i16.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i16.Future<List<Object?>>);
+            _i17.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i17.Future<List<Object?>>);
 
   @override
-  _i16.Future<void> setPushRuleActions(
+  _i17.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -6589,12 +6623,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<bool> isPushRuleEnabled(
+  _i17.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6606,12 +6640,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> setPushRuleEnabled(
+  _i17.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -6625,19 +6659,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i17.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
+            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
           this,
           Invocation.method(
             #refresh,
@@ -6645,28 +6679,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
+            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i16.Future<_i4.RefreshResponse>);
+      ) as _i17.Future<_i4.RefreshResponse>);
 
   @override
-  _i16.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i17.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i16.Future<bool?>.value(),
-        returnValueForMissingStub: _i16.Future<bool?>.value(),
-      ) as _i16.Future<bool?>);
+        returnValue: _i17.Future<bool?>.value(),
+        returnValueForMissingStub: _i17.Future<bool?>.value(),
+      ) as _i17.Future<bool?>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6688,8 +6722,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6705,8 +6739,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6722,10 +6756,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6749,8 +6783,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6767,8 +6801,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6785,17 +6819,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -6803,23 +6837,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i17.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
+        returnValue: _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -6827,17 +6861,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
+            _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeys>);
+      ) as _i17.Future<_i4.RoomKeys>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -6849,8 +6883,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6861,8 +6895,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6872,10 +6906,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6887,8 +6921,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6899,8 +6933,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6910,10 +6944,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6925,7 +6959,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
+        returnValue: _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6936,7 +6970,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
+            _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6946,10 +6980,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeyBackup>);
+      ) as _i17.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -6963,8 +6997,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6976,8 +7010,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6988,10 +7022,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7005,8 +7039,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7018,8 +7052,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7030,10 +7064,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i17.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7047,7 +7081,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7059,7 +7093,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7070,10 +7104,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.KeyBackupData>);
+      ) as _i17.Future<_i4.KeyBackupData>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7089,8 +7123,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7103,8 +7137,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7116,18 +7150,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_68(
+                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_69(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7135,18 +7169,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_68(
+                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_69(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i16.Future<String> postRoomKeysVersion(
+  _i17.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7158,7 +7192,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7169,7 +7203,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7179,29 +7213,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i17.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i17.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_69(
+        returnValue: _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_70(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7209,18 +7243,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_69(
+            _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_70(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i17.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i17.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7235,24 +7269,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i17.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 
   @override
-  _i16.Future<void> ban(
+  _i17.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7266,12 +7300,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.EventContext> getEventContext(
+  _i17.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7289,7 +7323,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<_i4.EventContext>.value(_FakeEventContext_70(
+        returnValue: _i17.Future<_i4.EventContext>.value(_FakeEventContext_71(
           this,
           Invocation.method(
             #getEventContext,
@@ -7304,7 +7338,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.EventContext>.value(_FakeEventContext_70(
+            _i17.Future<_i4.EventContext>.value(_FakeEventContext_71(
           this,
           Invocation.method(
             #getEventContext,
@@ -7318,10 +7352,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.EventContext>);
+      ) as _i17.Future<_i4.EventContext>);
 
   @override
-  _i16.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i17.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7333,7 +7367,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7344,7 +7378,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7354,20 +7388,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.MatrixEvent>);
+      ) as _i17.Future<_i4.MatrixEvent>);
 
   @override
-  _i16.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> inviteBy3PID(
+  _i17.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7379,12 +7413,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> inviteUser(
+  _i17.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7398,12 +7432,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> joinRoomById(
+  _i17.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7417,7 +7451,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7429,7 +7463,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7440,23 +7474,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i17.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i17.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i16.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i16.Future<Map<String, _i4.RoomMember>?>);
+            _i17.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i17.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i16.Future<void> kick(
+  _i17.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7470,12 +7504,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leaveRoom(
+  _i17.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7485,12 +7519,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i17.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -7506,12 +7540,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i16.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i16.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i17.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i17.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i16.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i17.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -7533,8 +7567,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_71(
+        returnValue: _i17.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_72(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7550,8 +7584,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_71(
+        returnValueForMissingStub: _i17.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_72(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7567,10 +7601,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomEventsResponse>);
+      ) as _i17.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i16.Future<void> setReadMarker(
+  _i17.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7586,12 +7620,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> postReceipt(
+  _i17.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -7607,12 +7641,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEvent(
+  _i17.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7628,12 +7662,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> reportRoom(
+  _i17.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7645,12 +7679,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> reportEvent(
+  _i17.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7668,12 +7702,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> sendMessage(
+  _i17.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7689,7 +7723,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7702,7 +7736,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7714,23 +7748,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i17.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i16.Future<List<_i4.MatrixEvent>>);
+            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i17.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i17.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -7747,13 +7781,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<String> setRoomStateWithKey(
+  _i17.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -7769,7 +7803,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7782,7 +7816,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7794,10 +7828,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> unban(
+  _i17.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7811,12 +7845,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> upgradeRoom(
+  _i17.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -7830,7 +7864,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7842,7 +7876,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7853,10 +7887,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.SearchResults> search(
+  _i17.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -7866,7 +7900,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
+        returnValue: _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
           this,
           Invocation.method(
             #search,
@@ -7875,7 +7909,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
+            _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
           this,
           Invocation.method(
             #search,
@@ -7883,10 +7917,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i16.Future<_i4.SearchResults>);
+      ) as _i17.Future<_i4.SearchResults>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> sync({
+  _i17.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -7907,7 +7941,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.method(
             #sync,
@@ -7923,7 +7957,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.method(
             #sync,
@@ -7938,22 +7972,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i17.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i16.Future<List<_i4.Location>>);
+            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i17.Future<List<_i4.Location>>);
 
   @override
-  _i16.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i17.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7963,21 +7997,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i16.Future<List<_i4.Location>>);
+            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i17.Future<List<_i4.Location>>);
 
   @override
-  _i16.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i17.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_73(
+        returnValue: _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_74(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -7985,45 +8019,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_73(
+            _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_74(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i16.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i17.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i16.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i17.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8034,13 +8068,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getAccountData(
+  _i17.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -8053,13 +8087,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> setAccountData(
+  _i17.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8073,12 +8107,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> defineFilter(
+  _i17.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -8090,7 +8124,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8101,7 +8135,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8111,10 +8145,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.Filter> getFilter(
+  _i17.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8126,7 +8160,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i16.Future<_i4.Filter>.value(_FakeFilter_13(
+        returnValue: _i17.Future<_i4.Filter>.value(_FakeFilter_14(
           this,
           Invocation.method(
             #getFilter,
@@ -8136,7 +8170,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.Filter>.value(_FakeFilter_13(
+        returnValueForMissingStub: _i17.Future<_i4.Filter>.value(_FakeFilter_14(
           this,
           Invocation.method(
             #getFilter,
@@ -8146,10 +8180,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.Filter>);
+      ) as _i17.Future<_i4.Filter>);
 
   @override
-  _i16.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i17.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8162,7 +8196,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
+            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8173,7 +8207,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
+            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8183,10 +8217,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.OpenIdCredentials>);
+      ) as _i17.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i16.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i17.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8201,13 +8235,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> setAccountDataPerRoom(
+  _i17.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8223,12 +8257,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i17.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8240,12 +8274,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i16.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i16.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i16.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i17.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i17.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i17.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i16.Future<void> deleteRoomTag(
+  _i17.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8259,12 +8293,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setRoomTag(
+  _i17.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8280,12 +8314,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i17.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8295,8 +8329,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i16.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_75(
+        returnValue: _i17.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_76(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8305,8 +8339,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_75(
+            _i17.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_76(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8314,10 +8348,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i16.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i17.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> reportUser(
+  _i17.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8330,40 +8364,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i17.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i16.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_76(
+        returnValue: _i17.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_77(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_76(
+        returnValueForMissingStub: _i17.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_77(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.CreateContentResponse>);
+      ) as _i17.Future<_i4.CreateContentResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> uploadContentToMXC(
+  _i17.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i24.Uint8List? body, {
+    _i25.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8381,10 +8415,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Room].
@@ -8394,11 +8428,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8428,11 +8462,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -8462,11 +8496,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i16.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i17.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i16.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i16.Completer<dynamic>>[],
-      ) as List<_i16.Completer<dynamic>>);
+        returnValue: <_i17.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i17.Completer<dynamic>>[],
+      ) as List<_i17.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -8485,51 +8519,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i14.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i15.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_18<String>(
+        returnValue: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i14.CachedStreamController<String> get onSessionKeyReceived =>
+  _i15.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_18<String>(
+        returnValue: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8545,11 +8579,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8558,11 +8592,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8605,11 +8639,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8618,11 +8652,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_19(
+        returnValue: _FakeDateTime_20(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_19(
+        returnValueForMissingStub: _FakeDateTime_20(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -8652,11 +8686,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8677,18 +8711,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i16.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i17.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -8875,18 +8909,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i25.SpaceParent>[],
-        returnValueForMissingStub: <_i25.SpaceParent>[],
-      ) as List<_i25.SpaceParent>);
+        returnValue: <_i26.SpaceParent>[],
+        returnValueForMissingStub: <_i26.SpaceParent>[],
+      ) as List<_i26.SpaceParent>);
 
   @override
-  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i25.SpaceChild>[],
-        returnValueForMissingStub: <_i25.SpaceChild>[],
-      ) as List<_i25.SpaceChild>);
+        returnValue: <_i26.SpaceChild>[],
+        returnValueForMissingStub: <_i26.SpaceChild>[],
+      ) as List<_i26.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -8999,14 +9033,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i16.Future<void> postLoad() => (super.noSuchMethod(
+  _i17.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -9034,15 +9068,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i16.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i17.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i16.Future<List<_i4.User>>);
+            _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i17.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -9053,14 +9087,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9070,18 +9104,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i16.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i17.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Event?> refreshLastEvent(
+  _i17.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9089,9 +9123,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -9103,12 +9137,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i16.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i17.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9116,22 +9150,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i17.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9139,17 +9173,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> addTag(
+  _i17.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -9159,27 +9193,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i17.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i17.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -9187,53 +9221,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i17.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i17.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+  _i17.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
         Invocation.method(
           #setLowPriority,
           [lowPriority],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i17.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9241,14 +9275,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -9260,7 +9294,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i16.Future<String?> sendTextEvent(
+  _i17.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -9292,12 +9326,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendReaction(
+  _i17.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -9311,12 +9345,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendLocation(
+  _i17.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -9330,12 +9364,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendFileEvent(
+  _i17.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -9363,25 +9397,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i17.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i16.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i17.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i16.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i17.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i16.Future<_i4.EncryptionHealthState>);
+      ) as _i17.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i16.Future<String?> sendEvent(
+  _i17.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -9405,73 +9439,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i17.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leave() => (super.noSuchMethod(
+  _i17.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> forget() => (super.noSuchMethod(
+  _i17.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> setPower(
+  _i17.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -9483,7 +9517,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9494,7 +9528,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9504,10 +9538,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> invite(
+  _i17.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -9517,12 +9551,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<int> requestHistory({
+  _i17.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -9539,32 +9573,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
-  _i16.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i17.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setReadMarker(
+  _i17.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -9578,23 +9612,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i26.TimelineChunk?> getEventContext(String? eventId) =>
+  _i17.Future<_i27.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i16.Future<_i26.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i16.Future<_i26.TimelineChunk?>.value(),
-      ) as _i16.Future<_i26.TimelineChunk?>);
+        returnValue: _i17.Future<_i27.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i17.Future<_i27.TimelineChunk?>.value(),
+      ) as _i17.Future<_i27.TimelineChunk?>);
 
   @override
-  _i16.Future<void> postReceipt(
+  _i17.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -9604,12 +9638,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Timeline> getTimeline({
+  _i17.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -9632,7 +9666,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i16.Future<_i4.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i17.Future<_i4.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9649,7 +9683,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Timeline>.value(_FakeTimeline_79(
+            _i17.Future<_i4.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9665,7 +9699,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Timeline>);
+      ) as _i17.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -9684,7 +9718,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i16.Future<List<_i4.User>> requestParticipants([
+  _i17.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -9702,10 +9736,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i16.Future<List<_i4.User>>);
+            _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i17.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -9713,14 +9747,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9736,14 +9770,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9753,7 +9787,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i16.Future<_i4.User?> requestUser(
+  _i17.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -9769,19 +9803,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i16.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.User?>.value(),
-      ) as _i16.Future<_i4.User?>);
+        returnValue: _i17.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.User?>.value(),
+      ) as _i17.Future<_i4.User?>);
 
   @override
-  _i16.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i17.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -9794,12 +9828,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i16.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i17.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9807,14 +9841,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -9837,14 +9871,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i16.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i17.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -9883,18 +9917,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i16.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i17.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEvent(
+  _i17.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -9908,12 +9942,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> setTyping(
+  _i17.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -9923,12 +9957,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setJoinRules(
+  _i17.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -9942,59 +9976,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i17.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setHistoryVisibility(
+  _i17.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i17.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i17.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i16.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i17.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i16.Future<List<_i4.DeviceKeys>>);
+            _i17.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i17.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i16.Future<void> requestSessionKey(
+  _i17.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -10006,12 +10040,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setSpaceChild(
+  _i17.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -10027,44 +10061,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i17.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i16.Future<Uri>.value(_FakeUri_32(
+        returnValue: _i17.Future<Uri>.value(_FakeUri_33(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_32(
+        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_33(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i16.Future<Uri>);
+      ) as _i17.Future<Uri>);
 
   @override
-  _i16.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<
+  _i17.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -10091,21 +10125,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i16.Future<
+        returnValue: _i17.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i16.Future<
+        returnValueForMissingStub: _i17.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i16.Future<
+      ) as _i17.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -10117,13 +10151,13 @@ class MockRoom extends _i1.Mock implements _i4.Room {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockFlutterLocalNotificationsPlugin extends _i1.Mock
-    implements _i27.FlutterLocalNotificationsPlugin {
+    implements _i28.FlutterLocalNotificationsPlugin {
   @override
-  _i16.Future<bool?> initialize({
-    required _i28.InitializationSettings? settings,
-    _i29.DidReceiveNotificationResponseCallback?
+  _i17.Future<bool?> initialize({
+    required _i29.InitializationSettings? settings,
+    _i30.DidReceiveNotificationResponseCallback?
         onDidReceiveNotificationResponse,
-    _i29.DidReceiveBackgroundNotificationResponseCallback?
+    _i30.DidReceiveBackgroundNotificationResponseCallback?
         onDidReceiveBackgroundNotificationResponse,
   }) =>
       (super.noSuchMethod(
@@ -10137,29 +10171,29 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
                 onDidReceiveBackgroundNotificationResponse,
           },
         ),
-        returnValue: _i16.Future<bool?>.value(),
-        returnValueForMissingStub: _i16.Future<bool?>.value(),
-      ) as _i16.Future<bool?>);
+        returnValue: _i17.Future<bool?>.value(),
+        returnValueForMissingStub: _i17.Future<bool?>.value(),
+      ) as _i17.Future<bool?>);
 
   @override
-  _i16.Future<_i29.NotificationAppLaunchDetails?>
+  _i17.Future<_i30.NotificationAppLaunchDetails?>
       getNotificationAppLaunchDetails() => (super.noSuchMethod(
             Invocation.method(
               #getNotificationAppLaunchDetails,
               [],
             ),
             returnValue:
-                _i16.Future<_i29.NotificationAppLaunchDetails?>.value(),
+                _i17.Future<_i30.NotificationAppLaunchDetails?>.value(),
             returnValueForMissingStub:
-                _i16.Future<_i29.NotificationAppLaunchDetails?>.value(),
-          ) as _i16.Future<_i29.NotificationAppLaunchDetails?>);
+                _i17.Future<_i30.NotificationAppLaunchDetails?>.value(),
+          ) as _i17.Future<_i30.NotificationAppLaunchDetails?>);
 
   @override
-  _i16.Future<void> show({
+  _i17.Future<void> show({
     required int? id,
     String? title,
     String? body,
-    _i30.NotificationDetails? notificationDetails,
+    _i31.NotificationDetails? notificationDetails,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -10174,12 +10208,12 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #payload: payload,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> cancel({
+  _i17.Future<void> cancel({
     required int? id,
     String? tag,
   }) =>
@@ -10192,40 +10226,40 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #tag: tag,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> cancelAll() => (super.noSuchMethod(
+  _i17.Future<void> cancelAll() => (super.noSuchMethod(
         Invocation.method(
           #cancelAll,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> cancelAllPendingNotifications() => (super.noSuchMethod(
+  _i17.Future<void> cancelAllPendingNotifications() => (super.noSuchMethod(
         Invocation.method(
           #cancelAllPendingNotifications,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> zonedSchedule({
+  _i17.Future<void> zonedSchedule({
     required int? id,
-    required _i31.TZDateTime? scheduledDate,
-    required _i30.NotificationDetails? notificationDetails,
-    required _i32.AndroidScheduleMode? androidScheduleMode,
+    required _i32.TZDateTime? scheduledDate,
+    required _i31.NotificationDetails? notificationDetails,
+    required _i33.AndroidScheduleMode? androidScheduleMode,
     String? title,
     String? body,
     String? payload,
-    _i33.DateTimeComponents? matchDateTimeComponents,
+    _i34.DateTimeComponents? matchDateTimeComponents,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -10242,16 +10276,16 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #matchDateTimeComponents: matchDateTimeComponents,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> periodicallyShow({
+  _i17.Future<void> periodicallyShow({
     required int? id,
-    required _i29.RepeatInterval? repeatInterval,
-    required _i30.NotificationDetails? notificationDetails,
-    required _i32.AndroidScheduleMode? androidScheduleMode,
+    required _i30.RepeatInterval? repeatInterval,
+    required _i31.NotificationDetails? notificationDetails,
+    required _i33.AndroidScheduleMode? androidScheduleMode,
     String? title,
     String? body,
     String? payload,
@@ -10270,19 +10304,19 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #payload: payload,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> periodicallyShowWithDuration({
+  _i17.Future<void> periodicallyShowWithDuration({
     required int? id,
     required Duration? repeatDurationInterval,
-    required _i30.NotificationDetails? notificationDetails,
+    required _i31.NotificationDetails? notificationDetails,
     String? title,
     String? body,
-    _i32.AndroidScheduleMode? androidScheduleMode =
-        _i32.AndroidScheduleMode.exact,
+    _i33.AndroidScheduleMode? androidScheduleMode =
+        _i33.AndroidScheduleMode.exact,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -10299,36 +10333,36 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #payload: payload,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i29.PendingNotificationRequest>>
+  _i17.Future<List<_i30.PendingNotificationRequest>>
       pendingNotificationRequests() => (super.noSuchMethod(
             Invocation.method(
               #pendingNotificationRequests,
               [],
             ),
             returnValue:
-                _i16.Future<List<_i29.PendingNotificationRequest>>.value(
-                    <_i29.PendingNotificationRequest>[]),
+                _i17.Future<List<_i30.PendingNotificationRequest>>.value(
+                    <_i30.PendingNotificationRequest>[]),
             returnValueForMissingStub:
-                _i16.Future<List<_i29.PendingNotificationRequest>>.value(
-                    <_i29.PendingNotificationRequest>[]),
-          ) as _i16.Future<List<_i29.PendingNotificationRequest>>);
+                _i17.Future<List<_i30.PendingNotificationRequest>>.value(
+                    <_i30.PendingNotificationRequest>[]),
+          ) as _i17.Future<List<_i30.PendingNotificationRequest>>);
 
   @override
-  _i16.Future<List<_i29.ActiveNotification>> getActiveNotifications() =>
+  _i17.Future<List<_i30.ActiveNotification>> getActiveNotifications() =>
       (super.noSuchMethod(
         Invocation.method(
           #getActiveNotifications,
           [],
         ),
-        returnValue: _i16.Future<List<_i29.ActiveNotification>>.value(
-            <_i29.ActiveNotification>[]),
+        returnValue: _i17.Future<List<_i30.ActiveNotification>>.value(
+            <_i30.ActiveNotification>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i29.ActiveNotification>>.value(
-                <_i29.ActiveNotification>[]),
-      ) as _i16.Future<List<_i29.ActiveNotification>>);
+            _i17.Future<List<_i30.ActiveNotification>>.value(
+                <_i30.ActiveNotification>[]),
+      ) as _i17.Future<List<_i30.ActiveNotification>>);
 }

--- a/test/widgets/add_existing_rooms_dialog_test.mocks.dart
+++ b/test/widgets/add_existing_rooms_dialog_test.mocks.dart
@@ -3,15 +3,15 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i16;
-import 'dart:typed_data' as _i26;
-import 'dart:ui' as _i20;
+import 'dart:async' as _i17;
+import 'dart:typed_data' as _i27;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
-import 'package:http/http.dart' as _i15;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i13;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
+import 'package:http/http.dart' as _i16;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -27,14 +27,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i25;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i13;
+import 'package:matrix/encryption.dart' as _i26;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i17;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i14;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i18;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i15;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -168,9 +169,9 @@ class _FakeOutboxService_10 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_11 extends _i1.SmartFake
-    implements _i13.StickerPackService {
-  _FakeStickerPackService_11(
+class _FakeAvatarResolver_11 extends _i1.SmartFake
+    implements _i13.AvatarResolver {
+  _FakeAvatarResolver_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -179,8 +180,9 @@ class _FakeStickerPackService_11 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_12 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_12(
+class _FakeStickerPackService_12 extends _i1.SmartFake
+    implements _i14.StickerPackService {
+  _FakeStickerPackService_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -189,9 +191,8 @@ class _FakeRoomSummary_12 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_13<T> extends _i1.SmartFake
-    implements _i14.CachedStreamController<T> {
-  _FakeCachedStreamController_13(
+class _FakeRoomSummary_13 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -200,8 +201,9 @@ class _FakeCachedStreamController_13<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_14 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_14(
+class _FakeCachedStreamController_14<T> extends _i1.SmartFake
+    implements _i15.CachedStreamController<T> {
+  _FakeCachedStreamController_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -210,9 +212,19 @@ class _FakeDateTime_14 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_15 extends _i1.SmartFake
+class _FakeDateTime_15 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_15(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_16 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_15(
+  _FakeLatestReceiptState_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -221,8 +233,8 @@ class _FakeLatestReceiptState_15 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_16 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_16(
+class _FakeSyncUpdate_17 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -231,8 +243,8 @@ class _FakeSyncUpdate_16 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_17 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_17(
+class _FakeTimeline_18 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -241,8 +253,8 @@ class _FakeTimeline_17 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_18 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_18(
+class _FakeUser_19 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -251,8 +263,8 @@ class _FakeUser_18 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_19 extends _i1.SmartFake implements Uri {
-  _FakeUri_19(
+class _FakeUri_20 extends _i1.SmartFake implements Uri {
+  _FakeUri_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -261,8 +273,8 @@ class _FakeUri_19 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_20 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_20(
+class _FakeDatabaseApi_21 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -271,8 +283,8 @@ class _FakeDatabaseApi_20 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_21 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_21(
+class _FakeFilter_22 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -281,9 +293,9 @@ class _FakeFilter_21 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_22 extends _i1.SmartFake
+class _FakeNativeImplementations_23 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_22(
+  _FakeNativeImplementations_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -292,8 +304,8 @@ class _FakeNativeImplementations_22 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_23 extends _i1.SmartFake implements Duration {
-  _FakeDuration_23(
+class _FakeDuration_24 extends _i1.SmartFake implements Duration {
+  _FakeDuration_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -302,9 +314,9 @@ class _FakeDuration_23 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_24 extends _i1.SmartFake
+class _FakePushruleEvaluator_25 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_24(
+  _FakePushruleEvaluator_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -313,8 +325,8 @@ class _FakePushruleEvaluator_24 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_25 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_25(
+class _FakeProfile_26 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -323,8 +335,8 @@ class _FakeProfile_25 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_26 extends _i1.SmartFake implements _i15.Client {
-  _FakeClient_26(
+class _FakeClient_27 extends _i1.SmartFake implements _i16.Client {
+  _FakeClient_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -333,9 +345,9 @@ class _FakeClient_26 extends _i1.SmartFake implements _i15.Client {
         );
 }
 
-class _FakeDiscoveryInformation_27 extends _i1.SmartFake
+class _FakeDiscoveryInformation_28 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_27(
+  _FakeDiscoveryInformation_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -344,9 +356,9 @@ class _FakeDiscoveryInformation_27 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_28 extends _i1.SmartFake
+class _FakeGetVersionsResponse_29 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_28(
+  _FakeGetVersionsResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -355,9 +367,9 @@ class _FakeGetVersionsResponse_28 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_29 extends _i1.SmartFake
+class _FakeRegisterResponse_30 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_29(
+  _FakeRegisterResponse_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -366,8 +378,8 @@ class _FakeRegisterResponse_29 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_30 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_30(
+class _FakeLoginResponse_31 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -376,9 +388,9 @@ class _FakeLoginResponse_30 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_31 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_32 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_31(
+  _FakeGetAuthMetadataResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -387,8 +399,8 @@ class _FakeGetAuthMetadataResponse_31 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_32<T1> extends _i1.SmartFake implements _i16.Future<T1> {
-  _FakeFuture_32(
+class _FakeFuture_33<T1> extends _i1.SmartFake implements _i17.Future<T1> {
+  _FakeFuture_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -397,9 +409,9 @@ class _FakeFuture_32<T1> extends _i1.SmartFake implements _i16.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_33 extends _i1.SmartFake
+class _FakeCachedProfileInformation_34 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_33(
+  _FakeCachedProfileInformation_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -408,8 +420,8 @@ class _FakeCachedProfileInformation_33 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_34 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_34(
+class _FakeMediaConfig_35 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -418,8 +430,8 @@ class _FakeMediaConfig_34 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_35 extends _i1.SmartFake implements _i17.FileResponse {
-  _FakeFileResponse_35(
+class _FakeFileResponse_36 extends _i1.SmartFake implements _i18.FileResponse {
+  _FakeFileResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -428,8 +440,8 @@ class _FakeFileResponse_35 extends _i1.SmartFake implements _i17.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_36 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_36(
+class _FakePreviewForUrl_37 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -438,9 +450,9 @@ class _FakePreviewForUrl_36 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_37 extends _i1.SmartFake
+class _FakeCachedPresence_38 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_37(
+  _FakeCachedPresence_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -449,9 +461,9 @@ class _FakeCachedPresence_37 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_38 extends _i1.SmartFake
+class _FakeTurnServerCredentials_39 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_38(
+  _FakeTurnServerCredentials_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -460,9 +472,9 @@ class _FakeTurnServerCredentials_38 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_39 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_40 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_39(
+  _FakeRoomKeysUpdateResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -471,8 +483,8 @@ class _FakeRoomKeysUpdateResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_40 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_40(
+class _FakeKeyBackupData_41 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -481,9 +493,9 @@ class _FakeKeyBackupData_40 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_41 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_42 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_41(
+  _FakeGetWellknownSupportResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -492,9 +504,9 @@ class _FakeGetWellknownSupportResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_42 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_43 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_42(
+  _FakeGenerateLoginTokenResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -503,9 +515,9 @@ class _FakeGenerateLoginTokenResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_43 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_44 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_43(
+  _FakeGetRoomSummaryResponse$3_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -514,9 +526,9 @@ class _FakeGetRoomSummaryResponse$3_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_44 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_45 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_44(
+  _FakeGetSpaceHierarchyResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -525,9 +537,9 @@ class _FakeGetSpaceHierarchyResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_45 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_46 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_45(
+  _FakeGetRelatingEventsResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -536,9 +548,9 @@ class _FakeGetRelatingEventsResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_46 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_47 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_46(
+  _FakeGetRelatingEventsWithRelTypeResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -547,9 +559,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -558,9 +570,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_48 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_49 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_48(
+  _FakeGetThreadRootsResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -569,9 +581,9 @@ class _FakeGetThreadRootsResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_49 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_50 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_49(
+  _FakeGetEventByTimestampResponse_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -580,9 +592,9 @@ class _FakeGetEventByTimestampResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_50 extends _i1.SmartFake
+class _FakeRequestTokenResponse_51 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_50(
+  _FakeRequestTokenResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -591,9 +603,9 @@ class _FakeRequestTokenResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_51 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_52 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_51(
+  _FakeTokenOwnerInfo_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -602,8 +614,8 @@ class _FakeTokenOwnerInfo_51 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_52 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_52(
+class _FakeWhoIsInfo_53 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -612,8 +624,8 @@ class _FakeWhoIsInfo_52 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_53 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_53(
+class _FakeCapabilities_54 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -622,8 +634,8 @@ class _FakeCapabilities_53 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_54 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_54(
+class _FakeDevice_55 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -632,9 +644,9 @@ class _FakeDevice_54 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_55 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_56 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_55(
+  _FakeGetRoomIdByAliasResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -643,9 +655,9 @@ class _FakeGetRoomIdByAliasResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_56 extends _i1.SmartFake
+class _FakeGetEventsResponse_57 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_56(
+  _FakeGetEventsResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -654,9 +666,9 @@ class _FakeGetEventsResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_57 extends _i1.SmartFake
+class _FakePeekEventsResponse_58 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_57(
+  _FakePeekEventsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -665,8 +677,8 @@ class _FakePeekEventsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_58 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_58(
+class _FakeMatrixEvent_59 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -675,9 +687,9 @@ class _FakeMatrixEvent_58 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_59 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_60 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_59(
+  _FakeGetKeysChangesResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -686,9 +698,9 @@ class _FakeGetKeysChangesResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_60 extends _i1.SmartFake
+class _FakeClaimKeysResponse_61 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_60(
+  _FakeClaimKeysResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -697,9 +709,9 @@ class _FakeClaimKeysResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_61 extends _i1.SmartFake
+class _FakeQueryKeysResponse_62 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_61(
+  _FakeQueryKeysResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -708,9 +720,9 @@ class _FakeQueryKeysResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_62 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_63 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_62(
+  _FakeGetNotificationsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -719,9 +731,9 @@ class _FakeGetNotificationsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_63 extends _i1.SmartFake
+class _FakeGetPresenceResponse_64 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_63(
+  _FakeGetPresenceResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -730,9 +742,9 @@ class _FakeGetPresenceResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_64 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_65 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_64(
+  _FakeGetPublicRoomsResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -741,9 +753,9 @@ class _FakeGetPublicRoomsResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_65 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_66 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_65(
+  _FakeQueryPublicRoomsResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -752,8 +764,8 @@ class _FakeQueryPublicRoomsResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_66 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_66(
+class _FakePushRuleSet_67 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -762,9 +774,9 @@ class _FakePushRuleSet_66 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_67 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_68 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_67(
+  _FakeGetPushRulesGlobalResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -773,8 +785,8 @@ class _FakeGetPushRulesGlobalResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_68 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_68(
+class _FakePushRule_69 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -783,9 +795,9 @@ class _FakePushRule_68 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_69 extends _i1.SmartFake
+class _FakeRefreshResponse_70 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_69(
+  _FakeRefreshResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -794,8 +806,8 @@ class _FakeRefreshResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_70 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_70(
+class _FakeRoomKeys_71 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -804,8 +816,8 @@ class _FakeRoomKeys_70 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_71 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_71(
+class _FakeRoomKeyBackup_72 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -814,9 +826,9 @@ class _FakeRoomKeyBackup_71 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_72 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_73 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_72(
+  _FakeGetRoomKeysVersionCurrentResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -825,9 +837,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_73 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_74 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_73(
+  _FakeGetRoomKeysVersionResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -836,8 +848,8 @@ class _FakeGetRoomKeysVersionResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_74 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_74(
+class _FakeEventContext_75 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -846,9 +858,9 @@ class _FakeEventContext_74 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_75 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_76 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_75(
+  _FakeGetRoomEventsResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -857,8 +869,8 @@ class _FakeGetRoomEventsResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_76 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_76(
+class _FakeSearchResults_77 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,9 +879,9 @@ class _FakeSearchResults_76 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_77 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_78 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_77(
+  _FakeGetProtocolMetadataResponse$2_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -878,9 +890,9 @@ class _FakeGetProtocolMetadataResponse$2_77 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_78 extends _i1.SmartFake
+class _FakeOpenIdCredentials_79 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_78(
+  _FakeOpenIdCredentials_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -889,9 +901,9 @@ class _FakeOpenIdCredentials_78 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_79 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_80 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_79(
+  _FakeSearchUserDirectoryResponse_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -900,9 +912,9 @@ class _FakeSearchUserDirectoryResponse_79 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_80 extends _i1.SmartFake
+class _FakeCreateContentResponse_81 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_80(
+  _FakeCreateContentResponse_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -914,7 +926,7 @@ class _FakeCreateContentResponse_80 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -944,11 +956,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1086,17 +1098,30 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i12.OutboxService);
 
   @override
-  _i13.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i13.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i13.AvatarResolver);
+
+  @override
+  _i14.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_11(
+        returnValue: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_11(
+        returnValueForMissingStub: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i13.StickerPackService);
+      ) as _i14.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1205,7 +1230,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set stickerPacks(_i13.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i13.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i14.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -1221,14 +1255,14 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  _i16.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i17.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1258,7 +1292,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1268,18 +1302,18 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i17.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<bool> login({
+  _i17.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1296,12 +1330,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> completeSsoLogin({
+  _i17.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1314,12 +1348,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> completeRegistration(
+  _i17.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1329,32 +1363,32 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> logout() => (super.noSuchMethod(
+  _i17.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i17.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1363,7 +1397,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1372,17 +1406,17 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i17.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1393,7 +1427,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1430,26 +1464,26 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i17.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+  _i17.Future<bool> didPushRouteInformation(
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1479,7 +1513,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1488,7 +1522,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1497,16 +1531,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i17.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i16.Future<_i20.AppExitResponse>);
+            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i17.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1534,11 +1568,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1568,11 +1602,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_12(
+        returnValue: _FakeRoomSummary_13(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_12(
+        returnValueForMissingStub: _FakeRoomSummary_13(
           this,
           Invocation.getter(#summary),
         ),
@@ -1602,11 +1636,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i16.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i17.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i16.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i16.Completer<dynamic>>[],
-      ) as List<_i16.Completer<dynamic>>);
+        returnValue: <_i17.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i17.Completer<dynamic>>[],
+      ) as List<_i17.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1625,51 +1659,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i14.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i15.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i14.CachedStreamController<String> get onSessionKeyReceived =>
+  _i15.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1685,11 +1719,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1698,11 +1732,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1745,11 +1779,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1758,11 +1792,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_14(
+        returnValue: _FakeDateTime_15(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_14(
+        returnValueForMissingStub: _FakeDateTime_15(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1792,11 +1826,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_15(
+        returnValue: _FakeLatestReceiptState_16(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_15(
+        returnValueForMissingStub: _FakeLatestReceiptState_16(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1817,18 +1851,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i16.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i17.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -2015,18 +2049,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -2139,14 +2173,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i16.Future<void> postLoad() => (super.noSuchMethod(
+  _i17.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2174,15 +2208,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i16.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i17.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i16.Future<List<_i4.User>>);
+            _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i17.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2193,14 +2227,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2210,18 +2244,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i16.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i17.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Event?> refreshLastEvent(
+  _i17.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2229,9 +2263,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2243,12 +2277,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i16.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i17.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2256,22 +2290,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i17.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2279,17 +2313,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> addTag(
+  _i17.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2299,27 +2333,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i17.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i17.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2327,53 +2361,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i17.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i17.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+  _i17.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
         Invocation.method(
           #setLowPriority,
           [lowPriority],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i17.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2381,14 +2415,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2400,7 +2434,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i16.Future<String?> sendTextEvent(
+  _i17.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2432,12 +2466,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendReaction(
+  _i17.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2451,12 +2485,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendLocation(
+  _i17.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2470,12 +2504,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendFileEvent(
+  _i17.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2503,25 +2537,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i17.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i16.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i17.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i16.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i17.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i16.Future<_i4.EncryptionHealthState>);
+      ) as _i17.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i16.Future<String?> sendEvent(
+  _i17.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2545,73 +2579,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i17.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leave() => (super.noSuchMethod(
+  _i17.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> forget() => (super.noSuchMethod(
+  _i17.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> setPower(
+  _i17.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2623,7 +2657,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2634,7 +2668,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2644,10 +2678,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> invite(
+  _i17.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2657,12 +2691,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<int> requestHistory({
+  _i17.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2679,32 +2713,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
-  _i16.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i17.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setReadMarker(
+  _i17.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2718,23 +2752,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
+  _i17.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i16.Future<_i24.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i16.Future<_i24.TimelineChunk?>.value(),
-      ) as _i16.Future<_i24.TimelineChunk?>);
+        returnValue: _i17.Future<_i25.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i17.Future<_i25.TimelineChunk?>.value(),
+      ) as _i17.Future<_i25.TimelineChunk?>);
 
   @override
-  _i16.Future<void> postReceipt(
+  _i17.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2744,12 +2778,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Timeline> getTimeline({
+  _i17.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2772,7 +2806,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i16.Future<_i4.Timeline>.value(_FakeTimeline_17(
+        returnValue: _i17.Future<_i4.Timeline>.value(_FakeTimeline_18(
           this,
           Invocation.method(
             #getTimeline,
@@ -2789,7 +2823,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Timeline>.value(_FakeTimeline_17(
+            _i17.Future<_i4.Timeline>.value(_FakeTimeline_18(
           this,
           Invocation.method(
             #getTimeline,
@@ -2805,7 +2839,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Timeline>);
+      ) as _i17.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2824,7 +2858,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i16.Future<List<_i4.User>> requestParticipants([
+  _i17.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2842,10 +2876,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i16.Future<List<_i4.User>>);
+            _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i17.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2853,14 +2887,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_18(
+        returnValue: _FakeUser_19(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_18(
+        returnValueForMissingStub: _FakeUser_19(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2876,14 +2910,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_18(
+        returnValue: _FakeUser_19(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_18(
+        returnValueForMissingStub: _FakeUser_19(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2893,7 +2927,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i16.Future<_i4.User?> requestUser(
+  _i17.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2909,19 +2943,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i16.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.User?>.value(),
-      ) as _i16.Future<_i4.User?>);
+        returnValue: _i17.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.User?>.value(),
+      ) as _i17.Future<_i4.User?>);
 
   @override
-  _i16.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i17.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2934,12 +2968,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i16.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i17.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2947,14 +2981,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2977,14 +3011,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i16.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i17.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -3023,18 +3057,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i16.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i17.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEvent(
+  _i17.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -3048,12 +3082,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> setTyping(
+  _i17.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -3063,12 +3097,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setJoinRules(
+  _i17.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -3082,59 +3116,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i17.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setHistoryVisibility(
+  _i17.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i17.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i17.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i16.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i17.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i16.Future<List<_i4.DeviceKeys>>);
+            _i17.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i17.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i16.Future<void> requestSessionKey(
+  _i17.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3146,12 +3180,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setSpaceChild(
+  _i17.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3167,44 +3201,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i17.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValue: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i16.Future<Uri>);
+      ) as _i17.Future<Uri>);
 
   @override
-  _i16.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<
+  _i17.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3231,21 +3265,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i16.Future<
+        returnValue: _i17.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i16.Future<
+        returnValueForMissingStub: _i17.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i16.Future<
+      ) as _i17.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3260,23 +3294,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_20(
+        returnValue: _FakeDatabaseApi_21(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_20(
+        returnValueForMissingStub: _FakeDatabaseApi_21(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i25.KeyVerificationMethod> get verificationMethods =>
+  Set<_i26.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i25.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i25.KeyVerificationMethod>{},
-      ) as Set<_i25.KeyVerificationMethod>);
+        returnValue: <_i26.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i26.KeyVerificationMethod>{},
+      ) as Set<_i26.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3337,11 +3371,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_21(
+        returnValue: _FakeFilter_22(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_21(
+        returnValueForMissingStub: _FakeFilter_22(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3350,11 +3384,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_22(
+        returnValue: _FakeNativeImplementations_23(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_22(
+        returnValueForMissingStub: _FakeNativeImplementations_23(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3370,11 +3404,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_23(
+        returnValue: _FakeDuration_24(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_23(
+        returnValueForMissingStub: _FakeDuration_24(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3383,11 +3417,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_23(
+        returnValue: _FakeDuration_24(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_23(
+        returnValueForMissingStub: _FakeDuration_24(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3396,11 +3430,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3437,11 +3471,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3471,11 +3505,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3484,11 +3518,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3511,11 +3545,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_24(
+        returnValue: _FakePushruleEvaluator_25(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_24(
+        returnValueForMissingStub: _FakePushruleEvaluator_25(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3536,332 +3570,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i16.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i17.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i14.CachedStreamController<String> get onUserProfileUpdate =>
+  _i15.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i16.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i17.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i16.Future<List<_i4.Room>>);
+            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i17.Future<List<_i4.Room>>);
 
   @override
-  _i14.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i15.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.EventUpdate>(
+            _FakeCachedStreamController_14<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.EventUpdate>);
+      ) as _i15.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i15.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i15.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onNotification =>
+  _i15.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i15.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i15.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i14.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i15.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_13<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_13<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i14.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i15.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i14.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i15.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_13<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_14<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.LoginState>(
+            _FakeCachedStreamController_14<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i14.CachedStreamController<_i4.LoginState>);
+      ) as _i15.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i14.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i15.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_13<bool>(
+        returnValue: _FakeCachedStreamController_14<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i14.CachedStreamController<bool>);
+      ) as _i15.CachedStreamController<bool>);
 
   @override
-  _i14.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i15.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_13<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_14<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i14.CachedStreamController<_i4.SdkError>);
+      ) as _i15.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i14.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i15.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_13<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.SyncUpdate>(
+            _FakeCachedStreamController_14<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i14.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i15.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i15.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_13<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i14.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i15.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.Presence> get onPresence =>
+  _i15.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_13<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_14<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i14.CachedStreamController<_i4.Presence>);
+      ) as _i15.CachedStreamController<_i4.Presence>);
 
   @override
-  _i14.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i15.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_13<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_14<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.CachedPresence>(
+            _FakeCachedStreamController_14<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i14.CachedStreamController<_i4.CachedPresence>);
+      ) as _i15.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i14.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i15.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_13<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_14<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.BasicEvent>(
+            _FakeCachedStreamController_14<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i14.CachedStreamController<_i4.BasicEvent>);
+      ) as _i15.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i14.CachedStreamController<_i25.RoomKeyRequest> get onRoomKeyRequest =>
+  _i15.CachedStreamController<_i26.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_13<_i25.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_14<_i26.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i25.RoomKeyRequest>(
+            _FakeCachedStreamController_14<_i26.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i14.CachedStreamController<_i25.RoomKeyRequest>);
+      ) as _i15.CachedStreamController<_i26.RoomKeyRequest>);
 
   @override
-  _i14.CachedStreamController<_i25.KeyVerification>
+  _i15.CachedStreamController<_i26.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_13<_i25.KeyVerification>(
+            returnValue: _FakeCachedStreamController_14<_i26.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_13<_i25.KeyVerification>(
+                _FakeCachedStreamController_14<_i26.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i14.CachedStreamController<_i25.KeyVerification>);
+          ) as _i15.CachedStreamController<_i26.KeyVerification>);
 
   @override
-  _i14.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i15.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_13<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i14.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i15.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i15.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<String> get onCancelSendEvent =>
+  _i15.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i14.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i15.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_13<
+            returnValue: _FakeCachedStreamController_14<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_13<
+            returnValueForMissingStub: _FakeCachedStreamController_14<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i14.CachedStreamController<
+          ) as _i15.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3881,11 +3915,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_14(
+        returnValue: _FakeDateTime_15(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_14(
+        returnValueForMissingStub: _FakeDateTime_15(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3958,7 +3992,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i25.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i26.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -4013,7 +4047,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i16.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i17.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -4024,7 +4058,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i16.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i17.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -4135,7 +4169,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4144,7 +4178,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4153,7 +4187,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4180,20 +4214,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i15.Client get httpClient => (super.noSuchMethod(
+  _i16.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_26(
+        returnValue: _FakeClient_27(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_26(
+        returnValueForMissingStub: _FakeClient_27(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i15.Client);
+      ) as _i16.Client);
 
   @override
-  set httpClient(_i15.Client? value) => super.noSuchMethod(
+  set httpClient(_i16.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4220,7 +4254,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<void> refreshAccessToken(
+  _i17.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4228,9 +4262,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4248,14 +4282,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4292,33 +4326,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i16.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i17.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i16.Future<_i4.DiscoveryInformation>);
+      ) as _i17.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i16.Future<
+  _i17.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4340,7 +4374,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i16.Future<
+        returnValue: _i17.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4348,7 +4382,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_28(
+          _FakeGetVersionsResponse_29(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4363,7 +4397,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i16.Future<
+        returnValueForMissingStub: _i17.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4371,7 +4405,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_28(
+          _FakeGetVersionsResponse_29(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4386,7 +4420,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i16.Future<
+      ) as _i17.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4395,7 +4429,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i16.Future<_i4.DiscoveryInformation> getWellknown({
+  _i17.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4408,8 +4442,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getWellknown,
@@ -4420,8 +4454,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getWellknown,
@@ -4432,10 +4466,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.DiscoveryInformation>);
+      ) as _i17.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i16.Future<_i4.RegisterResponse> register({
+  _i17.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4463,7 +4497,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_29(
+            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_30(
           this,
           Invocation.method(
             #register,
@@ -4482,7 +4516,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_29(
+            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_30(
           this,
           Invocation.method(
             #register,
@@ -4500,10 +4534,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RegisterResponse>);
+      ) as _i17.Future<_i4.RegisterResponse>);
 
   @override
-  _i16.Future<_i4.LoginResponse> login(
+  _i17.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4533,7 +4567,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_30(
+        returnValue: _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_31(
           this,
           Invocation.method(
             #login,
@@ -4553,7 +4587,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_30(
+            _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_31(
           this,
           Invocation.method(
             #login,
@@ -4572,10 +4606,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.LoginResponse>);
+      ) as _i17.Future<_i4.LoginResponse>);
 
   @override
-  _i16.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i17.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4588,8 +4622,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_31(
+        returnValue: _i17.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_32(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4601,8 +4635,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_31(
+            _i17.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_32(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4613,74 +4647,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i17.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i16.Future<void> logout() => (super.noSuchMethod(
+  _i17.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> logoutAll() => (super.noSuchMethod(
+  _i17.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<T> uiaRequestBackground<T>(
-          _i16.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i17.Future<T> uiaRequestBackground<T>(
+          _i17.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i16.Future<T>.value(v),
+              (T v) => _i17.Future<T>.value(v),
             ) ??
-            _FakeFuture_32<T>(
+            _FakeFuture_33<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i16.Future<T>.value(v),
+              (T v) => _i17.Future<T>.value(v),
             ) ??
-            _FakeFuture_32<T>(
+            _FakeFuture_33<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i16.Future<T>);
+      ) as _i17.Future<T>);
 
   @override
-  _i16.Future<String> startDirectChat(
+  _i17.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4702,7 +4736,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4718,7 +4752,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4733,10 +4767,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<String> createGroupChat({
+  _i17.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4767,7 +4801,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4788,7 +4822,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4808,10 +4842,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i17.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4827,7 +4861,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4840,7 +4874,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4852,21 +4886,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i17.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<String> createSpace({
+  _i17.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4891,7 +4925,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4909,7 +4943,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4926,10 +4960,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i17.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4937,7 +4971,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4946,7 +4980,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4954,10 +4988,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i16.Future<_i4.Profile> fetchOwnProfile({
+  _i17.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4970,7 +5004,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4982,7 +5016,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4993,10 +5027,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i16.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i17.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -5010,8 +5044,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i16.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_33(
+        returnValue: _i17.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_34(
           this,
           Invocation.method(
             #getUserProfile,
@@ -5023,8 +5057,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_33(
+            _i17.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_34(
           this,
           Invocation.method(
             #getUserProfile,
@@ -5035,10 +5069,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.CachedProfileInformation>);
+      ) as _i17.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i16.Future<_i4.Profile> getProfileFromUserId(
+  _i17.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -5056,7 +5090,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5070,7 +5104,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5083,7 +5117,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -5105,31 +5139,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i16.Future<List<_i4.Room>>);
+            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i17.Future<List<_i4.Room>>);
 
   @override
-  _i16.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i17.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i16.Future<List<_i4.ArchivedRoom>>);
+            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i17.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i16.Future<_i4.GetVersionsResponse> getVersions({
+  _i17.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5142,8 +5176,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_28(
+        returnValue: _i17.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_29(
           this,
           Invocation.method(
             #getVersions,
@@ -5154,8 +5188,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_28(
+        returnValueForMissingStub: _i17.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_29(
           this,
           Invocation.method(
             #getVersions,
@@ -5166,20 +5200,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetVersionsResponse>);
+      ) as _i17.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i16.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i17.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.MediaConfig> getConfig({
+  _i17.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5192,7 +5226,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfig,
@@ -5204,7 +5238,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfig,
@@ -5215,10 +5249,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.MediaConfig>);
+      ) as _i17.Future<_i4.MediaConfig>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContent(
+  _i17.Future<_i18.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5238,7 +5272,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContent,
@@ -5254,7 +5288,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContent,
@@ -5269,10 +5303,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentOverrideName(
+  _i17.Future<_i18.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5294,7 +5328,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5311,7 +5345,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5327,10 +5361,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentThumbnail(
+  _i17.Future<_i18.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5358,7 +5392,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5378,7 +5412,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5397,10 +5431,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i17.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5410,7 +5444,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5419,7 +5453,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5427,11 +5461,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i16.Future<_i4.PreviewForUrl>);
+      ) as _i17.Future<_i4.PreviewForUrl>);
 
   @override
-  _i16.Future<Uri> uploadContent(
-    _i26.Uint8List? file, {
+  _i17.Future<Uri> uploadContent(
+    _i27.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5444,7 +5478,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValue: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #uploadContent,
@@ -5455,7 +5489,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #uploadContent,
@@ -5466,10 +5500,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<Uri>);
+      ) as _i17.Future<Uri>);
 
   @override
-  _i16.Future<void> setTyping(
+  _i17.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5485,42 +5519,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> exportDump() => (super.noSuchMethod(
+  _i17.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i17.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i17.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Event?> getEventByPushNotification(
+  _i17.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5536,12 +5570,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
-  _i16.Future<void> init({
+  _i17.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5576,9 +5610,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5590,40 +5624,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<void> clear() => (super.noSuchMethod(
+  _i17.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i17.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ensureNotSoftLoggedOut(
+  _i17.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> handleSync(
+  _i17.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5633,9 +5667,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5648,29 +5682,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i16.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i17.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i17.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDevice(
+  _i17.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5684,12 +5718,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDevicesOfUserIds(
+  _i17.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5705,12 +5739,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDeviceEncrypted(
+  _i17.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5730,12 +5764,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDeviceEncryptedChunked(
+  _i17.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5749,23 +5783,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i17.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> joinRoom(
+  _i17.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5783,7 +5817,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5797,7 +5831,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5810,10 +5844,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> changePassword(
+  _i17.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5829,22 +5863,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> clearCache() => (super.noSuchMethod(
+  _i17.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ignoreUser(
+  _i17.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5854,22 +5888,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i17.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i17.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5880,7 +5914,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_37(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_38(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5889,7 +5923,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_37(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_38(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5897,32 +5931,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i16.Future<_i4.CachedPresence>);
+      ) as _i17.Future<_i4.CachedPresence>);
 
   @override
-  _i16.Future<void> abortSync() => (super.noSuchMethod(
+  _i17.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i17.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEventWithMetadata(
+  _i17.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5942,14 +5976,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i15.BaseResponse? response,
-    _i26.Uint8List? body,
+    _i16.BaseResponse? response,
+    _i27.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5981,7 +6015,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i16.Future<Map<String, Object?>> request(
+  _i17.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -6002,13 +6036,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> postPusher(
+  _i17.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -6018,57 +6052,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i17.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i17.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i17.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i16.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_38(
+        returnValue: _i17.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_39(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_38(
+        returnValueForMissingStub: _i17.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_39(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.TurnServerCredentials>);
+      ) as _i17.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6082,8 +6116,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6095,8 +6129,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6107,10 +6141,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6126,8 +6160,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6140,8 +6174,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6153,10 +6187,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i17.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6170,7 +6204,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6182,7 +6216,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6193,17 +6227,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.KeyBackupData>);
+      ) as _i17.Future<_i4.KeyBackupData>);
 
   @override
-  _i16.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i17.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i16.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_41(
+        returnValue: _i17.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_42(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6211,18 +6245,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_41(
+            _i17.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_42(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i17.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i16.Future<int> pingAppservice(
+  _i17.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6232,12 +6266,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
-  _i16.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i17.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6245,8 +6279,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_42(
+        returnValue: _i17.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_43(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6255,8 +6289,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_42(
+            _i17.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_43(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6264,15 +6298,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i16.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i17.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i16.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i17.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6280,17 +6314,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.MediaConfig>);
+      ) as _i17.Future<_i4.MediaConfig>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentAuthed(
+  _i17.Future<_i18.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6304,7 +6338,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6316,7 +6350,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6327,10 +6361,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentOverrideNameAuthed(
+  _i17.Future<_i18.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6346,7 +6380,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6359,7 +6393,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6371,10 +6405,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i17.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6384,7 +6418,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6393,7 +6427,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6401,10 +6435,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i16.Future<_i4.PreviewForUrl>);
+      ) as _i17.Future<_i4.PreviewForUrl>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentThumbnailAuthed(
+  _i17.Future<_i18.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6428,7 +6462,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6446,7 +6480,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6463,21 +6497,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<bool> registrationTokenValidity(String? token) =>
+  _i17.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i17.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6487,8 +6521,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_43(
+        returnValue: _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_44(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6497,8 +6531,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_43(
+            _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_44(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6506,10 +6540,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i17.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i16.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i17.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6527,8 +6561,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_44(
+        returnValue: _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_45(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6542,8 +6576,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_44(
+            _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_45(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6556,10 +6590,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i17.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i17.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6583,8 +6617,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i16.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_45(
+        returnValue: _i17.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_46(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6602,8 +6636,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_45(
+            _i17.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_46(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6620,10 +6654,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i17.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6651,8 +6685,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_46(
+                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_47(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6671,8 +6705,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_46(
+                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_47(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6690,10 +6724,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i17.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6722,9 +6756,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i16.Future<
+            returnValue: _i17.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6743,9 +6777,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i16.Future<
+            returnValueForMissingStub: _i17.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6764,11 +6798,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i16
+          ) as _i17
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i16.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i17.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6784,8 +6818,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i16.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_48(
+        returnValue: _i17.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_49(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6798,8 +6832,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_48(
+            _i17.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_49(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6811,10 +6845,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetThreadRootsResponse>);
+      ) as _i17.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i16.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i17.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6828,8 +6862,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i16.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_49(
+        returnValue: _i17.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_50(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6841,8 +6875,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_49(
+            _i17.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_50(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6853,33 +6887,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i17.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i17.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i16.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i17.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i16.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i17.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i16.Future<Uri?>.value(),
-        returnValueForMissingStub: _i16.Future<Uri?>.value(),
-      ) as _i16.Future<Uri?>);
+        returnValue: _i17.Future<Uri?>.value(),
+        returnValueForMissingStub: _i17.Future<Uri?>.value(),
+      ) as _i17.Future<Uri?>);
 
   @override
-  _i16.Future<void> add3PID(
+  _i17.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6893,12 +6927,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> bind3PID(
+  _i17.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6914,12 +6948,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i17.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6933,14 +6967,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6962,8 +6996,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6979,8 +7013,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6996,10 +7030,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7023,8 +7057,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -7041,8 +7075,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -7059,10 +7093,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i17.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -7076,14 +7110,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i17.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -7098,14 +7132,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7127,8 +7161,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7144,8 +7178,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7161,10 +7195,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7188,8 +7222,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7206,8 +7240,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7224,16 +7258,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i17.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_51(
+            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_52(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7241,22 +7275,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_51(
+            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_52(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.TokenOwnerInfo>);
+      ) as _i17.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i16.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i17.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_52(
+        returnValue: _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_53(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7264,22 +7298,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_52(
+            _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_53(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i16.Future<_i4.WhoIsInfo>);
+      ) as _i17.Future<_i4.WhoIsInfo>);
 
   @override
-  _i16.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i17.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_53(
+        returnValue: _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_54(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7287,17 +7321,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_53(
+            _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_54(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.Capabilities>);
+      ) as _i17.Future<_i4.Capabilities>);
 
   @override
-  _i16.Future<String> createRoom({
+  _i17.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7330,7 +7364,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7352,7 +7386,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7373,10 +7407,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> deleteDevices(
+  _i17.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7386,22 +7420,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.Device>?>.value(),
-      ) as _i16.Future<List<_i4.Device>?>);
+        returnValue: _i17.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.Device>?>.value(),
+      ) as _i17.Future<List<_i4.Device>?>);
 
   @override
-  _i16.Future<void> deleteDevice(
+  _i17.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7411,34 +7445,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i17.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i16.Future<_i4.Device>.value(_FakeDevice_54(
+        returnValue: _i17.Future<_i4.Device>.value(_FakeDevice_55(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.Device>.value(_FakeDevice_54(
+        returnValueForMissingStub: _i17.Future<_i4.Device>.value(_FakeDevice_55(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i16.Future<_i4.Device>);
+      ) as _i17.Future<_i4.Device>);
 
   @override
-  _i16.Future<void> updateDevice(
+  _i17.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7448,12 +7482,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i17.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7468,24 +7502,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i17.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i16.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Visibility?>.value(),
-      ) as _i16.Future<_i4.Visibility?>);
+        returnValue: _i17.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Visibility?>.value(),
+      ) as _i17.Future<_i4.Visibility?>);
 
   @override
-  _i16.Future<void> setRoomVisibilityOnDirectory(
+  _i17.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7495,30 +7529,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i17.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i17.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_55(
+        returnValue: _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_56(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7526,18 +7560,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_55(
+            _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_56(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i17.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i16.Future<void> setRoomAlias(
+  _i17.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7549,12 +7583,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetEventsResponse> getEvents({
+  _i17.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7568,7 +7602,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_56(
+            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_57(
           this,
           Invocation.method(
             #getEvents,
@@ -7580,7 +7614,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_56(
+            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_57(
           this,
           Invocation.method(
             #getEvents,
@@ -7591,10 +7625,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetEventsResponse>);
+      ) as _i17.Future<_i4.GetEventsResponse>);
 
   @override
-  _i16.Future<_i4.PeekEventsResponse> peekEvents({
+  _i17.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7609,8 +7643,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i16.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_57(
+        returnValue: _i17.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_58(
           this,
           Invocation.method(
             #peekEvents,
@@ -7622,8 +7656,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_57(
+        returnValueForMissingStub: _i17.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_58(
           this,
           Invocation.method(
             #peekEvents,
@@ -7635,16 +7669,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.PeekEventsResponse>);
+      ) as _i17.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i16.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i17.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7652,27 +7686,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i16.Future<_i4.MatrixEvent>);
+      ) as _i17.Future<_i4.MatrixEvent>);
 
   @override
-  _i16.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i17.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 
   @override
-  _i16.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i17.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7684,8 +7718,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i16.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_59(
+        returnValue: _i17.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_60(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7696,8 +7730,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_59(
+            _i17.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_60(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7707,10 +7741,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.GetKeysChangesResponse>);
+      ) as _i17.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i16.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i17.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7721,7 +7755,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_60(
+            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_61(
           this,
           Invocation.method(
             #claimKeys,
@@ -7730,7 +7764,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_60(
+            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_61(
           this,
           Invocation.method(
             #claimKeys,
@@ -7738,10 +7772,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i16.Future<_i4.ClaimKeysResponse>);
+      ) as _i17.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i16.Future<void> uploadCrossSigningKeys({
+  _i17.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7758,12 +7792,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.QueryKeysResponse> queryKeys(
+  _i17.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7774,7 +7808,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_61(
+            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_62(
           this,
           Invocation.method(
             #queryKeys,
@@ -7783,7 +7817,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_61(
+            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_62(
           this,
           Invocation.method(
             #queryKeys,
@@ -7791,10 +7825,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i16.Future<_i4.QueryKeysResponse>);
+      ) as _i17.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7802,14 +7836,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i16.Future<
+            returnValue: _i17.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i16.Future<
+            returnValueForMissingStub: _i17.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i16.Future<Map<String, int>> uploadKeys({
+  _i17.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7824,13 +7858,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i16.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i17.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i16.Future<Map<String, int>>);
+            _i17.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i17.Future<Map<String, int>>);
 
   @override
-  _i16.Future<String> knockRoom(
+  _i17.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7844,7 +7878,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7856,7 +7890,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7867,20 +7901,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i17.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i16.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i17.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i17.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i16.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i17.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7895,8 +7929,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i16.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_62(
+        returnValue: _i17.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_63(
           this,
           Invocation.method(
             #getNotifications,
@@ -7909,8 +7943,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_62(
+            _i17.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_63(
           this,
           Invocation.method(
             #getNotifications,
@@ -7922,35 +7956,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetNotificationsResponse>);
+      ) as _i17.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i16.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i17.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i16.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_63(
+        returnValue: _i17.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_64(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_63(
+        returnValueForMissingStub: _i17.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_64(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i16.Future<_i4.GetPresenceResponse>);
+      ) as _i17.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i16.Future<void> setPresence(
+  _i17.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7964,12 +7998,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, Object?>> deleteProfileField(
+  _i17.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7982,13 +8016,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getProfileField(
+  _i17.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -8001,13 +8035,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<Map<String, Object?>> setProfileField(
+  _i17.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -8022,13 +8056,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i17.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -8043,8 +8077,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i16.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_64(
+        returnValue: _i17.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_65(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -8057,8 +8091,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_64(
+            _i17.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_65(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -8070,10 +8104,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i17.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i16.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i17.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -8094,8 +8128,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i16.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_65(
+        returnValue: _i17.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_66(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8111,8 +8145,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_65(
+            _i17.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_66(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8127,25 +8161,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i17.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i16.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.Pusher>?>.value(),
-      ) as _i16.Future<List<_i4.Pusher>?>);
+        returnValue: _i17.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.Pusher>?>.value(),
+      ) as _i17.Future<List<_i4.Pusher>?>);
 
   @override
-  _i16.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i17.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_66(
+        returnValue: _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_67(
           this,
           Invocation.method(
             #getPushRules,
@@ -8153,24 +8187,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_66(
+            _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_67(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.PushRuleSet>);
+      ) as _i17.Future<_i4.PushRuleSet>);
 
   @override
-  _i16.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i17.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_67(
+        returnValue: _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_68(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8178,18 +8212,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_67(
+            _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_68(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i17.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i16.Future<void> deletePushRule(
+  _i17.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8201,12 +8235,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.PushRule> getPushRule(
+  _i17.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8218,7 +8252,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<_i4.PushRule>.value(_FakePushRule_68(
+        returnValue: _i17.Future<_i4.PushRule>.value(_FakePushRule_69(
           this,
           Invocation.method(
             #getPushRule,
@@ -8229,7 +8263,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PushRule>.value(_FakePushRule_68(
+            _i17.Future<_i4.PushRule>.value(_FakePushRule_69(
           this,
           Invocation.method(
             #getPushRule,
@@ -8239,10 +8273,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.PushRule>);
+      ) as _i17.Future<_i4.PushRule>);
 
   @override
-  _i16.Future<void> setPushRule(
+  _i17.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8266,12 +8300,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<Object?>> getPushRuleActions(
+  _i17.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8283,13 +8317,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i17.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i16.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i16.Future<List<Object?>>);
+            _i17.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i17.Future<List<Object?>>);
 
   @override
-  _i16.Future<void> setPushRuleActions(
+  _i17.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8303,12 +8337,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<bool> isPushRuleEnabled(
+  _i17.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8320,12 +8354,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> setPushRuleEnabled(
+  _i17.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8339,19 +8373,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i17.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_69(
+            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_70(
           this,
           Invocation.method(
             #refresh,
@@ -8359,28 +8393,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_69(
+            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_70(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i16.Future<_i4.RefreshResponse>);
+      ) as _i17.Future<_i4.RefreshResponse>);
 
   @override
-  _i16.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i17.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i16.Future<bool?>.value(),
-        returnValueForMissingStub: _i16.Future<bool?>.value(),
-      ) as _i16.Future<bool?>);
+        returnValue: _i17.Future<bool?>.value(),
+        returnValueForMissingStub: _i17.Future<bool?>.value(),
+      ) as _i17.Future<bool?>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8402,8 +8436,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8419,8 +8453,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8436,10 +8470,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8463,8 +8497,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8481,8 +8515,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8499,17 +8533,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8517,23 +8551,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i17.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_70(
+        returnValue: _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_71(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8541,17 +8575,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_70(
+            _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_71(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeys>);
+      ) as _i17.Future<_i4.RoomKeys>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8563,8 +8597,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8575,8 +8609,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8586,10 +8620,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8601,8 +8635,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8613,8 +8647,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8624,10 +8658,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8639,7 +8673,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_71(
+        returnValue: _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_72(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8650,7 +8684,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_71(
+            _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_72(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8660,10 +8694,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeyBackup>);
+      ) as _i17.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8677,8 +8711,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8690,8 +8724,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8702,10 +8736,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8719,8 +8753,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8732,8 +8766,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8744,10 +8778,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i17.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8761,7 +8795,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8773,7 +8807,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8784,10 +8818,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.KeyBackupData>);
+      ) as _i17.Future<_i4.KeyBackupData>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8803,8 +8837,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8817,8 +8851,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8830,18 +8864,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_72(
+                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_73(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8849,18 +8883,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_72(
+                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_73(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i16.Future<String> postRoomKeysVersion(
+  _i17.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8872,7 +8906,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8883,7 +8917,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8893,29 +8927,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i17.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i17.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_73(
+        returnValue: _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_74(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8923,18 +8957,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_73(
+            _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_74(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i17.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i17.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8949,24 +8983,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i17.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 
   @override
-  _i16.Future<void> ban(
+  _i17.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8980,12 +9014,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.EventContext> getEventContext(
+  _i17.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -9003,7 +9037,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<_i4.EventContext>.value(_FakeEventContext_74(
+        returnValue: _i17.Future<_i4.EventContext>.value(_FakeEventContext_75(
           this,
           Invocation.method(
             #getEventContext,
@@ -9018,7 +9052,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.EventContext>.value(_FakeEventContext_74(
+            _i17.Future<_i4.EventContext>.value(_FakeEventContext_75(
           this,
           Invocation.method(
             #getEventContext,
@@ -9032,10 +9066,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.EventContext>);
+      ) as _i17.Future<_i4.EventContext>);
 
   @override
-  _i16.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i17.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -9047,7 +9081,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -9058,7 +9092,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -9068,20 +9102,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.MatrixEvent>);
+      ) as _i17.Future<_i4.MatrixEvent>);
 
   @override
-  _i16.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> inviteBy3PID(
+  _i17.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -9093,12 +9127,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> inviteUser(
+  _i17.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9112,12 +9146,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> joinRoomById(
+  _i17.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -9131,7 +9165,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9143,7 +9177,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9154,23 +9188,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i17.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i17.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i16.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i16.Future<Map<String, _i4.RoomMember>?>);
+            _i17.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i17.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i16.Future<void> kick(
+  _i17.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9184,12 +9218,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leaveRoom(
+  _i17.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9199,12 +9233,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i17.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9220,12 +9254,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i16.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i16.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i17.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i17.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i16.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i17.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9247,8 +9281,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_75(
+        returnValue: _i17.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_76(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9264,8 +9298,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_75(
+        returnValueForMissingStub: _i17.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_76(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9281,10 +9315,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomEventsResponse>);
+      ) as _i17.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i16.Future<void> setReadMarker(
+  _i17.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9300,12 +9334,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> postReceipt(
+  _i17.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9321,12 +9355,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEvent(
+  _i17.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9342,12 +9376,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> reportRoom(
+  _i17.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9359,12 +9393,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> reportEvent(
+  _i17.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9382,12 +9416,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> sendMessage(
+  _i17.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9403,7 +9437,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9416,7 +9450,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9428,23 +9462,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i17.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i16.Future<List<_i4.MatrixEvent>>);
+            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i17.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i17.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9461,13 +9495,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<String> setRoomStateWithKey(
+  _i17.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9483,7 +9517,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9496,7 +9530,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9508,10 +9542,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> unban(
+  _i17.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9525,12 +9559,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> upgradeRoom(
+  _i17.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9544,7 +9578,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9556,7 +9590,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9567,10 +9601,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.SearchResults> search(
+  _i17.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9580,7 +9614,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_76(
+        returnValue: _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_77(
           this,
           Invocation.method(
             #search,
@@ -9589,7 +9623,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_76(
+            _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_77(
           this,
           Invocation.method(
             #search,
@@ -9597,10 +9631,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i16.Future<_i4.SearchResults>);
+      ) as _i17.Future<_i4.SearchResults>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> sync({
+  _i17.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9621,7 +9655,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #sync,
@@ -9637,7 +9671,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #sync,
@@ -9652,22 +9686,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i17.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i16.Future<List<_i4.Location>>);
+            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i17.Future<List<_i4.Location>>);
 
   @override
-  _i16.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i17.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9677,21 +9711,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i16.Future<List<_i4.Location>>);
+            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i17.Future<List<_i4.Location>>);
 
   @override
-  _i16.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i17.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_77(
+        returnValue: _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_78(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9699,45 +9733,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_77(
+            _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_78(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i16.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i17.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i16.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i17.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9748,13 +9782,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getAccountData(
+  _i17.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9767,13 +9801,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> setAccountData(
+  _i17.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9787,12 +9821,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> defineFilter(
+  _i17.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9804,7 +9838,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9815,7 +9849,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9825,10 +9859,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.Filter> getFilter(
+  _i17.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9840,7 +9874,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i16.Future<_i4.Filter>.value(_FakeFilter_21(
+        returnValue: _i17.Future<_i4.Filter>.value(_FakeFilter_22(
           this,
           Invocation.method(
             #getFilter,
@@ -9850,7 +9884,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.Filter>.value(_FakeFilter_21(
+        returnValueForMissingStub: _i17.Future<_i4.Filter>.value(_FakeFilter_22(
           this,
           Invocation.method(
             #getFilter,
@@ -9860,10 +9894,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.Filter>);
+      ) as _i17.Future<_i4.Filter>);
 
   @override
-  _i16.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i17.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9876,7 +9910,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_78(
+            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_79(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9887,7 +9921,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_78(
+            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_79(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9897,10 +9931,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.OpenIdCredentials>);
+      ) as _i17.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i16.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i17.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9915,13 +9949,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> setAccountDataPerRoom(
+  _i17.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9937,12 +9971,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i17.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9954,12 +9988,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i16.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i16.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i16.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i17.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i17.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i17.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i16.Future<void> deleteRoomTag(
+  _i17.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9973,12 +10007,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setRoomTag(
+  _i17.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9994,12 +10028,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i17.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -10009,8 +10043,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i16.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_79(
+        returnValue: _i17.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_80(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -10019,8 +10053,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_79(
+            _i17.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_80(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -10028,10 +10062,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i16.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i17.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> reportUser(
+  _i17.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -10044,40 +10078,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i17.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i16.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_80(
+        returnValue: _i17.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_81(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_80(
+        returnValueForMissingStub: _i17.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_81(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.CreateContentResponse>);
+      ) as _i17.Future<_i4.CreateContentResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> uploadContentToMXC(
+  _i17.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i26.Uint8List? body, {
+    _i27.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10095,8 +10129,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 }

--- a/test/widgets/add_room_to_space_dialog_test.mocks.dart
+++ b/test/widgets/add_room_to_space_dialog_test.mocks.dart
@@ -3,15 +3,15 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i16;
-import 'dart:typed_data' as _i26;
-import 'dart:ui' as _i20;
+import 'dart:async' as _i17;
+import 'dart:typed_data' as _i27;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
-import 'package:http/http.dart' as _i15;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i13;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
+import 'package:http/http.dart' as _i16;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -27,14 +27,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i25;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i13;
+import 'package:matrix/encryption.dart' as _i26;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i17;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i14;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i18;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i15;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -168,9 +169,9 @@ class _FakeOutboxService_10 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_11 extends _i1.SmartFake
-    implements _i13.StickerPackService {
-  _FakeStickerPackService_11(
+class _FakeAvatarResolver_11 extends _i1.SmartFake
+    implements _i13.AvatarResolver {
+  _FakeAvatarResolver_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -179,8 +180,9 @@ class _FakeStickerPackService_11 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_12 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_12(
+class _FakeStickerPackService_12 extends _i1.SmartFake
+    implements _i14.StickerPackService {
+  _FakeStickerPackService_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -189,9 +191,8 @@ class _FakeRoomSummary_12 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_13<T> extends _i1.SmartFake
-    implements _i14.CachedStreamController<T> {
-  _FakeCachedStreamController_13(
+class _FakeRoomSummary_13 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -200,8 +201,9 @@ class _FakeCachedStreamController_13<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_14 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_14(
+class _FakeCachedStreamController_14<T> extends _i1.SmartFake
+    implements _i15.CachedStreamController<T> {
+  _FakeCachedStreamController_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -210,9 +212,19 @@ class _FakeDateTime_14 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_15 extends _i1.SmartFake
+class _FakeDateTime_15 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_15(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_16 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_15(
+  _FakeLatestReceiptState_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -221,8 +233,8 @@ class _FakeLatestReceiptState_15 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_16 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_16(
+class _FakeSyncUpdate_17 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -231,8 +243,8 @@ class _FakeSyncUpdate_16 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_17 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_17(
+class _FakeTimeline_18 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -241,8 +253,8 @@ class _FakeTimeline_17 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_18 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_18(
+class _FakeUser_19 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -251,8 +263,8 @@ class _FakeUser_18 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_19 extends _i1.SmartFake implements Uri {
-  _FakeUri_19(
+class _FakeUri_20 extends _i1.SmartFake implements Uri {
+  _FakeUri_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -261,8 +273,8 @@ class _FakeUri_19 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_20 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_20(
+class _FakeDatabaseApi_21 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -271,8 +283,8 @@ class _FakeDatabaseApi_20 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_21 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_21(
+class _FakeFilter_22 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -281,9 +293,9 @@ class _FakeFilter_21 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_22 extends _i1.SmartFake
+class _FakeNativeImplementations_23 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_22(
+  _FakeNativeImplementations_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -292,8 +304,8 @@ class _FakeNativeImplementations_22 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_23 extends _i1.SmartFake implements Duration {
-  _FakeDuration_23(
+class _FakeDuration_24 extends _i1.SmartFake implements Duration {
+  _FakeDuration_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -302,9 +314,9 @@ class _FakeDuration_23 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_24 extends _i1.SmartFake
+class _FakePushruleEvaluator_25 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_24(
+  _FakePushruleEvaluator_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -313,8 +325,8 @@ class _FakePushruleEvaluator_24 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_25 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_25(
+class _FakeProfile_26 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -323,8 +335,8 @@ class _FakeProfile_25 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_26 extends _i1.SmartFake implements _i15.Client {
-  _FakeClient_26(
+class _FakeClient_27 extends _i1.SmartFake implements _i16.Client {
+  _FakeClient_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -333,9 +345,9 @@ class _FakeClient_26 extends _i1.SmartFake implements _i15.Client {
         );
 }
 
-class _FakeDiscoveryInformation_27 extends _i1.SmartFake
+class _FakeDiscoveryInformation_28 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_27(
+  _FakeDiscoveryInformation_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -344,9 +356,9 @@ class _FakeDiscoveryInformation_27 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_28 extends _i1.SmartFake
+class _FakeGetVersionsResponse_29 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_28(
+  _FakeGetVersionsResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -355,9 +367,9 @@ class _FakeGetVersionsResponse_28 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_29 extends _i1.SmartFake
+class _FakeRegisterResponse_30 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_29(
+  _FakeRegisterResponse_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -366,8 +378,8 @@ class _FakeRegisterResponse_29 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_30 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_30(
+class _FakeLoginResponse_31 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -376,9 +388,9 @@ class _FakeLoginResponse_30 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_31 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_32 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_31(
+  _FakeGetAuthMetadataResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -387,8 +399,8 @@ class _FakeGetAuthMetadataResponse_31 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_32<T1> extends _i1.SmartFake implements _i16.Future<T1> {
-  _FakeFuture_32(
+class _FakeFuture_33<T1> extends _i1.SmartFake implements _i17.Future<T1> {
+  _FakeFuture_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -397,9 +409,9 @@ class _FakeFuture_32<T1> extends _i1.SmartFake implements _i16.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_33 extends _i1.SmartFake
+class _FakeCachedProfileInformation_34 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_33(
+  _FakeCachedProfileInformation_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -408,8 +420,8 @@ class _FakeCachedProfileInformation_33 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_34 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_34(
+class _FakeMediaConfig_35 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -418,8 +430,8 @@ class _FakeMediaConfig_34 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_35 extends _i1.SmartFake implements _i17.FileResponse {
-  _FakeFileResponse_35(
+class _FakeFileResponse_36 extends _i1.SmartFake implements _i18.FileResponse {
+  _FakeFileResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -428,8 +440,8 @@ class _FakeFileResponse_35 extends _i1.SmartFake implements _i17.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_36 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_36(
+class _FakePreviewForUrl_37 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -438,9 +450,9 @@ class _FakePreviewForUrl_36 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_37 extends _i1.SmartFake
+class _FakeCachedPresence_38 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_37(
+  _FakeCachedPresence_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -449,9 +461,9 @@ class _FakeCachedPresence_37 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_38 extends _i1.SmartFake
+class _FakeTurnServerCredentials_39 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_38(
+  _FakeTurnServerCredentials_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -460,9 +472,9 @@ class _FakeTurnServerCredentials_38 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_39 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_40 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_39(
+  _FakeRoomKeysUpdateResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -471,8 +483,8 @@ class _FakeRoomKeysUpdateResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_40 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_40(
+class _FakeKeyBackupData_41 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -481,9 +493,9 @@ class _FakeKeyBackupData_40 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_41 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_42 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_41(
+  _FakeGetWellknownSupportResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -492,9 +504,9 @@ class _FakeGetWellknownSupportResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_42 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_43 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_42(
+  _FakeGenerateLoginTokenResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -503,9 +515,9 @@ class _FakeGenerateLoginTokenResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_43 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_44 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_43(
+  _FakeGetRoomSummaryResponse$3_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -514,9 +526,9 @@ class _FakeGetRoomSummaryResponse$3_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_44 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_45 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_44(
+  _FakeGetSpaceHierarchyResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -525,9 +537,9 @@ class _FakeGetSpaceHierarchyResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_45 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_46 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_45(
+  _FakeGetRelatingEventsResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -536,9 +548,9 @@ class _FakeGetRelatingEventsResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_46 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_47 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_46(
+  _FakeGetRelatingEventsWithRelTypeResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -547,9 +559,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -558,9 +570,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_48 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_49 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_48(
+  _FakeGetThreadRootsResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -569,9 +581,9 @@ class _FakeGetThreadRootsResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_49 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_50 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_49(
+  _FakeGetEventByTimestampResponse_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -580,9 +592,9 @@ class _FakeGetEventByTimestampResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_50 extends _i1.SmartFake
+class _FakeRequestTokenResponse_51 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_50(
+  _FakeRequestTokenResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -591,9 +603,9 @@ class _FakeRequestTokenResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_51 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_52 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_51(
+  _FakeTokenOwnerInfo_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -602,8 +614,8 @@ class _FakeTokenOwnerInfo_51 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_52 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_52(
+class _FakeWhoIsInfo_53 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -612,8 +624,8 @@ class _FakeWhoIsInfo_52 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_53 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_53(
+class _FakeCapabilities_54 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -622,8 +634,8 @@ class _FakeCapabilities_53 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_54 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_54(
+class _FakeDevice_55 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -632,9 +644,9 @@ class _FakeDevice_54 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_55 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_56 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_55(
+  _FakeGetRoomIdByAliasResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -643,9 +655,9 @@ class _FakeGetRoomIdByAliasResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_56 extends _i1.SmartFake
+class _FakeGetEventsResponse_57 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_56(
+  _FakeGetEventsResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -654,9 +666,9 @@ class _FakeGetEventsResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_57 extends _i1.SmartFake
+class _FakePeekEventsResponse_58 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_57(
+  _FakePeekEventsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -665,8 +677,8 @@ class _FakePeekEventsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_58 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_58(
+class _FakeMatrixEvent_59 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -675,9 +687,9 @@ class _FakeMatrixEvent_58 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_59 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_60 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_59(
+  _FakeGetKeysChangesResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -686,9 +698,9 @@ class _FakeGetKeysChangesResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_60 extends _i1.SmartFake
+class _FakeClaimKeysResponse_61 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_60(
+  _FakeClaimKeysResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -697,9 +709,9 @@ class _FakeClaimKeysResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_61 extends _i1.SmartFake
+class _FakeQueryKeysResponse_62 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_61(
+  _FakeQueryKeysResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -708,9 +720,9 @@ class _FakeQueryKeysResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_62 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_63 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_62(
+  _FakeGetNotificationsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -719,9 +731,9 @@ class _FakeGetNotificationsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_63 extends _i1.SmartFake
+class _FakeGetPresenceResponse_64 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_63(
+  _FakeGetPresenceResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -730,9 +742,9 @@ class _FakeGetPresenceResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_64 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_65 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_64(
+  _FakeGetPublicRoomsResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -741,9 +753,9 @@ class _FakeGetPublicRoomsResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_65 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_66 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_65(
+  _FakeQueryPublicRoomsResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -752,8 +764,8 @@ class _FakeQueryPublicRoomsResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_66 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_66(
+class _FakePushRuleSet_67 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -762,9 +774,9 @@ class _FakePushRuleSet_66 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_67 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_68 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_67(
+  _FakeGetPushRulesGlobalResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -773,8 +785,8 @@ class _FakeGetPushRulesGlobalResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_68 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_68(
+class _FakePushRule_69 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -783,9 +795,9 @@ class _FakePushRule_68 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_69 extends _i1.SmartFake
+class _FakeRefreshResponse_70 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_69(
+  _FakeRefreshResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -794,8 +806,8 @@ class _FakeRefreshResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_70 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_70(
+class _FakeRoomKeys_71 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -804,8 +816,8 @@ class _FakeRoomKeys_70 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_71 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_71(
+class _FakeRoomKeyBackup_72 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -814,9 +826,9 @@ class _FakeRoomKeyBackup_71 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_72 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_73 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_72(
+  _FakeGetRoomKeysVersionCurrentResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -825,9 +837,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_73 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_74 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_73(
+  _FakeGetRoomKeysVersionResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -836,8 +848,8 @@ class _FakeGetRoomKeysVersionResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_74 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_74(
+class _FakeEventContext_75 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -846,9 +858,9 @@ class _FakeEventContext_74 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_75 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_76 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_75(
+  _FakeGetRoomEventsResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -857,8 +869,8 @@ class _FakeGetRoomEventsResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_76 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_76(
+class _FakeSearchResults_77 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,9 +879,9 @@ class _FakeSearchResults_76 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_77 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_78 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_77(
+  _FakeGetProtocolMetadataResponse$2_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -878,9 +890,9 @@ class _FakeGetProtocolMetadataResponse$2_77 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_78 extends _i1.SmartFake
+class _FakeOpenIdCredentials_79 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_78(
+  _FakeOpenIdCredentials_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -889,9 +901,9 @@ class _FakeOpenIdCredentials_78 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_79 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_80 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_79(
+  _FakeSearchUserDirectoryResponse_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -900,9 +912,9 @@ class _FakeSearchUserDirectoryResponse_79 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_80 extends _i1.SmartFake
+class _FakeCreateContentResponse_81 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_80(
+  _FakeCreateContentResponse_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -914,7 +926,7 @@ class _FakeCreateContentResponse_80 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -944,11 +956,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1086,17 +1098,30 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i12.OutboxService);
 
   @override
-  _i13.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i13.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i13.AvatarResolver);
+
+  @override
+  _i14.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_11(
+        returnValue: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_11(
+        returnValueForMissingStub: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i13.StickerPackService);
+      ) as _i14.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1205,7 +1230,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set stickerPacks(_i13.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i13.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i14.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -1221,14 +1255,14 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  _i16.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i17.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1258,7 +1292,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1268,18 +1302,18 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i17.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<bool> login({
+  _i17.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1296,12 +1330,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> completeSsoLogin({
+  _i17.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1314,12 +1348,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> completeRegistration(
+  _i17.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1329,32 +1363,32 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> logout() => (super.noSuchMethod(
+  _i17.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i17.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1363,7 +1397,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1372,17 +1406,17 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i17.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1393,7 +1427,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1430,26 +1464,26 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i17.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+  _i17.Future<bool> didPushRouteInformation(
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1479,7 +1513,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1488,7 +1522,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1497,16 +1531,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i17.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i16.Future<_i20.AppExitResponse>);
+            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i17.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1534,11 +1568,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1568,11 +1602,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_12(
+        returnValue: _FakeRoomSummary_13(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_12(
+        returnValueForMissingStub: _FakeRoomSummary_13(
           this,
           Invocation.getter(#summary),
         ),
@@ -1602,11 +1636,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i16.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i17.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i16.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i16.Completer<dynamic>>[],
-      ) as List<_i16.Completer<dynamic>>);
+        returnValue: <_i17.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i17.Completer<dynamic>>[],
+      ) as List<_i17.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1625,51 +1659,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i14.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i15.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i14.CachedStreamController<String> get onSessionKeyReceived =>
+  _i15.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1685,11 +1719,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1698,11 +1732,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1745,11 +1779,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1758,11 +1792,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_14(
+        returnValue: _FakeDateTime_15(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_14(
+        returnValueForMissingStub: _FakeDateTime_15(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1792,11 +1826,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_15(
+        returnValue: _FakeLatestReceiptState_16(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_15(
+        returnValueForMissingStub: _FakeLatestReceiptState_16(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1817,18 +1851,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i16.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i17.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -2015,18 +2049,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -2139,14 +2173,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i16.Future<void> postLoad() => (super.noSuchMethod(
+  _i17.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2174,15 +2208,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i16.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i17.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i16.Future<List<_i4.User>>);
+            _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i17.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2193,14 +2227,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2210,18 +2244,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i16.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i17.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Event?> refreshLastEvent(
+  _i17.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2229,9 +2263,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2243,12 +2277,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i16.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i17.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2256,22 +2290,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i17.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2279,17 +2313,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> addTag(
+  _i17.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2299,27 +2333,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i17.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i17.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2327,53 +2361,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i17.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i17.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+  _i17.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
         Invocation.method(
           #setLowPriority,
           [lowPriority],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i17.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2381,14 +2415,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2400,7 +2434,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i16.Future<String?> sendTextEvent(
+  _i17.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2432,12 +2466,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendReaction(
+  _i17.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2451,12 +2485,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendLocation(
+  _i17.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2470,12 +2504,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendFileEvent(
+  _i17.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2503,25 +2537,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i17.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i16.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i17.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i16.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i17.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i16.Future<_i4.EncryptionHealthState>);
+      ) as _i17.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i16.Future<String?> sendEvent(
+  _i17.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2545,73 +2579,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i17.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leave() => (super.noSuchMethod(
+  _i17.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> forget() => (super.noSuchMethod(
+  _i17.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> setPower(
+  _i17.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2623,7 +2657,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2634,7 +2668,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2644,10 +2678,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> invite(
+  _i17.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2657,12 +2691,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<int> requestHistory({
+  _i17.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2679,32 +2713,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
-  _i16.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i17.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setReadMarker(
+  _i17.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2718,23 +2752,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
+  _i17.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i16.Future<_i24.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i16.Future<_i24.TimelineChunk?>.value(),
-      ) as _i16.Future<_i24.TimelineChunk?>);
+        returnValue: _i17.Future<_i25.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i17.Future<_i25.TimelineChunk?>.value(),
+      ) as _i17.Future<_i25.TimelineChunk?>);
 
   @override
-  _i16.Future<void> postReceipt(
+  _i17.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2744,12 +2778,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Timeline> getTimeline({
+  _i17.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2772,7 +2806,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i16.Future<_i4.Timeline>.value(_FakeTimeline_17(
+        returnValue: _i17.Future<_i4.Timeline>.value(_FakeTimeline_18(
           this,
           Invocation.method(
             #getTimeline,
@@ -2789,7 +2823,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Timeline>.value(_FakeTimeline_17(
+            _i17.Future<_i4.Timeline>.value(_FakeTimeline_18(
           this,
           Invocation.method(
             #getTimeline,
@@ -2805,7 +2839,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Timeline>);
+      ) as _i17.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2824,7 +2858,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i16.Future<List<_i4.User>> requestParticipants([
+  _i17.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2842,10 +2876,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i16.Future<List<_i4.User>>);
+            _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i17.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2853,14 +2887,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_18(
+        returnValue: _FakeUser_19(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_18(
+        returnValueForMissingStub: _FakeUser_19(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2876,14 +2910,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_18(
+        returnValue: _FakeUser_19(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_18(
+        returnValueForMissingStub: _FakeUser_19(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2893,7 +2927,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i16.Future<_i4.User?> requestUser(
+  _i17.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2909,19 +2943,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i16.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.User?>.value(),
-      ) as _i16.Future<_i4.User?>);
+        returnValue: _i17.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.User?>.value(),
+      ) as _i17.Future<_i4.User?>);
 
   @override
-  _i16.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i17.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2934,12 +2968,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i16.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i17.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2947,14 +2981,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2977,14 +3011,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i16.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i17.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -3023,18 +3057,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i16.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i17.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEvent(
+  _i17.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -3048,12 +3082,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> setTyping(
+  _i17.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -3063,12 +3097,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setJoinRules(
+  _i17.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -3082,59 +3116,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i17.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setHistoryVisibility(
+  _i17.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i17.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i17.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i16.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i17.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i16.Future<List<_i4.DeviceKeys>>);
+            _i17.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i17.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i16.Future<void> requestSessionKey(
+  _i17.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3146,12 +3180,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setSpaceChild(
+  _i17.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3167,44 +3201,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i17.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValue: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i16.Future<Uri>);
+      ) as _i17.Future<Uri>);
 
   @override
-  _i16.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<
+  _i17.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3231,21 +3265,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i16.Future<
+        returnValue: _i17.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i16.Future<
+        returnValueForMissingStub: _i17.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i16.Future<
+      ) as _i17.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3260,23 +3294,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_20(
+        returnValue: _FakeDatabaseApi_21(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_20(
+        returnValueForMissingStub: _FakeDatabaseApi_21(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i25.KeyVerificationMethod> get verificationMethods =>
+  Set<_i26.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i25.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i25.KeyVerificationMethod>{},
-      ) as Set<_i25.KeyVerificationMethod>);
+        returnValue: <_i26.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i26.KeyVerificationMethod>{},
+      ) as Set<_i26.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3337,11 +3371,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_21(
+        returnValue: _FakeFilter_22(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_21(
+        returnValueForMissingStub: _FakeFilter_22(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3350,11 +3384,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_22(
+        returnValue: _FakeNativeImplementations_23(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_22(
+        returnValueForMissingStub: _FakeNativeImplementations_23(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3370,11 +3404,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_23(
+        returnValue: _FakeDuration_24(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_23(
+        returnValueForMissingStub: _FakeDuration_24(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3383,11 +3417,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_23(
+        returnValue: _FakeDuration_24(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_23(
+        returnValueForMissingStub: _FakeDuration_24(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3396,11 +3430,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3437,11 +3471,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3471,11 +3505,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3484,11 +3518,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3511,11 +3545,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_24(
+        returnValue: _FakePushruleEvaluator_25(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_24(
+        returnValueForMissingStub: _FakePushruleEvaluator_25(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3536,332 +3570,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i16.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i17.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i14.CachedStreamController<String> get onUserProfileUpdate =>
+  _i15.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i16.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i17.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i16.Future<List<_i4.Room>>);
+            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i17.Future<List<_i4.Room>>);
 
   @override
-  _i14.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i15.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.EventUpdate>(
+            _FakeCachedStreamController_14<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.EventUpdate>);
+      ) as _i15.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i15.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i15.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onNotification =>
+  _i15.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i15.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i15.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i14.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i15.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_13<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_13<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i14.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i15.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i14.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i15.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_13<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_14<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.LoginState>(
+            _FakeCachedStreamController_14<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i14.CachedStreamController<_i4.LoginState>);
+      ) as _i15.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i14.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i15.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_13<bool>(
+        returnValue: _FakeCachedStreamController_14<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i14.CachedStreamController<bool>);
+      ) as _i15.CachedStreamController<bool>);
 
   @override
-  _i14.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i15.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_13<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_14<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i14.CachedStreamController<_i4.SdkError>);
+      ) as _i15.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i14.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i15.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_13<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.SyncUpdate>(
+            _FakeCachedStreamController_14<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i14.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i15.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i15.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_13<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i14.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i15.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.Presence> get onPresence =>
+  _i15.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_13<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_14<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i14.CachedStreamController<_i4.Presence>);
+      ) as _i15.CachedStreamController<_i4.Presence>);
 
   @override
-  _i14.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i15.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_13<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_14<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.CachedPresence>(
+            _FakeCachedStreamController_14<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i14.CachedStreamController<_i4.CachedPresence>);
+      ) as _i15.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i14.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i15.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_13<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_14<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.BasicEvent>(
+            _FakeCachedStreamController_14<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i14.CachedStreamController<_i4.BasicEvent>);
+      ) as _i15.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i14.CachedStreamController<_i25.RoomKeyRequest> get onRoomKeyRequest =>
+  _i15.CachedStreamController<_i26.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_13<_i25.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_14<_i26.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i25.RoomKeyRequest>(
+            _FakeCachedStreamController_14<_i26.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i14.CachedStreamController<_i25.RoomKeyRequest>);
+      ) as _i15.CachedStreamController<_i26.RoomKeyRequest>);
 
   @override
-  _i14.CachedStreamController<_i25.KeyVerification>
+  _i15.CachedStreamController<_i26.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_13<_i25.KeyVerification>(
+            returnValue: _FakeCachedStreamController_14<_i26.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_13<_i25.KeyVerification>(
+                _FakeCachedStreamController_14<_i26.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i14.CachedStreamController<_i25.KeyVerification>);
+          ) as _i15.CachedStreamController<_i26.KeyVerification>);
 
   @override
-  _i14.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i15.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_13<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i14.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i15.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i15.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<String> get onCancelSendEvent =>
+  _i15.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i14.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i15.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_13<
+            returnValue: _FakeCachedStreamController_14<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_13<
+            returnValueForMissingStub: _FakeCachedStreamController_14<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i14.CachedStreamController<
+          ) as _i15.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3881,11 +3915,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_14(
+        returnValue: _FakeDateTime_15(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_14(
+        returnValueForMissingStub: _FakeDateTime_15(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3958,7 +3992,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i25.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i26.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -4013,7 +4047,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i16.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i17.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -4024,7 +4058,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i16.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i17.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -4135,7 +4169,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4144,7 +4178,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4153,7 +4187,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4180,20 +4214,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i15.Client get httpClient => (super.noSuchMethod(
+  _i16.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_26(
+        returnValue: _FakeClient_27(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_26(
+        returnValueForMissingStub: _FakeClient_27(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i15.Client);
+      ) as _i16.Client);
 
   @override
-  set httpClient(_i15.Client? value) => super.noSuchMethod(
+  set httpClient(_i16.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4220,7 +4254,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<void> refreshAccessToken(
+  _i17.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4228,9 +4262,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4248,14 +4282,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4292,33 +4326,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i16.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i17.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i16.Future<_i4.DiscoveryInformation>);
+      ) as _i17.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i16.Future<
+  _i17.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4340,7 +4374,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i16.Future<
+        returnValue: _i17.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4348,7 +4382,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_28(
+          _FakeGetVersionsResponse_29(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4363,7 +4397,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i16.Future<
+        returnValueForMissingStub: _i17.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4371,7 +4405,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_28(
+          _FakeGetVersionsResponse_29(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4386,7 +4420,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i16.Future<
+      ) as _i17.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4395,7 +4429,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i16.Future<_i4.DiscoveryInformation> getWellknown({
+  _i17.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4408,8 +4442,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getWellknown,
@@ -4420,8 +4454,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getWellknown,
@@ -4432,10 +4466,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.DiscoveryInformation>);
+      ) as _i17.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i16.Future<_i4.RegisterResponse> register({
+  _i17.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4463,7 +4497,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_29(
+            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_30(
           this,
           Invocation.method(
             #register,
@@ -4482,7 +4516,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_29(
+            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_30(
           this,
           Invocation.method(
             #register,
@@ -4500,10 +4534,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RegisterResponse>);
+      ) as _i17.Future<_i4.RegisterResponse>);
 
   @override
-  _i16.Future<_i4.LoginResponse> login(
+  _i17.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4533,7 +4567,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_30(
+        returnValue: _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_31(
           this,
           Invocation.method(
             #login,
@@ -4553,7 +4587,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_30(
+            _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_31(
           this,
           Invocation.method(
             #login,
@@ -4572,10 +4606,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.LoginResponse>);
+      ) as _i17.Future<_i4.LoginResponse>);
 
   @override
-  _i16.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i17.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4588,8 +4622,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_31(
+        returnValue: _i17.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_32(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4601,8 +4635,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_31(
+            _i17.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_32(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4613,74 +4647,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i17.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i16.Future<void> logout() => (super.noSuchMethod(
+  _i17.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> logoutAll() => (super.noSuchMethod(
+  _i17.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<T> uiaRequestBackground<T>(
-          _i16.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i17.Future<T> uiaRequestBackground<T>(
+          _i17.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i16.Future<T>.value(v),
+              (T v) => _i17.Future<T>.value(v),
             ) ??
-            _FakeFuture_32<T>(
+            _FakeFuture_33<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i16.Future<T>.value(v),
+              (T v) => _i17.Future<T>.value(v),
             ) ??
-            _FakeFuture_32<T>(
+            _FakeFuture_33<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i16.Future<T>);
+      ) as _i17.Future<T>);
 
   @override
-  _i16.Future<String> startDirectChat(
+  _i17.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4702,7 +4736,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4718,7 +4752,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4733,10 +4767,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<String> createGroupChat({
+  _i17.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4767,7 +4801,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4788,7 +4822,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4808,10 +4842,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i17.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4827,7 +4861,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4840,7 +4874,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4852,21 +4886,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i17.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<String> createSpace({
+  _i17.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4891,7 +4925,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4909,7 +4943,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4926,10 +4960,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i17.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4937,7 +4971,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4946,7 +4980,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4954,10 +4988,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i16.Future<_i4.Profile> fetchOwnProfile({
+  _i17.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4970,7 +5004,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4982,7 +5016,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4993,10 +5027,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i16.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i17.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -5010,8 +5044,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i16.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_33(
+        returnValue: _i17.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_34(
           this,
           Invocation.method(
             #getUserProfile,
@@ -5023,8 +5057,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_33(
+            _i17.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_34(
           this,
           Invocation.method(
             #getUserProfile,
@@ -5035,10 +5069,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.CachedProfileInformation>);
+      ) as _i17.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i16.Future<_i4.Profile> getProfileFromUserId(
+  _i17.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -5056,7 +5090,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5070,7 +5104,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5083,7 +5117,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -5105,31 +5139,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i16.Future<List<_i4.Room>>);
+            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i17.Future<List<_i4.Room>>);
 
   @override
-  _i16.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i17.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i16.Future<List<_i4.ArchivedRoom>>);
+            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i17.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i16.Future<_i4.GetVersionsResponse> getVersions({
+  _i17.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5142,8 +5176,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_28(
+        returnValue: _i17.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_29(
           this,
           Invocation.method(
             #getVersions,
@@ -5154,8 +5188,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_28(
+        returnValueForMissingStub: _i17.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_29(
           this,
           Invocation.method(
             #getVersions,
@@ -5166,20 +5200,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetVersionsResponse>);
+      ) as _i17.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i16.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i17.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.MediaConfig> getConfig({
+  _i17.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5192,7 +5226,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfig,
@@ -5204,7 +5238,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfig,
@@ -5215,10 +5249,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.MediaConfig>);
+      ) as _i17.Future<_i4.MediaConfig>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContent(
+  _i17.Future<_i18.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5238,7 +5272,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContent,
@@ -5254,7 +5288,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContent,
@@ -5269,10 +5303,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentOverrideName(
+  _i17.Future<_i18.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5294,7 +5328,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5311,7 +5345,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5327,10 +5361,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentThumbnail(
+  _i17.Future<_i18.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5358,7 +5392,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5378,7 +5412,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5397,10 +5431,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i17.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5410,7 +5444,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5419,7 +5453,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5427,11 +5461,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i16.Future<_i4.PreviewForUrl>);
+      ) as _i17.Future<_i4.PreviewForUrl>);
 
   @override
-  _i16.Future<Uri> uploadContent(
-    _i26.Uint8List? file, {
+  _i17.Future<Uri> uploadContent(
+    _i27.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5444,7 +5478,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValue: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #uploadContent,
@@ -5455,7 +5489,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #uploadContent,
@@ -5466,10 +5500,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<Uri>);
+      ) as _i17.Future<Uri>);
 
   @override
-  _i16.Future<void> setTyping(
+  _i17.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5485,42 +5519,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> exportDump() => (super.noSuchMethod(
+  _i17.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i17.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i17.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Event?> getEventByPushNotification(
+  _i17.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5536,12 +5570,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
-  _i16.Future<void> init({
+  _i17.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5576,9 +5610,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5590,40 +5624,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<void> clear() => (super.noSuchMethod(
+  _i17.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i17.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ensureNotSoftLoggedOut(
+  _i17.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> handleSync(
+  _i17.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5633,9 +5667,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5648,29 +5682,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i16.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i17.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i17.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDevice(
+  _i17.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5684,12 +5718,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDevicesOfUserIds(
+  _i17.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5705,12 +5739,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDeviceEncrypted(
+  _i17.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5730,12 +5764,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDeviceEncryptedChunked(
+  _i17.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5749,23 +5783,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i17.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> joinRoom(
+  _i17.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5783,7 +5817,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5797,7 +5831,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5810,10 +5844,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> changePassword(
+  _i17.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5829,22 +5863,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> clearCache() => (super.noSuchMethod(
+  _i17.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ignoreUser(
+  _i17.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5854,22 +5888,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i17.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i17.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5880,7 +5914,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_37(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_38(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5889,7 +5923,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_37(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_38(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5897,32 +5931,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i16.Future<_i4.CachedPresence>);
+      ) as _i17.Future<_i4.CachedPresence>);
 
   @override
-  _i16.Future<void> abortSync() => (super.noSuchMethod(
+  _i17.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i17.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEventWithMetadata(
+  _i17.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5942,14 +5976,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i15.BaseResponse? response,
-    _i26.Uint8List? body,
+    _i16.BaseResponse? response,
+    _i27.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5981,7 +6015,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i16.Future<Map<String, Object?>> request(
+  _i17.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -6002,13 +6036,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> postPusher(
+  _i17.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -6018,57 +6052,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i17.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i17.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i17.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i16.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_38(
+        returnValue: _i17.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_39(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_38(
+        returnValueForMissingStub: _i17.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_39(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.TurnServerCredentials>);
+      ) as _i17.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6082,8 +6116,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6095,8 +6129,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6107,10 +6141,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6126,8 +6160,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6140,8 +6174,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6153,10 +6187,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i17.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6170,7 +6204,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6182,7 +6216,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6193,17 +6227,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.KeyBackupData>);
+      ) as _i17.Future<_i4.KeyBackupData>);
 
   @override
-  _i16.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i17.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i16.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_41(
+        returnValue: _i17.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_42(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6211,18 +6245,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_41(
+            _i17.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_42(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i17.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i16.Future<int> pingAppservice(
+  _i17.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6232,12 +6266,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
-  _i16.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i17.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6245,8 +6279,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_42(
+        returnValue: _i17.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_43(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6255,8 +6289,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_42(
+            _i17.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_43(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6264,15 +6298,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i16.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i17.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i16.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i17.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6280,17 +6314,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.MediaConfig>);
+      ) as _i17.Future<_i4.MediaConfig>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentAuthed(
+  _i17.Future<_i18.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6304,7 +6338,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6316,7 +6350,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6327,10 +6361,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentOverrideNameAuthed(
+  _i17.Future<_i18.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6346,7 +6380,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6359,7 +6393,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6371,10 +6405,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i17.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6384,7 +6418,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6393,7 +6427,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6401,10 +6435,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i16.Future<_i4.PreviewForUrl>);
+      ) as _i17.Future<_i4.PreviewForUrl>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentThumbnailAuthed(
+  _i17.Future<_i18.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6428,7 +6462,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6446,7 +6480,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6463,21 +6497,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<bool> registrationTokenValidity(String? token) =>
+  _i17.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i17.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6487,8 +6521,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_43(
+        returnValue: _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_44(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6497,8 +6531,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_43(
+            _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_44(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6506,10 +6540,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i17.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i16.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i17.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6527,8 +6561,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_44(
+        returnValue: _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_45(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6542,8 +6576,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_44(
+            _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_45(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6556,10 +6590,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i17.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i17.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6583,8 +6617,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i16.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_45(
+        returnValue: _i17.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_46(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6602,8 +6636,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_45(
+            _i17.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_46(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6620,10 +6654,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i17.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6651,8 +6685,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_46(
+                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_47(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6671,8 +6705,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_46(
+                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_47(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6690,10 +6724,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i17.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6722,9 +6756,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i16.Future<
+            returnValue: _i17.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6743,9 +6777,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i16.Future<
+            returnValueForMissingStub: _i17.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6764,11 +6798,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i16
+          ) as _i17
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i16.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i17.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6784,8 +6818,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i16.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_48(
+        returnValue: _i17.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_49(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6798,8 +6832,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_48(
+            _i17.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_49(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6811,10 +6845,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetThreadRootsResponse>);
+      ) as _i17.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i16.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i17.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6828,8 +6862,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i16.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_49(
+        returnValue: _i17.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_50(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6841,8 +6875,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_49(
+            _i17.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_50(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6853,33 +6887,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i17.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i17.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i16.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i17.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i16.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i17.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i16.Future<Uri?>.value(),
-        returnValueForMissingStub: _i16.Future<Uri?>.value(),
-      ) as _i16.Future<Uri?>);
+        returnValue: _i17.Future<Uri?>.value(),
+        returnValueForMissingStub: _i17.Future<Uri?>.value(),
+      ) as _i17.Future<Uri?>);
 
   @override
-  _i16.Future<void> add3PID(
+  _i17.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6893,12 +6927,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> bind3PID(
+  _i17.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6914,12 +6948,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i17.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6933,14 +6967,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6962,8 +6996,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6979,8 +7013,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6996,10 +7030,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7023,8 +7057,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -7041,8 +7075,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -7059,10 +7093,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i17.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -7076,14 +7110,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i17.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -7098,14 +7132,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7127,8 +7161,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7144,8 +7178,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7161,10 +7195,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7188,8 +7222,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7206,8 +7240,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7224,16 +7258,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i17.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_51(
+            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_52(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7241,22 +7275,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_51(
+            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_52(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.TokenOwnerInfo>);
+      ) as _i17.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i16.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i17.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_52(
+        returnValue: _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_53(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7264,22 +7298,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_52(
+            _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_53(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i16.Future<_i4.WhoIsInfo>);
+      ) as _i17.Future<_i4.WhoIsInfo>);
 
   @override
-  _i16.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i17.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_53(
+        returnValue: _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_54(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7287,17 +7321,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_53(
+            _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_54(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.Capabilities>);
+      ) as _i17.Future<_i4.Capabilities>);
 
   @override
-  _i16.Future<String> createRoom({
+  _i17.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7330,7 +7364,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7352,7 +7386,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7373,10 +7407,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> deleteDevices(
+  _i17.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7386,22 +7420,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.Device>?>.value(),
-      ) as _i16.Future<List<_i4.Device>?>);
+        returnValue: _i17.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.Device>?>.value(),
+      ) as _i17.Future<List<_i4.Device>?>);
 
   @override
-  _i16.Future<void> deleteDevice(
+  _i17.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7411,34 +7445,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i17.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i16.Future<_i4.Device>.value(_FakeDevice_54(
+        returnValue: _i17.Future<_i4.Device>.value(_FakeDevice_55(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.Device>.value(_FakeDevice_54(
+        returnValueForMissingStub: _i17.Future<_i4.Device>.value(_FakeDevice_55(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i16.Future<_i4.Device>);
+      ) as _i17.Future<_i4.Device>);
 
   @override
-  _i16.Future<void> updateDevice(
+  _i17.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7448,12 +7482,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i17.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7468,24 +7502,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i17.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i16.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Visibility?>.value(),
-      ) as _i16.Future<_i4.Visibility?>);
+        returnValue: _i17.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Visibility?>.value(),
+      ) as _i17.Future<_i4.Visibility?>);
 
   @override
-  _i16.Future<void> setRoomVisibilityOnDirectory(
+  _i17.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7495,30 +7529,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i17.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i17.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_55(
+        returnValue: _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_56(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7526,18 +7560,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_55(
+            _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_56(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i17.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i16.Future<void> setRoomAlias(
+  _i17.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7549,12 +7583,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetEventsResponse> getEvents({
+  _i17.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7568,7 +7602,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_56(
+            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_57(
           this,
           Invocation.method(
             #getEvents,
@@ -7580,7 +7614,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_56(
+            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_57(
           this,
           Invocation.method(
             #getEvents,
@@ -7591,10 +7625,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetEventsResponse>);
+      ) as _i17.Future<_i4.GetEventsResponse>);
 
   @override
-  _i16.Future<_i4.PeekEventsResponse> peekEvents({
+  _i17.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7609,8 +7643,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i16.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_57(
+        returnValue: _i17.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_58(
           this,
           Invocation.method(
             #peekEvents,
@@ -7622,8 +7656,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_57(
+        returnValueForMissingStub: _i17.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_58(
           this,
           Invocation.method(
             #peekEvents,
@@ -7635,16 +7669,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.PeekEventsResponse>);
+      ) as _i17.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i16.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i17.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7652,27 +7686,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i16.Future<_i4.MatrixEvent>);
+      ) as _i17.Future<_i4.MatrixEvent>);
 
   @override
-  _i16.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i17.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 
   @override
-  _i16.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i17.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7684,8 +7718,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i16.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_59(
+        returnValue: _i17.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_60(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7696,8 +7730,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_59(
+            _i17.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_60(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7707,10 +7741,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.GetKeysChangesResponse>);
+      ) as _i17.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i16.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i17.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7721,7 +7755,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_60(
+            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_61(
           this,
           Invocation.method(
             #claimKeys,
@@ -7730,7 +7764,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_60(
+            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_61(
           this,
           Invocation.method(
             #claimKeys,
@@ -7738,10 +7772,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i16.Future<_i4.ClaimKeysResponse>);
+      ) as _i17.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i16.Future<void> uploadCrossSigningKeys({
+  _i17.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7758,12 +7792,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.QueryKeysResponse> queryKeys(
+  _i17.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7774,7 +7808,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_61(
+            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_62(
           this,
           Invocation.method(
             #queryKeys,
@@ -7783,7 +7817,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_61(
+            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_62(
           this,
           Invocation.method(
             #queryKeys,
@@ -7791,10 +7825,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i16.Future<_i4.QueryKeysResponse>);
+      ) as _i17.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7802,14 +7836,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i16.Future<
+            returnValue: _i17.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i16.Future<
+            returnValueForMissingStub: _i17.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i16.Future<Map<String, int>> uploadKeys({
+  _i17.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7824,13 +7858,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i16.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i17.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i16.Future<Map<String, int>>);
+            _i17.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i17.Future<Map<String, int>>);
 
   @override
-  _i16.Future<String> knockRoom(
+  _i17.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7844,7 +7878,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7856,7 +7890,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7867,20 +7901,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i17.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i16.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i17.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i17.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i16.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i17.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7895,8 +7929,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i16.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_62(
+        returnValue: _i17.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_63(
           this,
           Invocation.method(
             #getNotifications,
@@ -7909,8 +7943,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_62(
+            _i17.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_63(
           this,
           Invocation.method(
             #getNotifications,
@@ -7922,35 +7956,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetNotificationsResponse>);
+      ) as _i17.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i16.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i17.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i16.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_63(
+        returnValue: _i17.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_64(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_63(
+        returnValueForMissingStub: _i17.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_64(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i16.Future<_i4.GetPresenceResponse>);
+      ) as _i17.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i16.Future<void> setPresence(
+  _i17.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7964,12 +7998,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, Object?>> deleteProfileField(
+  _i17.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7982,13 +8016,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getProfileField(
+  _i17.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -8001,13 +8035,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<Map<String, Object?>> setProfileField(
+  _i17.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -8022,13 +8056,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i17.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -8043,8 +8077,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i16.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_64(
+        returnValue: _i17.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_65(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -8057,8 +8091,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_64(
+            _i17.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_65(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -8070,10 +8104,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i17.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i16.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i17.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -8094,8 +8128,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i16.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_65(
+        returnValue: _i17.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_66(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8111,8 +8145,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_65(
+            _i17.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_66(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8127,25 +8161,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i17.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i16.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.Pusher>?>.value(),
-      ) as _i16.Future<List<_i4.Pusher>?>);
+        returnValue: _i17.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.Pusher>?>.value(),
+      ) as _i17.Future<List<_i4.Pusher>?>);
 
   @override
-  _i16.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i17.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_66(
+        returnValue: _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_67(
           this,
           Invocation.method(
             #getPushRules,
@@ -8153,24 +8187,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_66(
+            _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_67(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.PushRuleSet>);
+      ) as _i17.Future<_i4.PushRuleSet>);
 
   @override
-  _i16.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i17.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_67(
+        returnValue: _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_68(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8178,18 +8212,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_67(
+            _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_68(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i17.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i16.Future<void> deletePushRule(
+  _i17.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8201,12 +8235,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.PushRule> getPushRule(
+  _i17.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8218,7 +8252,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<_i4.PushRule>.value(_FakePushRule_68(
+        returnValue: _i17.Future<_i4.PushRule>.value(_FakePushRule_69(
           this,
           Invocation.method(
             #getPushRule,
@@ -8229,7 +8263,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PushRule>.value(_FakePushRule_68(
+            _i17.Future<_i4.PushRule>.value(_FakePushRule_69(
           this,
           Invocation.method(
             #getPushRule,
@@ -8239,10 +8273,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.PushRule>);
+      ) as _i17.Future<_i4.PushRule>);
 
   @override
-  _i16.Future<void> setPushRule(
+  _i17.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8266,12 +8300,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<Object?>> getPushRuleActions(
+  _i17.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8283,13 +8317,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i17.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i16.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i16.Future<List<Object?>>);
+            _i17.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i17.Future<List<Object?>>);
 
   @override
-  _i16.Future<void> setPushRuleActions(
+  _i17.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8303,12 +8337,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<bool> isPushRuleEnabled(
+  _i17.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8320,12 +8354,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> setPushRuleEnabled(
+  _i17.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8339,19 +8373,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i17.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_69(
+            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_70(
           this,
           Invocation.method(
             #refresh,
@@ -8359,28 +8393,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_69(
+            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_70(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i16.Future<_i4.RefreshResponse>);
+      ) as _i17.Future<_i4.RefreshResponse>);
 
   @override
-  _i16.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i17.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i16.Future<bool?>.value(),
-        returnValueForMissingStub: _i16.Future<bool?>.value(),
-      ) as _i16.Future<bool?>);
+        returnValue: _i17.Future<bool?>.value(),
+        returnValueForMissingStub: _i17.Future<bool?>.value(),
+      ) as _i17.Future<bool?>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8402,8 +8436,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8419,8 +8453,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8436,10 +8470,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8463,8 +8497,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8481,8 +8515,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8499,17 +8533,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8517,23 +8551,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i17.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_70(
+        returnValue: _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_71(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8541,17 +8575,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_70(
+            _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_71(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeys>);
+      ) as _i17.Future<_i4.RoomKeys>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8563,8 +8597,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8575,8 +8609,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8586,10 +8620,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8601,8 +8635,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8613,8 +8647,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8624,10 +8658,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8639,7 +8673,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_71(
+        returnValue: _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_72(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8650,7 +8684,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_71(
+            _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_72(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8660,10 +8694,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeyBackup>);
+      ) as _i17.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8677,8 +8711,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8690,8 +8724,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8702,10 +8736,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8719,8 +8753,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8732,8 +8766,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8744,10 +8778,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i17.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8761,7 +8795,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8773,7 +8807,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8784,10 +8818,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.KeyBackupData>);
+      ) as _i17.Future<_i4.KeyBackupData>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8803,8 +8837,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8817,8 +8851,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8830,18 +8864,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_72(
+                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_73(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8849,18 +8883,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_72(
+                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_73(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i16.Future<String> postRoomKeysVersion(
+  _i17.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8872,7 +8906,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8883,7 +8917,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8893,29 +8927,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i17.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i17.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_73(
+        returnValue: _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_74(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8923,18 +8957,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_73(
+            _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_74(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i17.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i17.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8949,24 +8983,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i17.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 
   @override
-  _i16.Future<void> ban(
+  _i17.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8980,12 +9014,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.EventContext> getEventContext(
+  _i17.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -9003,7 +9037,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<_i4.EventContext>.value(_FakeEventContext_74(
+        returnValue: _i17.Future<_i4.EventContext>.value(_FakeEventContext_75(
           this,
           Invocation.method(
             #getEventContext,
@@ -9018,7 +9052,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.EventContext>.value(_FakeEventContext_74(
+            _i17.Future<_i4.EventContext>.value(_FakeEventContext_75(
           this,
           Invocation.method(
             #getEventContext,
@@ -9032,10 +9066,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.EventContext>);
+      ) as _i17.Future<_i4.EventContext>);
 
   @override
-  _i16.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i17.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -9047,7 +9081,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -9058,7 +9092,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -9068,20 +9102,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.MatrixEvent>);
+      ) as _i17.Future<_i4.MatrixEvent>);
 
   @override
-  _i16.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> inviteBy3PID(
+  _i17.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -9093,12 +9127,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> inviteUser(
+  _i17.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9112,12 +9146,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> joinRoomById(
+  _i17.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -9131,7 +9165,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9143,7 +9177,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9154,23 +9188,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i17.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i17.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i16.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i16.Future<Map<String, _i4.RoomMember>?>);
+            _i17.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i17.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i16.Future<void> kick(
+  _i17.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9184,12 +9218,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leaveRoom(
+  _i17.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9199,12 +9233,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i17.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9220,12 +9254,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i16.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i16.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i17.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i17.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i16.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i17.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9247,8 +9281,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_75(
+        returnValue: _i17.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_76(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9264,8 +9298,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_75(
+        returnValueForMissingStub: _i17.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_76(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9281,10 +9315,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomEventsResponse>);
+      ) as _i17.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i16.Future<void> setReadMarker(
+  _i17.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9300,12 +9334,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> postReceipt(
+  _i17.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9321,12 +9355,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEvent(
+  _i17.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9342,12 +9376,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> reportRoom(
+  _i17.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9359,12 +9393,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> reportEvent(
+  _i17.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9382,12 +9416,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> sendMessage(
+  _i17.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9403,7 +9437,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9416,7 +9450,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9428,23 +9462,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i17.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i16.Future<List<_i4.MatrixEvent>>);
+            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i17.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i17.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9461,13 +9495,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<String> setRoomStateWithKey(
+  _i17.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9483,7 +9517,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9496,7 +9530,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9508,10 +9542,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> unban(
+  _i17.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9525,12 +9559,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> upgradeRoom(
+  _i17.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9544,7 +9578,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9556,7 +9590,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9567,10 +9601,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.SearchResults> search(
+  _i17.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9580,7 +9614,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_76(
+        returnValue: _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_77(
           this,
           Invocation.method(
             #search,
@@ -9589,7 +9623,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_76(
+            _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_77(
           this,
           Invocation.method(
             #search,
@@ -9597,10 +9631,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i16.Future<_i4.SearchResults>);
+      ) as _i17.Future<_i4.SearchResults>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> sync({
+  _i17.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9621,7 +9655,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #sync,
@@ -9637,7 +9671,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #sync,
@@ -9652,22 +9686,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i17.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i16.Future<List<_i4.Location>>);
+            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i17.Future<List<_i4.Location>>);
 
   @override
-  _i16.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i17.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9677,21 +9711,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i16.Future<List<_i4.Location>>);
+            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i17.Future<List<_i4.Location>>);
 
   @override
-  _i16.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i17.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_77(
+        returnValue: _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_78(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9699,45 +9733,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_77(
+            _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_78(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i16.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i17.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i16.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i17.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9748,13 +9782,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getAccountData(
+  _i17.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9767,13 +9801,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> setAccountData(
+  _i17.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9787,12 +9821,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> defineFilter(
+  _i17.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9804,7 +9838,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9815,7 +9849,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9825,10 +9859,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.Filter> getFilter(
+  _i17.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9840,7 +9874,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i16.Future<_i4.Filter>.value(_FakeFilter_21(
+        returnValue: _i17.Future<_i4.Filter>.value(_FakeFilter_22(
           this,
           Invocation.method(
             #getFilter,
@@ -9850,7 +9884,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.Filter>.value(_FakeFilter_21(
+        returnValueForMissingStub: _i17.Future<_i4.Filter>.value(_FakeFilter_22(
           this,
           Invocation.method(
             #getFilter,
@@ -9860,10 +9894,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.Filter>);
+      ) as _i17.Future<_i4.Filter>);
 
   @override
-  _i16.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i17.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9876,7 +9910,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_78(
+            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_79(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9887,7 +9921,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_78(
+            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_79(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9897,10 +9931,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.OpenIdCredentials>);
+      ) as _i17.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i16.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i17.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9915,13 +9949,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> setAccountDataPerRoom(
+  _i17.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9937,12 +9971,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i17.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9954,12 +9988,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i16.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i16.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i16.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i17.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i17.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i17.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i16.Future<void> deleteRoomTag(
+  _i17.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9973,12 +10007,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setRoomTag(
+  _i17.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9994,12 +10028,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i17.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -10009,8 +10043,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i16.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_79(
+        returnValue: _i17.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_80(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -10019,8 +10053,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_79(
+            _i17.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_80(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -10028,10 +10062,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i16.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i17.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> reportUser(
+  _i17.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -10044,40 +10078,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i17.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i16.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_80(
+        returnValue: _i17.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_81(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_80(
+        returnValueForMissingStub: _i17.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_81(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.CreateContentResponse>);
+      ) as _i17.Future<_i4.CreateContentResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> uploadContentToMXC(
+  _i17.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i26.Uint8List? body, {
+    _i27.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10095,8 +10129,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 }

--- a/test/widgets/admin_settings_section_test.mocks.dart
+++ b/test/widgets/admin_settings_section_test.mocks.dart
@@ -4,15 +4,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i22;
-import 'dart:ui' as _i24;
+import 'dart:typed_data' as _i23;
+import 'dart:ui' as _i25;
 
-import 'package:flutter/services.dart' as _i25;
-import 'package:flutter/widgets.dart' as _i26;
+import 'package:flutter/services.dart' as _i26;
+import 'package:flutter/widgets.dart' as _i27;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/models/join_mode.dart' as _i27;
-import 'package:kohera/core/services/matrix_service.dart' as _i23;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/models/join_mode.dart' as _i28;
+import 'package:kohera/core/services/matrix_service.dart' as _i24;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -29,14 +29,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i21;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i22;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i20;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i19;
+import 'package:matrix/src/utils/space_child.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i18;
+import 'package:mockito/src/dummies.dart' as _i19;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -902,9 +903,9 @@ class _FakeOutboxService_79 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_80 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_80(
+class _FakeAvatarResolver_80 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -913,8 +914,19 @@ class _FakeStickerPackService_80 extends _i1.SmartFake
         );
 }
 
-class _FakeStateEvent_81 extends _i1.SmartFake implements _i2.StateEvent {
-  _FakeStateEvent_81(
+class _FakeStickerPackService_81 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_81(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeStateEvent_82 extends _i1.SmartFake implements _i2.StateEvent {
+  _FakeStateEvent_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -930,11 +942,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1021,11 +1033,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -1061,11 +1073,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1081,11 +1093,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1094,11 +1106,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1141,11 +1153,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1411,18 +1423,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i19.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i19.SpaceParent>[],
-        returnValueForMissingStub: <_i19.SpaceParent>[],
-      ) as List<_i19.SpaceParent>);
+        returnValue: <_i20.SpaceParent>[],
+        returnValueForMissingStub: <_i20.SpaceParent>[],
+      ) as List<_i20.SpaceParent>);
 
   @override
-  List<_i19.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i19.SpaceChild>[],
-        returnValueForMissingStub: <_i19.SpaceChild>[],
-      ) as List<_i19.SpaceChild>);
+        returnValue: <_i20.SpaceChild>[],
+        returnValueForMissingStub: <_i20.SpaceChild>[],
+      ) as List<_i20.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -1589,14 +1601,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -1644,7 +1656,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -1652,7 +1664,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -1667,7 +1679,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -1675,7 +1687,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -1769,7 +1781,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -1777,7 +1789,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2019,7 +2031,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2030,7 +2042,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2119,15 +2131,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i20.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i20.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i20.TimelineChunk?>.value(),
-      ) as _i5.Future<_i20.TimelineChunk?>);
+        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
+      ) as _i5.Future<_i21.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -2335,7 +2347,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2343,7 +2355,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2666,12 +2678,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i21.KeyVerificationMethod> get verificationMethods =>
+  Set<_i22.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i21.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
-      ) as Set<_i21.KeyVerificationMethod>);
+        returnValue: <_i22.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
+      ) as Set<_i22.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -2791,11 +2803,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -2832,11 +2844,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -2866,11 +2878,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -2879,11 +2891,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3170,34 +3182,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_1<_i21.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_1<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_1<_i21.RoomKeyRequest>(
+            _FakeCachedStreamController_1<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i21.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i22.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i21.KeyVerification>
+  _i3.CachedStreamController<_i22.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_1<_i21.KeyVerification>(
+            returnValue: _FakeCachedStreamController_1<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_1<_i21.KeyVerification>(
+                _FakeCachedStreamController_1<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i21.KeyVerification>);
+          ) as _i3.CachedStreamController<_i22.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -3353,7 +3365,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3642,14 +3654,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4037,8 +4049,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValue: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -4054,8 +4066,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -4096,7 +4108,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4112,7 +4124,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4161,7 +4173,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4182,7 +4194,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4285,7 +4297,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4303,7 +4315,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4825,7 +4837,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i22.Uint8List? file, {
+    _i23.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5177,7 +5189,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5191,7 +5203,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5342,7 +5354,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i22.Uint8List? body,
+    _i23.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6720,7 +6732,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -6742,7 +6754,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7236,7 +7248,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7248,7 +7260,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -8256,7 +8268,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8267,7 +8279,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8515,7 +8527,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8527,7 +8539,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8787,7 +8799,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -8800,7 +8812,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -8867,7 +8879,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -8880,7 +8892,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -8928,7 +8940,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -8940,7 +8952,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9188,7 +9200,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9199,7 +9211,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9461,7 +9473,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i22.Uint8List? body, {
+    _i23.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9488,7 +9500,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -9518,11 +9530,11 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -9660,17 +9672,30 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_80(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_80(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_80(
+        returnValue: _FakeStickerPackService_81(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_80(
+        returnValueForMissingStub: _FakeStickerPackService_81(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -9779,7 +9804,16 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -9832,7 +9866,7 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i24.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i25.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -9928,7 +9962,7 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i24.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i25.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -9937,7 +9971,7 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       );
 
   @override
-  void removeListener(_i24.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i25.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -9956,7 +9990,7 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i25.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i26.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -9967,7 +10001,7 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i25.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i26.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -10015,7 +10049,7 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i26.RouteInformation? routeInformation) =>
+          _i27.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -10053,7 +10087,7 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i24.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i25.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -10062,7 +10096,7 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i24.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i25.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -10071,16 +10105,16 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       );
 
   @override
-  _i5.Future<_i24.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i25.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
+            _i5.Future<_i25.AppExitResponse>.value(_i25.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
-      ) as _i5.Future<_i24.AppExitResponse>);
+            _i5.Future<_i25.AppExitResponse>.value(_i25.AppExitResponse.exit),
+      ) as _i5.Future<_i25.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -10107,14 +10141,14 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
 class MockSpaceAccessService extends _i1.Mock
     implements _i13.SpaceAccessService {
   @override
-  _i27.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
+  _i28.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
         Invocation.method(
           #getJoinMode,
           [room],
         ),
-        returnValue: _i27.JoinMode.invite,
-        returnValueForMissingStub: _i27.JoinMode.invite,
-      ) as _i27.JoinMode);
+        returnValue: _i28.JoinMode.invite,
+        returnValueForMissingStub: _i28.JoinMode.invite,
+      ) as _i28.JoinMode);
 
   @override
   List<String> allowedSpaceIds(_i2.Room? room) => (super.noSuchMethod(
@@ -10198,7 +10232,7 @@ class MockSpaceAccessService extends _i1.Mock
   @override
   _i5.Future<void> applyJoinMode({
     required String? roomId,
-    required _i27.JoinMode? mode,
+    required _i28.JoinMode? mode,
     List<String>? allowSpaceIds = const [],
   }) =>
       (super.noSuchMethod(
@@ -10217,7 +10251,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   Map<String, Object?> buildJoinRulesPayload(
-    _i27.JoinMode? mode,
+    _i28.JoinMode? mode,
     List<String>? allowSpaceIds, {
     List<Map<String, Object?>>? preserveEntries = const [],
   }) =>
@@ -10236,7 +10270,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   _i2.StateEvent buildJoinRulesStateEvent(
-    _i27.JoinMode? mode,
+    _i28.JoinMode? mode,
     List<String>? allowSpaceIds,
   ) =>
       (super.noSuchMethod(
@@ -10247,7 +10281,7 @@ class MockSpaceAccessService extends _i1.Mock
             allowSpaceIds,
           ],
         ),
-        returnValue: _FakeStateEvent_81(
+        returnValue: _FakeStateEvent_82(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -10257,7 +10291,7 @@ class MockSpaceAccessService extends _i1.Mock
             ],
           ),
         ),
-        returnValueForMissingStub: _FakeStateEvent_81(
+        returnValueForMissingStub: _FakeStateEvent_82(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -10282,7 +10316,7 @@ class MockSpaceAccessService extends _i1.Mock
             newVersion,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,
@@ -10293,7 +10327,7 @@ class MockSpaceAccessService extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,

--- a/test/widgets/bootstrap_controller_test.mocks.dart
+++ b/test/widgets/bootstrap_controller_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i23;
-import 'dart:ui' as _i25;
+import 'dart:typed_data' as _i24;
+import 'dart:ui' as _i26;
 
-import 'package:flutter/services.dart' as _i26;
-import 'package:flutter/widgets.dart' as _i27;
+import 'package:flutter/services.dart' as _i27;
+import 'package:flutter/widgets.dart' as _i28;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i24;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i25;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,15 +28,16 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
-import 'package:matrix/encryption/cross_signing.dart' as _i21;
-import 'package:matrix/encryption/key_verification_manager.dart' as _i20;
-import 'package:matrix/encryption/olm_manager.dart' as _i19;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
+import 'package:matrix/encryption/cross_signing.dart' as _i22;
+import 'package:matrix/encryption/key_verification_manager.dart' as _i21;
+import 'package:matrix/encryption/olm_manager.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i22;
+import 'package:mockito/src/dummies.dart' as _i23;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -861,9 +862,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -872,8 +873,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyManager_77 extends _i1.SmartFake implements _i18.KeyManager {
-  _FakeKeyManager_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -882,8 +884,8 @@ class _FakeKeyManager_77 extends _i1.SmartFake implements _i18.KeyManager {
         );
 }
 
-class _FakeOlmManager_78 extends _i1.SmartFake implements _i19.OlmManager {
-  _FakeOlmManager_78(
+class _FakeKeyManager_78 extends _i1.SmartFake implements _i19.KeyManager {
+  _FakeKeyManager_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,9 +894,8 @@ class _FakeOlmManager_78 extends _i1.SmartFake implements _i19.OlmManager {
         );
 }
 
-class _FakeKeyVerificationManager_79 extends _i1.SmartFake
-    implements _i20.KeyVerificationManager {
-  _FakeKeyVerificationManager_79(
+class _FakeOlmManager_79 extends _i1.SmartFake implements _i20.OlmManager {
+  _FakeOlmManager_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -903,8 +904,9 @@ class _FakeKeyVerificationManager_79 extends _i1.SmartFake
         );
 }
 
-class _FakeCrossSigning_80 extends _i1.SmartFake implements _i21.CrossSigning {
-  _FakeCrossSigning_80(
+class _FakeKeyVerificationManager_80 extends _i1.SmartFake
+    implements _i21.KeyVerificationManager {
+  _FakeKeyVerificationManager_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -913,8 +915,8 @@ class _FakeCrossSigning_80 extends _i1.SmartFake implements _i21.CrossSigning {
         );
 }
 
-class _FakeSSSS_81 extends _i1.SmartFake implements _i18.SSSS {
-  _FakeSSSS_81(
+class _FakeCrossSigning_81 extends _i1.SmartFake implements _i22.CrossSigning {
+  _FakeCrossSigning_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -923,8 +925,8 @@ class _FakeSSSS_81 extends _i1.SmartFake implements _i18.SSSS {
         );
 }
 
-class _FakeBootstrap_82 extends _i1.SmartFake implements _i18.Bootstrap {
-  _FakeBootstrap_82(
+class _FakeSSSS_82 extends _i1.SmartFake implements _i19.SSSS {
+  _FakeSSSS_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -933,8 +935,8 @@ class _FakeBootstrap_82 extends _i1.SmartFake implements _i18.Bootstrap {
         );
 }
 
-class _FakeToDeviceEvent_83 extends _i1.SmartFake implements _i2.ToDeviceEvent {
-  _FakeToDeviceEvent_83(
+class _FakeBootstrap_83 extends _i1.SmartFake implements _i19.Bootstrap {
+  _FakeBootstrap_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -943,8 +945,8 @@ class _FakeToDeviceEvent_83 extends _i1.SmartFake implements _i2.ToDeviceEvent {
         );
 }
 
-class _FakeEvent_84 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_84(
+class _FakeToDeviceEvent_84 extends _i1.SmartFake implements _i2.ToDeviceEvent {
+  _FakeToDeviceEvent_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -953,8 +955,8 @@ class _FakeEvent_84 extends _i1.SmartFake implements _i2.Event {
         );
 }
 
-class _FakeEncryption_85 extends _i1.SmartFake implements _i18.Encryption {
-  _FakeEncryption_85(
+class _FakeEvent_85 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_85(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -963,9 +965,19 @@ class _FakeEncryption_85 extends _i1.SmartFake implements _i18.Encryption {
         );
 }
 
-class _FakeSecretStorageKeyContent_86 extends _i1.SmartFake
+class _FakeEncryption_86 extends _i1.SmartFake implements _i19.Encryption {
+  _FakeEncryption_86(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeSecretStorageKeyContent_87 extends _i1.SmartFake
     implements _i2.SecretStorageKeyContent {
-  _FakeSecretStorageKeyContent_86(
+  _FakeSecretStorageKeyContent_87(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -992,12 +1004,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1117,11 +1129,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1158,11 +1170,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1192,11 +1204,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1205,11 +1217,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1495,34 +1507,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1678,7 +1690,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1967,14 +1979,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2362,8 +2374,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i22.ifNotNull(
-              _i22.dummyValueOrNull<T>(
+        returnValue: _i23.ifNotNull(
+              _i23.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2379,8 +2391,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i22.ifNotNull(
-              _i22.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i23.ifNotNull(
+              _i23.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2421,7 +2433,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2437,7 +2449,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2486,7 +2498,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2507,7 +2519,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2610,7 +2622,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2628,7 +2640,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3147,7 +3159,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i23.Uint8List? file, {
+    _i24.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3499,7 +3511,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3513,7 +3525,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3664,7 +3676,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i23.Uint8List? body,
+    _i24.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5042,7 +5054,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5064,7 +5076,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5558,7 +5570,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5570,7 +5582,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6578,7 +6590,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6589,7 +6601,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6837,7 +6849,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6849,7 +6861,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7109,7 +7121,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7122,7 +7134,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7189,7 +7201,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7202,7 +7214,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7250,7 +7262,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7262,7 +7274,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7510,7 +7522,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7521,7 +7533,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7783,7 +7795,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i23.Uint8List? body, {
+    _i24.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7810,7 +7822,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7840,11 +7852,11 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7982,17 +7994,30 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8101,7 +8126,16 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8154,7 +8188,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i25.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i26.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8250,7 +8284,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i25.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i26.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8259,7 +8293,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  void removeListener(_i25.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i26.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8278,7 +8312,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i26.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i27.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8289,7 +8323,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i26.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i27.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8337,7 +8371,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i27.RouteInformation? routeInformation) =>
+          _i28.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8375,7 +8409,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i25.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i26.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8384,7 +8418,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i25.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i26.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8393,16 +8427,16 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  _i5.Future<_i25.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i26.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i25.AppExitResponse>.value(_i25.AppExitResponse.exit),
+            _i5.Future<_i26.AppExitResponse>.value(_i26.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i25.AppExitResponse>.value(_i25.AppExitResponse.exit),
-      ) as _i5.Future<_i25.AppExitResponse>);
+            _i5.Future<_i26.AppExitResponse>.value(_i26.AppExitResponse.exit),
+      ) as _i5.Future<_i26.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8542,7 +8576,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> runKeyRecovery({_i18.OpenSSSS? ssssKey}) =>
+  _i5.Future<void> runKeyRecovery({_i19.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
@@ -8596,7 +8630,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i25.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i26.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8605,7 +8639,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       );
 
   @override
-  void removeListener(_i25.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i26.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8635,7 +8669,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
 /// A class which mocks [Encryption].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEncryption extends _i1.Mock implements _i18.Encryption {
+class MockEncryption extends _i1.Mock implements _i19.Encryption {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -8664,85 +8698,85 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
       ) as bool);
 
   @override
-  _i18.KeyManager get keyManager => (super.noSuchMethod(
+  _i19.KeyManager get keyManager => (super.noSuchMethod(
         Invocation.getter(#keyManager),
-        returnValue: _FakeKeyManager_77(
+        returnValue: _FakeKeyManager_78(
           this,
           Invocation.getter(#keyManager),
         ),
-        returnValueForMissingStub: _FakeKeyManager_77(
+        returnValueForMissingStub: _FakeKeyManager_78(
           this,
           Invocation.getter(#keyManager),
         ),
-      ) as _i18.KeyManager);
+      ) as _i19.KeyManager);
 
   @override
-  _i19.OlmManager get olmManager => (super.noSuchMethod(
+  _i20.OlmManager get olmManager => (super.noSuchMethod(
         Invocation.getter(#olmManager),
-        returnValue: _FakeOlmManager_78(
+        returnValue: _FakeOlmManager_79(
           this,
           Invocation.getter(#olmManager),
         ),
-        returnValueForMissingStub: _FakeOlmManager_78(
+        returnValueForMissingStub: _FakeOlmManager_79(
           this,
           Invocation.getter(#olmManager),
         ),
-      ) as _i19.OlmManager);
+      ) as _i20.OlmManager);
 
   @override
-  _i20.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
+  _i21.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
         Invocation.getter(#keyVerificationManager),
-        returnValue: _FakeKeyVerificationManager_79(
+        returnValue: _FakeKeyVerificationManager_80(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-        returnValueForMissingStub: _FakeKeyVerificationManager_79(
+        returnValueForMissingStub: _FakeKeyVerificationManager_80(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-      ) as _i20.KeyVerificationManager);
+      ) as _i21.KeyVerificationManager);
 
   @override
-  _i21.CrossSigning get crossSigning => (super.noSuchMethod(
+  _i22.CrossSigning get crossSigning => (super.noSuchMethod(
         Invocation.getter(#crossSigning),
-        returnValue: _FakeCrossSigning_80(
+        returnValue: _FakeCrossSigning_81(
           this,
           Invocation.getter(#crossSigning),
         ),
-        returnValueForMissingStub: _FakeCrossSigning_80(
+        returnValueForMissingStub: _FakeCrossSigning_81(
           this,
           Invocation.getter(#crossSigning),
         ),
-      ) as _i21.CrossSigning);
+      ) as _i22.CrossSigning);
 
   @override
-  _i18.SSSS get ssss => (super.noSuchMethod(
+  _i19.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_81(
+        returnValue: _FakeSSSS_82(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_81(
+        returnValueForMissingStub: _FakeSSSS_82(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i18.SSSS);
+      ) as _i19.SSSS);
 
   @override
   String get ourDeviceId => (super.noSuchMethod(
         Invocation.getter(#ourDeviceId),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
       ) as String);
 
   @override
-  set keyManager(_i18.KeyManager? value) => super.noSuchMethod(
+  set keyManager(_i19.KeyManager? value) => super.noSuchMethod(
         Invocation.setter(
           #keyManager,
           value,
@@ -8751,7 +8785,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
       );
 
   @override
-  set olmManager(_i19.OlmManager? value) => super.noSuchMethod(
+  set olmManager(_i20.OlmManager? value) => super.noSuchMethod(
         Invocation.setter(
           #olmManager,
           value,
@@ -8760,7 +8794,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
       );
 
   @override
-  set keyVerificationManager(_i20.KeyVerificationManager? value) =>
+  set keyVerificationManager(_i21.KeyVerificationManager? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #keyVerificationManager,
@@ -8770,7 +8804,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
       );
 
   @override
-  set crossSigning(_i21.CrossSigning? value) => super.noSuchMethod(
+  set crossSigning(_i22.CrossSigning? value) => super.noSuchMethod(
         Invocation.setter(
           #crossSigning,
           value,
@@ -8779,7 +8813,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
       );
 
   @override
-  set ssss(_i18.SSSS? value) => super.noSuchMethod(
+  set ssss(_i19.SSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #ssss,
           value,
@@ -8818,14 +8852,14 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
       ) as _i5.Future<void>);
 
   @override
-  _i18.Bootstrap bootstrap({void Function(_i18.Bootstrap)? onUpdate}) =>
+  _i19.Bootstrap bootstrap({void Function(_i19.Bootstrap)? onUpdate}) =>
       (super.noSuchMethod(
         Invocation.method(
           #bootstrap,
           [],
           {#onUpdate: onUpdate},
         ),
-        returnValue: _FakeBootstrap_82(
+        returnValue: _FakeBootstrap_83(
           this,
           Invocation.method(
             #bootstrap,
@@ -8833,7 +8867,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-        returnValueForMissingStub: _FakeBootstrap_82(
+        returnValueForMissingStub: _FakeBootstrap_83(
           this,
           Invocation.method(
             #bootstrap,
@@ -8841,7 +8875,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-      ) as _i18.Bootstrap);
+      ) as _i19.Bootstrap);
 
   @override
   void handleDeviceOneTimeKeysCount(
@@ -8904,7 +8938,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
           #decryptToDeviceEvent,
           [event],
         ),
-        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_83(
+        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_84(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8912,7 +8946,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_83(
+            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_84(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8927,14 +8961,14 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
           #decryptRoomEventSync,
           [event],
         ),
-        returnValue: _FakeEvent_84(
+        returnValue: _FakeEvent_85(
           this,
           Invocation.method(
             #decryptRoomEventSync,
             [event],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_84(
+        returnValueForMissingStub: _FakeEvent_85(
           this,
           Invocation.method(
             #decryptRoomEventSync,
@@ -8958,7 +8992,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
             #updateType: updateType,
           },
         ),
-        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_84(
+        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_85(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8969,7 +9003,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
             },
           ),
         )),
-        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_84(
+        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_85(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -9051,19 +9085,19 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
 /// A class which mocks [Bootstrap].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBootstrap extends _i1.Mock implements _i18.Bootstrap {
+class MockBootstrap extends _i1.Mock implements _i19.Bootstrap {
   @override
-  _i18.Encryption get encryption => (super.noSuchMethod(
+  _i19.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_85(
+        returnValue: _FakeEncryption_86(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_85(
+        returnValueForMissingStub: _FakeEncryption_86(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i18.Encryption);
+      ) as _i19.Encryption);
 
   @override
   _i2.Client get client => (super.noSuchMethod(
@@ -9079,14 +9113,14 @@ class MockBootstrap extends _i1.Mock implements _i18.Bootstrap {
       ) as _i2.Client);
 
   @override
-  _i18.BootstrapState get state => (super.noSuchMethod(
+  _i19.BootstrapState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i18.BootstrapState.loading,
-        returnValueForMissingStub: _i18.BootstrapState.loading,
-      ) as _i18.BootstrapState);
+        returnValue: _i19.BootstrapState.loading,
+        returnValueForMissingStub: _i19.BootstrapState.loading,
+      ) as _i19.BootstrapState);
 
   @override
-  set onUpdate(void Function(_i18.Bootstrap)? value) => super.noSuchMethod(
+  set onUpdate(void Function(_i19.Bootstrap)? value) => super.noSuchMethod(
         Invocation.setter(
           #onUpdate,
           value,
@@ -9095,7 +9129,7 @@ class MockBootstrap extends _i1.Mock implements _i18.Bootstrap {
       );
 
   @override
-  set oldSsssKeys(Map<String, _i18.OpenSSSS>? value) => super.noSuchMethod(
+  set oldSsssKeys(Map<String, _i19.OpenSSSS>? value) => super.noSuchMethod(
         Invocation.setter(
           #oldSsssKeys,
           value,
@@ -9104,7 +9138,7 @@ class MockBootstrap extends _i1.Mock implements _i18.Bootstrap {
       );
 
   @override
-  set newSsssKey(_i18.OpenSSSS? value) => super.noSuchMethod(
+  set newSsssKey(_i19.OpenSSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #newSsssKey,
           value,
@@ -9122,7 +9156,7 @@ class MockBootstrap extends _i1.Mock implements _i18.Bootstrap {
       );
 
   @override
-  set state(_i18.BootstrapState? newState) => super.noSuchMethod(
+  set state(_i19.BootstrapState? newState) => super.noSuchMethod(
         Invocation.setter(
           #state,
           newState,
@@ -9156,14 +9190,14 @@ class MockBootstrap extends _i1.Mock implements _i18.Bootstrap {
           #mostUsedKey,
           [secrets],
         ),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
             [secrets],
           ),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
@@ -9330,28 +9364,28 @@ class MockBootstrap extends _i1.Mock implements _i18.Bootstrap {
 /// A class which mocks [OpenSSSS].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockOpenSSSS extends _i1.Mock implements _i18.OpenSSSS {
+class MockOpenSSSS extends _i1.Mock implements _i19.OpenSSSS {
   @override
-  _i18.SSSS get ssss => (super.noSuchMethod(
+  _i19.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_81(
+        returnValue: _FakeSSSS_82(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_81(
+        returnValueForMissingStub: _FakeSSSS_82(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i18.SSSS);
+      ) as _i19.SSSS);
 
   @override
   String get keyId => (super.noSuchMethod(
         Invocation.getter(#keyId),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
@@ -9360,11 +9394,11 @@ class MockOpenSSSS extends _i1.Mock implements _i18.OpenSSSS {
   @override
   _i2.SecretStorageKeyContent get keyData => (super.noSuchMethod(
         Invocation.getter(#keyData),
-        returnValue: _FakeSecretStorageKeyContent_86(
+        returnValue: _FakeSecretStorageKeyContent_87(
           this,
           Invocation.getter(#keyData),
         ),
-        returnValueForMissingStub: _FakeSecretStorageKeyContent_86(
+        returnValueForMissingStub: _FakeSecretStorageKeyContent_87(
           this,
           Invocation.getter(#keyData),
         ),
@@ -9385,7 +9419,7 @@ class MockOpenSSSS extends _i1.Mock implements _i18.OpenSSSS {
       ) as bool);
 
   @override
-  set privateKey(_i23.Uint8List? value) => super.noSuchMethod(
+  set privateKey(_i24.Uint8List? value) => super.noSuchMethod(
         Invocation.setter(
           #privateKey,
           value,
@@ -9416,7 +9450,7 @@ class MockOpenSSSS extends _i1.Mock implements _i18.OpenSSSS {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setPrivateKey(_i23.Uint8List? key) => (super.noSuchMethod(
+  _i5.Future<void> setPrivateKey(_i24.Uint8List? key) => (super.noSuchMethod(
         Invocation.method(
           #setPrivateKey,
           [key],
@@ -9431,7 +9465,7 @@ class MockOpenSSSS extends _i1.Mock implements _i18.OpenSSSS {
           #getStored,
           [type],
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,
@@ -9439,7 +9473,7 @@ class MockOpenSSSS extends _i1.Mock implements _i18.OpenSSSS {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,

--- a/test/widgets/bootstrap_driver_test.mocks.dart
+++ b/test/widgets/bootstrap_driver_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i23;
-import 'dart:ui' as _i25;
+import 'dart:typed_data' as _i24;
+import 'dart:ui' as _i26;
 
-import 'package:flutter/services.dart' as _i26;
-import 'package:flutter/widgets.dart' as _i27;
+import 'package:flutter/services.dart' as _i27;
+import 'package:flutter/widgets.dart' as _i28;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i24;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i25;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,15 +28,16 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
-import 'package:matrix/encryption/cross_signing.dart' as _i21;
-import 'package:matrix/encryption/key_verification_manager.dart' as _i20;
-import 'package:matrix/encryption/olm_manager.dart' as _i19;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
+import 'package:matrix/encryption/cross_signing.dart' as _i22;
+import 'package:matrix/encryption/key_verification_manager.dart' as _i21;
+import 'package:matrix/encryption/olm_manager.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i22;
+import 'package:mockito/src/dummies.dart' as _i23;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -861,9 +862,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -872,8 +873,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyManager_77 extends _i1.SmartFake implements _i18.KeyManager {
-  _FakeKeyManager_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -882,8 +884,8 @@ class _FakeKeyManager_77 extends _i1.SmartFake implements _i18.KeyManager {
         );
 }
 
-class _FakeOlmManager_78 extends _i1.SmartFake implements _i19.OlmManager {
-  _FakeOlmManager_78(
+class _FakeKeyManager_78 extends _i1.SmartFake implements _i19.KeyManager {
+  _FakeKeyManager_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,9 +894,8 @@ class _FakeOlmManager_78 extends _i1.SmartFake implements _i19.OlmManager {
         );
 }
 
-class _FakeKeyVerificationManager_79 extends _i1.SmartFake
-    implements _i20.KeyVerificationManager {
-  _FakeKeyVerificationManager_79(
+class _FakeOlmManager_79 extends _i1.SmartFake implements _i20.OlmManager {
+  _FakeOlmManager_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -903,8 +904,9 @@ class _FakeKeyVerificationManager_79 extends _i1.SmartFake
         );
 }
 
-class _FakeCrossSigning_80 extends _i1.SmartFake implements _i21.CrossSigning {
-  _FakeCrossSigning_80(
+class _FakeKeyVerificationManager_80 extends _i1.SmartFake
+    implements _i21.KeyVerificationManager {
+  _FakeKeyVerificationManager_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -913,8 +915,8 @@ class _FakeCrossSigning_80 extends _i1.SmartFake implements _i21.CrossSigning {
         );
 }
 
-class _FakeSSSS_81 extends _i1.SmartFake implements _i18.SSSS {
-  _FakeSSSS_81(
+class _FakeCrossSigning_81 extends _i1.SmartFake implements _i22.CrossSigning {
+  _FakeCrossSigning_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -923,8 +925,8 @@ class _FakeSSSS_81 extends _i1.SmartFake implements _i18.SSSS {
         );
 }
 
-class _FakeBootstrap_82 extends _i1.SmartFake implements _i18.Bootstrap {
-  _FakeBootstrap_82(
+class _FakeSSSS_82 extends _i1.SmartFake implements _i19.SSSS {
+  _FakeSSSS_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -933,8 +935,8 @@ class _FakeBootstrap_82 extends _i1.SmartFake implements _i18.Bootstrap {
         );
 }
 
-class _FakeToDeviceEvent_83 extends _i1.SmartFake implements _i2.ToDeviceEvent {
-  _FakeToDeviceEvent_83(
+class _FakeBootstrap_83 extends _i1.SmartFake implements _i19.Bootstrap {
+  _FakeBootstrap_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -943,8 +945,8 @@ class _FakeToDeviceEvent_83 extends _i1.SmartFake implements _i2.ToDeviceEvent {
         );
 }
 
-class _FakeEvent_84 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_84(
+class _FakeToDeviceEvent_84 extends _i1.SmartFake implements _i2.ToDeviceEvent {
+  _FakeToDeviceEvent_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -953,8 +955,18 @@ class _FakeEvent_84 extends _i1.SmartFake implements _i2.Event {
         );
 }
 
-class _FakeEncryption_85 extends _i1.SmartFake implements _i18.Encryption {
-  _FakeEncryption_85(
+class _FakeEvent_85 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_85(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeEncryption_86 extends _i1.SmartFake implements _i19.Encryption {
+  _FakeEncryption_86(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -981,12 +993,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1106,11 +1118,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1147,11 +1159,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1181,11 +1193,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1194,11 +1206,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1484,34 +1496,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1667,7 +1679,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1956,14 +1968,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2351,8 +2363,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i22.ifNotNull(
-              _i22.dummyValueOrNull<T>(
+        returnValue: _i23.ifNotNull(
+              _i23.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2368,8 +2380,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i22.ifNotNull(
-              _i22.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i23.ifNotNull(
+              _i23.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2410,7 +2422,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2426,7 +2438,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2475,7 +2487,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2496,7 +2508,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2599,7 +2611,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2617,7 +2629,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3136,7 +3148,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i23.Uint8List? file, {
+    _i24.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3488,7 +3500,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3502,7 +3514,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3653,7 +3665,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i23.Uint8List? body,
+    _i24.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5031,7 +5043,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5053,7 +5065,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5547,7 +5559,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5559,7 +5571,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6567,7 +6579,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6578,7 +6590,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6826,7 +6838,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6838,7 +6850,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7098,7 +7110,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7111,7 +7123,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7178,7 +7190,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7191,7 +7203,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7239,7 +7251,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7251,7 +7263,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7499,7 +7511,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i22.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7510,7 +7522,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i22.dummyValue<String>(
+            _i5.Future<String>.value(_i23.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7772,7 +7784,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i23.Uint8List? body, {
+    _i24.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7799,7 +7811,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7829,11 +7841,11 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7971,17 +7983,30 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8090,7 +8115,16 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8143,7 +8177,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i25.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i26.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8239,7 +8273,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i25.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i26.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8248,7 +8282,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  void removeListener(_i25.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i26.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8267,7 +8301,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i26.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i27.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8278,7 +8312,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i26.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i27.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8326,7 +8360,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i27.RouteInformation? routeInformation) =>
+          _i28.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8364,7 +8398,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i25.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i26.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8373,7 +8407,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i25.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i26.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8382,16 +8416,16 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  _i5.Future<_i25.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i26.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i25.AppExitResponse>.value(_i25.AppExitResponse.exit),
+            _i5.Future<_i26.AppExitResponse>.value(_i26.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i25.AppExitResponse>.value(_i25.AppExitResponse.exit),
-      ) as _i5.Future<_i25.AppExitResponse>);
+            _i5.Future<_i26.AppExitResponse>.value(_i26.AppExitResponse.exit),
+      ) as _i5.Future<_i26.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8415,7 +8449,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
 /// A class which mocks [Encryption].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEncryption extends _i1.Mock implements _i18.Encryption {
+class MockEncryption extends _i1.Mock implements _i19.Encryption {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -8444,85 +8478,85 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
       ) as bool);
 
   @override
-  _i18.KeyManager get keyManager => (super.noSuchMethod(
+  _i19.KeyManager get keyManager => (super.noSuchMethod(
         Invocation.getter(#keyManager),
-        returnValue: _FakeKeyManager_77(
+        returnValue: _FakeKeyManager_78(
           this,
           Invocation.getter(#keyManager),
         ),
-        returnValueForMissingStub: _FakeKeyManager_77(
+        returnValueForMissingStub: _FakeKeyManager_78(
           this,
           Invocation.getter(#keyManager),
         ),
-      ) as _i18.KeyManager);
+      ) as _i19.KeyManager);
 
   @override
-  _i19.OlmManager get olmManager => (super.noSuchMethod(
+  _i20.OlmManager get olmManager => (super.noSuchMethod(
         Invocation.getter(#olmManager),
-        returnValue: _FakeOlmManager_78(
+        returnValue: _FakeOlmManager_79(
           this,
           Invocation.getter(#olmManager),
         ),
-        returnValueForMissingStub: _FakeOlmManager_78(
+        returnValueForMissingStub: _FakeOlmManager_79(
           this,
           Invocation.getter(#olmManager),
         ),
-      ) as _i19.OlmManager);
+      ) as _i20.OlmManager);
 
   @override
-  _i20.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
+  _i21.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
         Invocation.getter(#keyVerificationManager),
-        returnValue: _FakeKeyVerificationManager_79(
+        returnValue: _FakeKeyVerificationManager_80(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-        returnValueForMissingStub: _FakeKeyVerificationManager_79(
+        returnValueForMissingStub: _FakeKeyVerificationManager_80(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-      ) as _i20.KeyVerificationManager);
+      ) as _i21.KeyVerificationManager);
 
   @override
-  _i21.CrossSigning get crossSigning => (super.noSuchMethod(
+  _i22.CrossSigning get crossSigning => (super.noSuchMethod(
         Invocation.getter(#crossSigning),
-        returnValue: _FakeCrossSigning_80(
+        returnValue: _FakeCrossSigning_81(
           this,
           Invocation.getter(#crossSigning),
         ),
-        returnValueForMissingStub: _FakeCrossSigning_80(
+        returnValueForMissingStub: _FakeCrossSigning_81(
           this,
           Invocation.getter(#crossSigning),
         ),
-      ) as _i21.CrossSigning);
+      ) as _i22.CrossSigning);
 
   @override
-  _i18.SSSS get ssss => (super.noSuchMethod(
+  _i19.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_81(
+        returnValue: _FakeSSSS_82(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_81(
+        returnValueForMissingStub: _FakeSSSS_82(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i18.SSSS);
+      ) as _i19.SSSS);
 
   @override
   String get ourDeviceId => (super.noSuchMethod(
         Invocation.getter(#ourDeviceId),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
       ) as String);
 
   @override
-  set keyManager(_i18.KeyManager? value) => super.noSuchMethod(
+  set keyManager(_i19.KeyManager? value) => super.noSuchMethod(
         Invocation.setter(
           #keyManager,
           value,
@@ -8531,7 +8565,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
       );
 
   @override
-  set olmManager(_i19.OlmManager? value) => super.noSuchMethod(
+  set olmManager(_i20.OlmManager? value) => super.noSuchMethod(
         Invocation.setter(
           #olmManager,
           value,
@@ -8540,7 +8574,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
       );
 
   @override
-  set keyVerificationManager(_i20.KeyVerificationManager? value) =>
+  set keyVerificationManager(_i21.KeyVerificationManager? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #keyVerificationManager,
@@ -8550,7 +8584,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
       );
 
   @override
-  set crossSigning(_i21.CrossSigning? value) => super.noSuchMethod(
+  set crossSigning(_i22.CrossSigning? value) => super.noSuchMethod(
         Invocation.setter(
           #crossSigning,
           value,
@@ -8559,7 +8593,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
       );
 
   @override
-  set ssss(_i18.SSSS? value) => super.noSuchMethod(
+  set ssss(_i19.SSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #ssss,
           value,
@@ -8598,14 +8632,14 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
       ) as _i5.Future<void>);
 
   @override
-  _i18.Bootstrap bootstrap({void Function(_i18.Bootstrap)? onUpdate}) =>
+  _i19.Bootstrap bootstrap({void Function(_i19.Bootstrap)? onUpdate}) =>
       (super.noSuchMethod(
         Invocation.method(
           #bootstrap,
           [],
           {#onUpdate: onUpdate},
         ),
-        returnValue: _FakeBootstrap_82(
+        returnValue: _FakeBootstrap_83(
           this,
           Invocation.method(
             #bootstrap,
@@ -8613,7 +8647,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-        returnValueForMissingStub: _FakeBootstrap_82(
+        returnValueForMissingStub: _FakeBootstrap_83(
           this,
           Invocation.method(
             #bootstrap,
@@ -8621,7 +8655,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-      ) as _i18.Bootstrap);
+      ) as _i19.Bootstrap);
 
   @override
   void handleDeviceOneTimeKeysCount(
@@ -8684,7 +8718,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
           #decryptToDeviceEvent,
           [event],
         ),
-        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_83(
+        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_84(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8692,7 +8726,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_83(
+            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_84(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8707,14 +8741,14 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
           #decryptRoomEventSync,
           [event],
         ),
-        returnValue: _FakeEvent_84(
+        returnValue: _FakeEvent_85(
           this,
           Invocation.method(
             #decryptRoomEventSync,
             [event],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_84(
+        returnValueForMissingStub: _FakeEvent_85(
           this,
           Invocation.method(
             #decryptRoomEventSync,
@@ -8738,7 +8772,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
             #updateType: updateType,
           },
         ),
-        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_84(
+        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_85(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8749,7 +8783,7 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
             },
           ),
         )),
-        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_84(
+        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_85(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8831,19 +8865,19 @@ class MockEncryption extends _i1.Mock implements _i18.Encryption {
 /// A class which mocks [Bootstrap].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBootstrap extends _i1.Mock implements _i18.Bootstrap {
+class MockBootstrap extends _i1.Mock implements _i19.Bootstrap {
   @override
-  _i18.Encryption get encryption => (super.noSuchMethod(
+  _i19.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_85(
+        returnValue: _FakeEncryption_86(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_85(
+        returnValueForMissingStub: _FakeEncryption_86(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i18.Encryption);
+      ) as _i19.Encryption);
 
   @override
   _i2.Client get client => (super.noSuchMethod(
@@ -8859,14 +8893,14 @@ class MockBootstrap extends _i1.Mock implements _i18.Bootstrap {
       ) as _i2.Client);
 
   @override
-  _i18.BootstrapState get state => (super.noSuchMethod(
+  _i19.BootstrapState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i18.BootstrapState.loading,
-        returnValueForMissingStub: _i18.BootstrapState.loading,
-      ) as _i18.BootstrapState);
+        returnValue: _i19.BootstrapState.loading,
+        returnValueForMissingStub: _i19.BootstrapState.loading,
+      ) as _i19.BootstrapState);
 
   @override
-  set onUpdate(void Function(_i18.Bootstrap)? value) => super.noSuchMethod(
+  set onUpdate(void Function(_i19.Bootstrap)? value) => super.noSuchMethod(
         Invocation.setter(
           #onUpdate,
           value,
@@ -8875,7 +8909,7 @@ class MockBootstrap extends _i1.Mock implements _i18.Bootstrap {
       );
 
   @override
-  set oldSsssKeys(Map<String, _i18.OpenSSSS>? value) => super.noSuchMethod(
+  set oldSsssKeys(Map<String, _i19.OpenSSSS>? value) => super.noSuchMethod(
         Invocation.setter(
           #oldSsssKeys,
           value,
@@ -8884,7 +8918,7 @@ class MockBootstrap extends _i1.Mock implements _i18.Bootstrap {
       );
 
   @override
-  set newSsssKey(_i18.OpenSSSS? value) => super.noSuchMethod(
+  set newSsssKey(_i19.OpenSSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #newSsssKey,
           value,
@@ -8902,7 +8936,7 @@ class MockBootstrap extends _i1.Mock implements _i18.Bootstrap {
       );
 
   @override
-  set state(_i18.BootstrapState? newState) => super.noSuchMethod(
+  set state(_i19.BootstrapState? newState) => super.noSuchMethod(
         Invocation.setter(
           #state,
           newState,
@@ -8936,14 +8970,14 @@ class MockBootstrap extends _i1.Mock implements _i18.Bootstrap {
           #mostUsedKey,
           [secrets],
         ),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
             [secrets],
           ),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,

--- a/test/widgets/chat/message_actions_test.mocks.dart
+++ b/test/widgets/chat/message_actions_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i23;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i24;
 
-import 'package:flutter/services.dart' as _i24;
-import 'package:flutter/widgets.dart' as _i25;
+import 'package:flutter/services.dart' as _i25;
+import 'package:flutter/widgets.dart' as _i26;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i22;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i23;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,14 +28,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i19;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i18;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i26;
+import 'package:matrix/src/utils/space_child.dart' as _i27;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i20;
+import 'package:mockito/src/dummies.dart' as _i21;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -860,9 +861,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -871,8 +872,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,9 +883,19 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_78(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,8 +904,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,8 +914,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -912,8 +924,8 @@ class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_81 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_81(
+class _FakeRoom_82 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -922,9 +934,9 @@ class _FakeRoom_81 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_82 extends _i1.SmartFake
-    implements _i18.TimelineChunk {
-  _FakeTimelineChunk_82(
+class _FakeTimelineChunk_83 extends _i1.SmartFake
+    implements _i19.TimelineChunk {
+  _FakeTimelineChunk_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -933,8 +945,8 @@ class _FakeTimelineChunk_82 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixFile_83 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_83(
+class _FakeMatrixFile_84 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -943,8 +955,8 @@ class _FakeMatrixFile_83 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_84 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_84(
+class _FakeEvent_85 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_85(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -971,12 +983,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i19.KeyVerificationMethod> get verificationMethods =>
+  Set<_i20.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i19.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
-      ) as Set<_i19.KeyVerificationMethod>);
+        returnValue: <_i20.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
+      ) as Set<_i20.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1096,11 +1108,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1137,11 +1149,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1171,11 +1183,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1184,11 +1196,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1474,34 +1486,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i20.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i19.KeyVerification>
+  _i3.CachedStreamController<_i20.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i19.KeyVerification>(
+                _FakeCachedStreamController_6<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i19.KeyVerification>);
+          ) as _i3.CachedStreamController<_i20.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1657,7 +1669,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1946,14 +1958,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2341,8 +2353,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValue: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2358,8 +2370,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2400,7 +2412,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2416,7 +2428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2465,7 +2477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2486,7 +2498,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2589,7 +2601,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2607,7 +2619,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3126,7 +3138,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3478,7 +3490,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3492,7 +3504,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3643,7 +3655,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5021,7 +5033,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5043,7 +5055,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5537,7 +5549,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5549,7 +5561,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6557,7 +6569,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6568,7 +6580,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6816,7 +6828,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6828,7 +6840,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7088,7 +7100,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7101,7 +7113,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7168,7 +7180,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7181,7 +7193,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7229,7 +7241,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7241,7 +7253,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7489,7 +7501,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7500,7 +7512,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7762,7 +7774,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7789,7 +7801,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7819,11 +7831,11 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7961,17 +7973,30 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8080,7 +8105,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8133,7 +8167,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i24.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8229,7 +8263,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8238,7 +8272,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8257,7 +8291,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i25.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8268,7 +8302,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i25.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8316,7 +8350,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i25.RouteInformation? routeInformation) =>
+          _i26.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8354,7 +8388,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i24.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8363,7 +8397,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i24.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8372,16 +8406,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i24.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
-      ) as _i5.Future<_i23.AppExitResponse>);
+            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
+      ) as _i5.Future<_i24.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8409,11 +8443,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8443,11 +8477,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -8500,11 +8534,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8540,11 +8574,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8560,11 +8594,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8573,11 +8607,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8620,11 +8654,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8667,11 +8701,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8890,18 +8924,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i27.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i26.SpaceParent>[],
-        returnValueForMissingStub: <_i26.SpaceParent>[],
-      ) as List<_i26.SpaceParent>);
+        returnValue: <_i27.SpaceParent>[],
+        returnValueForMissingStub: <_i27.SpaceParent>[],
+      ) as List<_i27.SpaceParent>);
 
   @override
-  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i27.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i26.SpaceChild>[],
-        returnValueForMissingStub: <_i26.SpaceChild>[],
-      ) as List<_i26.SpaceChild>);
+        returnValue: <_i27.SpaceChild>[],
+        returnValueForMissingStub: <_i27.SpaceChild>[],
+      ) as List<_i27.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9068,14 +9102,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9123,7 +9157,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9131,7 +9165,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9146,7 +9180,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9154,7 +9188,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9248,7 +9282,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9256,7 +9290,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9498,7 +9532,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9509,7 +9543,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9598,15 +9632,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i18.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i18.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i18.TimelineChunk?>.value(),
-      ) as _i5.Future<_i18.TimelineChunk?>);
+        returnValue: _i5.Future<_i19.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i19.TimelineChunk?>.value(),
+      ) as _i5.Future<_i19.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9647,7 +9681,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9664,7 +9698,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9728,14 +9762,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9751,14 +9785,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9814,7 +9848,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9822,7 +9856,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10134,11 +10168,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -10188,17 +10222,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i18.TimelineChunk get chunk => (super.noSuchMethod(
+  _i19.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_82(
+        returnValue: _FakeTimelineChunk_83(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_82(
+        returnValueForMissingStub: _FakeTimelineChunk_83(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i18.TimelineChunk);
+      ) as _i19.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10301,7 +10335,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i18.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i19.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10500,11 +10534,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.getter(#sender),
         ),
@@ -10513,11 +10547,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10526,11 +10560,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -10553,11 +10587,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10566,11 +10600,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10579,11 +10613,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10592,11 +10626,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10605,11 +10639,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10618,11 +10652,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10687,11 +10721,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10700,11 +10734,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10757,11 +10791,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10846,11 +10880,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10868,11 +10902,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11083,7 +11117,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i21.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i22.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -11098,7 +11132,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_83(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_84(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -11112,7 +11146,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_83(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_84(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -11148,7 +11182,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11163,7 +11197,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11200,7 +11234,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11214,7 +11248,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11251,7 +11285,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11265,7 +11299,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11299,7 +11333,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11312,7 +11346,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11388,14 +11422,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_84(
+        returnValue: _FakeEvent_85(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_84(
+        returnValueForMissingStub: _FakeEvent_85(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11412,11 +11446,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -11425,11 +11459,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11495,11 +11529,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11524,11 +11558,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11546,11 +11580,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11597,7 +11631,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11609,7 +11643,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11679,7 +11713,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11692,7 +11726,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/chat/pinned_messages_test.mocks.dart
+++ b/test/widgets/chat/pinned_messages_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i23;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i24;
 
-import 'package:flutter/services.dart' as _i24;
-import 'package:flutter/widgets.dart' as _i25;
+import 'package:flutter/services.dart' as _i25;
+import 'package:flutter/widgets.dart' as _i26;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i22;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i23;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,14 +28,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i19;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i18;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i26;
+import 'package:matrix/src/utils/space_child.dart' as _i27;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i20;
+import 'package:mockito/src/dummies.dart' as _i21;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -860,9 +861,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -871,8 +872,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,9 +883,19 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_78(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,8 +904,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,8 +914,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -912,8 +924,8 @@ class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_81 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_81(
+class _FakeRoom_82 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -922,9 +934,9 @@ class _FakeRoom_81 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_82 extends _i1.SmartFake
-    implements _i18.TimelineChunk {
-  _FakeTimelineChunk_82(
+class _FakeTimelineChunk_83 extends _i1.SmartFake
+    implements _i19.TimelineChunk {
+  _FakeTimelineChunk_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -933,8 +945,8 @@ class _FakeTimelineChunk_82 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixFile_83 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_83(
+class _FakeMatrixFile_84 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -943,8 +955,8 @@ class _FakeMatrixFile_83 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_84 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_84(
+class _FakeEvent_85 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_85(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -971,12 +983,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i19.KeyVerificationMethod> get verificationMethods =>
+  Set<_i20.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i19.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
-      ) as Set<_i19.KeyVerificationMethod>);
+        returnValue: <_i20.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
+      ) as Set<_i20.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1096,11 +1108,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1137,11 +1149,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1171,11 +1183,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1184,11 +1196,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1474,34 +1486,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i20.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i19.KeyVerification>
+  _i3.CachedStreamController<_i20.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i19.KeyVerification>(
+                _FakeCachedStreamController_6<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i19.KeyVerification>);
+          ) as _i3.CachedStreamController<_i20.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1657,7 +1669,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1946,14 +1958,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2341,8 +2353,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValue: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2358,8 +2370,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2400,7 +2412,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2416,7 +2428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2465,7 +2477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2486,7 +2498,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2589,7 +2601,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2607,7 +2619,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3126,7 +3138,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3478,7 +3490,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3492,7 +3504,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3643,7 +3655,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5021,7 +5033,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5043,7 +5055,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5537,7 +5549,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5549,7 +5561,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6557,7 +6569,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6568,7 +6580,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6816,7 +6828,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6828,7 +6840,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7088,7 +7100,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7101,7 +7113,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7168,7 +7180,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7181,7 +7193,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7229,7 +7241,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7241,7 +7253,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7489,7 +7501,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7500,7 +7512,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7762,7 +7774,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7789,7 +7801,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7819,11 +7831,11 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7961,17 +7973,30 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8080,7 +8105,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8133,7 +8167,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i24.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8229,7 +8263,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8238,7 +8272,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8257,7 +8291,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i25.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8268,7 +8302,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i25.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8316,7 +8350,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i25.RouteInformation? routeInformation) =>
+          _i26.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8354,7 +8388,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i24.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8363,7 +8397,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i24.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8372,16 +8406,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i24.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
-      ) as _i5.Future<_i23.AppExitResponse>);
+            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
+      ) as _i5.Future<_i24.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8409,11 +8443,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8443,11 +8477,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -8500,11 +8534,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8540,11 +8574,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8560,11 +8594,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8573,11 +8607,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8620,11 +8654,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8667,11 +8701,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8890,18 +8924,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i27.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i26.SpaceParent>[],
-        returnValueForMissingStub: <_i26.SpaceParent>[],
-      ) as List<_i26.SpaceParent>);
+        returnValue: <_i27.SpaceParent>[],
+        returnValueForMissingStub: <_i27.SpaceParent>[],
+      ) as List<_i27.SpaceParent>);
 
   @override
-  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i27.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i26.SpaceChild>[],
-        returnValueForMissingStub: <_i26.SpaceChild>[],
-      ) as List<_i26.SpaceChild>);
+        returnValue: <_i27.SpaceChild>[],
+        returnValueForMissingStub: <_i27.SpaceChild>[],
+      ) as List<_i27.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9068,14 +9102,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9123,7 +9157,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9131,7 +9165,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9146,7 +9180,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9154,7 +9188,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9248,7 +9282,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9256,7 +9290,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9498,7 +9532,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9509,7 +9543,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9598,15 +9632,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i18.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i18.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i18.TimelineChunk?>.value(),
-      ) as _i5.Future<_i18.TimelineChunk?>);
+        returnValue: _i5.Future<_i19.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i19.TimelineChunk?>.value(),
+      ) as _i5.Future<_i19.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9647,7 +9681,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9664,7 +9698,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9728,14 +9762,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9751,14 +9785,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9814,7 +9848,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9822,7 +9856,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10134,11 +10168,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -10188,17 +10222,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i18.TimelineChunk get chunk => (super.noSuchMethod(
+  _i19.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_82(
+        returnValue: _FakeTimelineChunk_83(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_82(
+        returnValueForMissingStub: _FakeTimelineChunk_83(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i18.TimelineChunk);
+      ) as _i19.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10301,7 +10335,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i18.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i19.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10500,11 +10534,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.getter(#sender),
         ),
@@ -10513,11 +10547,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10526,11 +10560,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -10553,11 +10587,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10566,11 +10600,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10579,11 +10613,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10592,11 +10626,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10605,11 +10639,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10618,11 +10652,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10687,11 +10721,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10700,11 +10734,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10757,11 +10791,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10846,11 +10880,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10868,11 +10902,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11083,7 +11117,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i21.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i22.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -11098,7 +11132,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_83(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_84(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -11112,7 +11146,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_83(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_84(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -11148,7 +11182,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11163,7 +11197,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11200,7 +11234,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11214,7 +11248,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11251,7 +11285,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11265,7 +11299,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11299,7 +11333,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11312,7 +11346,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11388,14 +11422,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_84(
+        returnValue: _FakeEvent_85(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_84(
+        returnValueForMissingStub: _FakeEvent_85(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11412,11 +11446,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -11425,11 +11459,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11495,11 +11529,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11524,11 +11558,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11546,11 +11580,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11597,7 +11631,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11609,7 +11643,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11679,7 +11713,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11692,7 +11726,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/chat/read_receipts_test.dart
+++ b/test/widgets/chat/read_receipts_test.dart
@@ -1,7 +1,10 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/preferences_service.dart';
+import 'package:kohera/features/chat/models/kohera_read_receipt.dart';
 import 'package:kohera/features/chat/widgets/read_receipts.dart';
+import 'package:kohera/shared/models/kohera_user_summary_mapper.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
 import 'package:matrix/matrix.dart';
 import 'package:mockito/annotations.dart';
@@ -18,13 +21,23 @@ import 'read_receipts_test.mocks.dart';
 
 // ── Helpers ──────────────────────────────────────────────────
 
+class _NullAvatarResolver implements AvatarResolver {
+  const _NullAvatarResolver();
+  @override
+  Future<AvatarThumbnail?> resolve(String? mxcUrl, {required double size}) async => null;
+}
+
 MockUser _makeUser(String id, String? displayName, {Uri? avatarUrl}) {
   final user = MockUser();
   when(user.id).thenReturn(id);
   when(user.displayName).thenReturn(displayName);
+  when(user.calcDisplayname()).thenReturn(displayName ?? id);
   when(user.avatarUrl).thenReturn(avatarUrl);
   return user;
 }
+
+KoheraReadReceipt _receipt(MockUser user, DateTime time) =>
+    KoheraReadReceipt(user: toKoheraUserSummary(user), time: time);
 
 MockRoom _makeRoom({
   required Map<String, LatestReceiptStateData> globalOtherUsers,
@@ -76,13 +89,13 @@ MockRoom _makeRoom({
   return room;
 }
 
-Widget _wrapRow(List<Receipt> receipts, Client client, {bool isMe = true}) {
+Widget _wrapRow(List<KoheraReadReceipt> receipts, {bool isMe = true}) {
   return MaterialApp(
     theme: ThemeData(splashFactory: InkRipple.splashFactory),
     home: Scaffold(
       body: ReadReceiptsRow(
         receipts: receipts,
-        client: client,
+        avatarResolver: const _NullAvatarResolver(),
         isMe: isMe,
       ),
     ),
@@ -114,12 +127,12 @@ void main() {
 
       expect(map.containsKey(r'$evt1'), isTrue);
       expect(map[r'$evt1']!.length, 2);
-      expect(map[r'$evt1']!.map((r) => r.user.id),
+      expect(map[r'$evt1']!.map((r) => r.user.userId),
           containsAll(['@alice:example.com', '@bob:example.com']),);
 
       // Own user should not appear
       expect(
-        map.values.expand((l) => l).any((r) => r.user.id == '@me:example.com'),
+        map.values.expand((l) => l).any((r) => r.user.userId == '@me:example.com'),
         isFalse,
       );
     });
@@ -144,7 +157,7 @@ void main() {
       // Alice should only appear once (from global, since it's processed first)
       final allReceipts = map.values.expand((l) => l).toList();
       expect(
-        allReceipts.where((r) => r.user.id == '@alice:example.com').length,
+        allReceipts.where((r) => r.user.userId == '@alice:example.com').length,
         1,
       );
     });
@@ -178,7 +191,7 @@ void main() {
       );
 
       expect(map.containsKey(r'$thread1'), isTrue);
-      expect(map[r'$thread1']!.single.user.id, '@bob:example.com');
+      expect(map[r'$thread1']!.single.user.userId, '@bob:example.com');
       expect(map.containsKey(r'$global1'), isFalse);
       expect(map.containsKey(r'$main1'), isFalse);
     });
@@ -214,15 +227,8 @@ void main() {
   });
 
   group('ReadReceiptsRow', () {
-    late MockClient mockClient;
-
-    setUp(() {
-      mockClient = MockClient();
-      when(mockClient.userID).thenReturn('@me:example.com');
-    });
-
     testWidgets('renders SizedBox.shrink for empty receipts', (tester) async {
-      await tester.pumpWidget(_wrapRow([], mockClient));
+      await tester.pumpWidget(_wrapRow([]));
 
       // Should find a SizedBox with zero dimensions (shrink)
       final sizedBox = tester.widget<SizedBox>(find.byType(SizedBox).first);
@@ -233,17 +239,17 @@ void main() {
     testWidgets('renders correct number of avatars for 2 receipts',
         (tester) async {
       final receipts = [
-        Receipt(
+        _receipt(
           _makeUser('@alice:example.com', 'Alice'),
           DateTime(2024, 1, 1, 12),
         ),
-        Receipt(
+        _receipt(
           _makeUser('@bob:example.com', 'Bob'),
           DateTime(2024, 1, 1, 12, 5),
         ),
       ];
 
-      await tester.pumpWidget(_wrapRow(receipts, mockClient));
+      await tester.pumpWidget(_wrapRow(receipts));
       await tester.pump();
 
       expect(find.byType(UserAvatar), findsNWidgets(2));
@@ -254,13 +260,13 @@ void main() {
     testWidgets('shows +N badge when more than 3 receipts', (tester) async {
       final receipts = List.generate(
         5,
-        (i) => Receipt(
+        (i) => _receipt(
           _makeUser('@user$i:example.com', 'User $i'),
           DateTime(2024, 1, 1, 12, i),
         ),
       );
 
-      await tester.pumpWidget(_wrapRow(receipts, mockClient));
+      await tester.pumpWidget(_wrapRow(receipts));
       await tester.pump();
 
       expect(find.text('+2'), findsOneWidget);
@@ -268,13 +274,13 @@ void main() {
 
     testWidgets('tap opens readers bottom sheet', (tester) async {
       final receipts = [
-        Receipt(
+        _receipt(
           _makeUser('@alice:example.com', 'Alice'),
           DateTime(2024, 1, 1, 14, 30),
         ),
       ];
 
-      await tester.pumpWidget(_wrapRow(receipts, mockClient));
+      await tester.pumpWidget(_wrapRow(receipts));
       await tester.pump();
 
       await tester.tap(find.byType(GestureDetector).first);
@@ -290,17 +296,17 @@ void main() {
 
     testWidgets('bottom sheet shows multiple readers', (tester) async {
       final receipts = [
-        Receipt(
+        _receipt(
           _makeUser('@alice:example.com', 'Alice'),
           DateTime(2024, 1, 1, 14, 30),
         ),
-        Receipt(
+        _receipt(
           _makeUser('@bob:example.com', 'Bob'),
           DateTime(2024, 1, 1, 15, 45),
         ),
       ];
 
-      await tester.pumpWidget(_wrapRow(receipts, mockClient));
+      await tester.pumpWidget(_wrapRow(receipts));
       await tester.pump();
 
       await tester.tap(find.byType(GestureDetector).first);
@@ -318,7 +324,7 @@ void main() {
       final prefs = PreferencesService(prefs: sp);
 
       final receipts = [
-        Receipt(
+        _receipt(
           _makeUser('@alice:example.com', 'Alice'),
           DateTime(2024, 1, 1, 14, 30),
         ),
@@ -337,7 +343,7 @@ void main() {
                   if (!show) return const SizedBox.shrink();
                   return ReadReceiptsRow(
                     receipts: receipts,
-                    client: mockClient,
+                    avatarResolver: const _NullAvatarResolver(),
                     isMe: true,
                   );
                 },
@@ -355,13 +361,13 @@ void main() {
     testWidgets('falls back to user ID when displayName is null',
         (tester) async {
       final receipts = [
-        Receipt(
+        _receipt(
           _makeUser('@anon:example.com', null),
           DateTime(2024, 1, 1, 10),
         ),
       ];
 
-      await tester.pumpWidget(_wrapRow(receipts, mockClient));
+      await tester.pumpWidget(_wrapRow(receipts));
       await tester.pump();
 
       await tester.tap(find.byType(GestureDetector).first);

--- a/test/widgets/create_subspace_dialog_test.mocks.dart
+++ b/test/widgets/create_subspace_dialog_test.mocks.dart
@@ -4,15 +4,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/models/join_mode.dart' as _i27;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/models/join_mode.dart' as _i28;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -29,14 +29,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i26;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i27;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i25;
+import 'package:matrix/src/utils/space_child.dart' as _i26;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -861,9 +862,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -872,8 +873,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -882,9 +884,19 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_78(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -893,8 +905,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -903,8 +915,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -913,8 +925,8 @@ class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeStateEvent_81 extends _i1.SmartFake implements _i2.StateEvent {
-  _FakeStateEvent_81(
+class _FakeStateEvent_82 extends _i1.SmartFake implements _i2.StateEvent {
+  _FakeStateEvent_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -941,12 +953,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1066,11 +1078,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1107,11 +1119,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1141,11 +1153,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1154,11 +1166,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1444,34 +1456,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1627,7 +1639,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1916,14 +1928,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2311,8 +2323,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2328,8 +2340,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2370,7 +2382,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2386,7 +2398,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2435,7 +2447,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2456,7 +2468,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2559,7 +2571,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2577,7 +2589,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3096,7 +3108,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3448,7 +3460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3462,7 +3474,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3613,7 +3625,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4991,7 +5003,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5013,7 +5025,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5507,7 +5519,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5519,7 +5531,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6527,7 +6539,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6538,7 +6550,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6786,7 +6798,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6798,7 +6810,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7058,7 +7070,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7071,7 +7083,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7138,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7151,7 +7163,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7199,7 +7211,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7211,7 +7223,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7459,7 +7471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7470,7 +7482,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7732,7 +7744,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7759,7 +7771,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7789,11 +7801,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7931,17 +7943,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8050,7 +8075,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8103,7 +8137,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8199,7 +8233,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8208,7 +8242,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8227,7 +8261,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8238,7 +8272,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8286,7 +8320,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8324,7 +8358,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8333,7 +8367,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8342,16 +8376,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8379,11 +8413,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8413,11 +8447,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -8470,11 +8504,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8510,11 +8544,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8530,11 +8564,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8543,11 +8577,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8590,11 +8624,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8637,11 +8671,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8860,18 +8894,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i25.SpaceParent>[],
-        returnValueForMissingStub: <_i25.SpaceParent>[],
-      ) as List<_i25.SpaceParent>);
+        returnValue: <_i26.SpaceParent>[],
+        returnValueForMissingStub: <_i26.SpaceParent>[],
+      ) as List<_i26.SpaceParent>);
 
   @override
-  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i25.SpaceChild>[],
-        returnValueForMissingStub: <_i25.SpaceChild>[],
-      ) as List<_i25.SpaceChild>);
+        returnValue: <_i26.SpaceChild>[],
+        returnValueForMissingStub: <_i26.SpaceChild>[],
+      ) as List<_i26.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9038,14 +9072,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9093,7 +9127,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9101,7 +9135,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9116,7 +9150,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9124,7 +9158,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9218,7 +9252,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9226,7 +9260,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9468,7 +9502,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9479,7 +9513,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9568,15 +9602,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i26.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i27.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i26.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i26.TimelineChunk?>.value(),
-      ) as _i5.Future<_i26.TimelineChunk?>);
+        returnValue: _i5.Future<_i27.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i27.TimelineChunk?>.value(),
+      ) as _i5.Future<_i27.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9617,7 +9651,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9634,7 +9668,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9698,14 +9732,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9721,14 +9755,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9784,7 +9818,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9792,7 +9826,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10103,14 +10137,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
 class MockSpaceAccessService extends _i1.Mock
     implements _i13.SpaceAccessService {
   @override
-  _i27.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
+  _i28.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
         Invocation.method(
           #getJoinMode,
           [room],
         ),
-        returnValue: _i27.JoinMode.invite,
-        returnValueForMissingStub: _i27.JoinMode.invite,
-      ) as _i27.JoinMode);
+        returnValue: _i28.JoinMode.invite,
+        returnValueForMissingStub: _i28.JoinMode.invite,
+      ) as _i28.JoinMode);
 
   @override
   List<String> allowedSpaceIds(_i2.Room? room) => (super.noSuchMethod(
@@ -10194,7 +10228,7 @@ class MockSpaceAccessService extends _i1.Mock
   @override
   _i5.Future<void> applyJoinMode({
     required String? roomId,
-    required _i27.JoinMode? mode,
+    required _i28.JoinMode? mode,
     List<String>? allowSpaceIds = const [],
   }) =>
       (super.noSuchMethod(
@@ -10213,7 +10247,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   Map<String, Object?> buildJoinRulesPayload(
-    _i27.JoinMode? mode,
+    _i28.JoinMode? mode,
     List<String>? allowSpaceIds, {
     List<Map<String, Object?>>? preserveEntries = const [],
   }) =>
@@ -10232,7 +10266,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   _i2.StateEvent buildJoinRulesStateEvent(
-    _i27.JoinMode? mode,
+    _i28.JoinMode? mode,
     List<String>? allowSpaceIds,
   ) =>
       (super.noSuchMethod(
@@ -10243,7 +10277,7 @@ class MockSpaceAccessService extends _i1.Mock
             allowSpaceIds,
           ],
         ),
-        returnValue: _FakeStateEvent_81(
+        returnValue: _FakeStateEvent_82(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -10253,7 +10287,7 @@ class MockSpaceAccessService extends _i1.Mock
             ],
           ),
         ),
-        returnValueForMissingStub: _FakeStateEvent_81(
+        returnValueForMissingStub: _FakeStateEvent_82(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -10278,7 +10312,7 @@ class MockSpaceAccessService extends _i1.Mock
             newVersion,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,
@@ -10289,7 +10323,7 @@ class MockSpaceAccessService extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,

--- a/test/widgets/homeserver_controller_test.mocks.dart
+++ b/test/widgets/homeserver_controller_test.mocks.dart
@@ -3,14 +3,14 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i17;
-import 'dart:ui' as _i18;
+import 'dart:async' as _i18;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
-import 'package:kohera/core/models/server_auth_capabilities.dart' as _i14;
-import 'package:kohera/core/services/matrix_service.dart' as _i15;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i13;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
+import 'package:kohera/core/models/server_auth_capabilities.dart' as _i15;
+import 'package:kohera/core/services/matrix_service.dart' as _i16;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -26,9 +26,10 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i13;
 import 'package:matrix/matrix.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -162,9 +163,9 @@ class _FakeOutboxService_10 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_11 extends _i1.SmartFake
-    implements _i13.StickerPackService {
-  _FakeStickerPackService_11(
+class _FakeAvatarResolver_11 extends _i1.SmartFake
+    implements _i13.AvatarResolver {
+  _FakeAvatarResolver_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -173,9 +174,20 @@ class _FakeStickerPackService_11 extends _i1.SmartFake
         );
 }
 
-class _FakeServerAuthCapabilities_12 extends _i1.SmartFake
-    implements _i14.ServerAuthCapabilities {
-  _FakeServerAuthCapabilities_12(
+class _FakeStickerPackService_12 extends _i1.SmartFake
+    implements _i14.StickerPackService {
+  _FakeStickerPackService_12(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeServerAuthCapabilities_13 extends _i1.SmartFake
+    implements _i15.ServerAuthCapabilities {
+  _FakeServerAuthCapabilities_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -187,7 +199,7 @@ class _FakeServerAuthCapabilities_12 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -217,11 +229,11 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -359,17 +371,30 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as _i12.OutboxService);
 
   @override
-  _i13.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i13.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i13.AvatarResolver);
+
+  @override
+  _i14.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_11(
+        returnValue: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_11(
+        returnValueForMissingStub: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i13.StickerPackService);
+      ) as _i14.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -478,7 +503,16 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set stickerPacks(_i13.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i13.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i14.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -494,14 +528,14 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as bool);
 
   @override
-  _i17.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i18.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -531,7 +565,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -541,18 +575,18 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i17.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i18.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<bool> login({
+  _i18.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -569,12 +603,12 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
             #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<bool> completeSsoLogin({
+  _i18.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -587,12 +621,12 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<void> completeRegistration(
+  _i18.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -602,32 +636,32 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> logout() => (super.noSuchMethod(
+  _i18.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i18.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -636,7 +670,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -645,17 +679,17 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i17.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i18.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -666,7 +700,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -703,26 +737,26 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i17.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i18.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+  _i18.Future<bool> didPushRouteInformation(
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -752,7 +786,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -761,7 +795,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -770,16 +804,16 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i17.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i18.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i17.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i18.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i17.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i17.Future<_i18.AppExitResponse>);
+            _i18.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i18.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -837,7 +871,7 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
       ) as bool);
 
   @override
-  _i17.Future<bool> login({
+  _i18.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -854,12 +888,12 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
             #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<bool> completeSsoLogin({
+  _i18.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -872,12 +906,12 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<void> completeRegistration(
+  _i18.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -887,9 +921,9 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
           [response],
           {#password: password},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   void activateRestoredSession() => super.noSuchMethod(
@@ -901,37 +935,37 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
       );
 
   @override
-  _i17.Future<void> logout() => (super.noSuchMethod(
+  _i18.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> handleServerLogout() => (super.noSuchMethod(
+  _i18.Future<void> handleServerLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleServerLogout,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> saveSessionBackup() => (super.noSuchMethod(
+  _i18.Future<void> saveSessionBackup() => (super.noSuchMethod(
         Invocation.method(
           #saveSessionBackup,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i14.ServerAuthCapabilities> getServerAuthCapabilities(
+  _i18.Future<_i15.ServerAuthCapabilities> getServerAuthCapabilities(
     String? homeserver, {
     required bool? isLoggedIn,
   }) =>
@@ -941,8 +975,8 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
           [homeserver],
           {#isLoggedIn: isLoggedIn},
         ),
-        returnValue: _i17.Future<_i14.ServerAuthCapabilities>.value(
-            _FakeServerAuthCapabilities_12(
+        returnValue: _i18.Future<_i15.ServerAuthCapabilities>.value(
+            _FakeServerAuthCapabilities_13(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -951,8 +985,8 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i14.ServerAuthCapabilities>.value(
-                _FakeServerAuthCapabilities_12(
+            _i18.Future<_i15.ServerAuthCapabilities>.value(
+                _FakeServerAuthCapabilities_13(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -960,7 +994,7 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
             {#isLoggedIn: isLoggedIn},
           ),
         )),
-      ) as _i17.Future<_i14.ServerAuthCapabilities>);
+      ) as _i18.Future<_i15.ServerAuthCapabilities>);
 
   @override
   bool isPermanentAuthFailure(Object? error) => (super.noSuchMethod(
@@ -973,17 +1007,17 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
       ) as bool);
 
   @override
-  _i17.Future<void> clearSessionKeys() => (super.noSuchMethod(
+  _i18.Future<void> clearSessionKeys() => (super.noSuchMethod(
         Invocation.method(
           #clearSessionKeys,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> saveLoginCredentials({
+  _i18.Future<void> saveLoginCredentials({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -998,56 +1032,56 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
             #password: password,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<({String password, String username})?> loadLoginCredentials(
+  _i18.Future<({String password, String username})?> loadLoginCredentials(
           String? homeserver) =>
       (super.noSuchMethod(
         Invocation.method(
           #loadLoginCredentials,
           [homeserver],
         ),
-        returnValue: _i17.Future<({String password, String username})?>.value(),
+        returnValue: _i18.Future<({String password, String username})?>.value(),
         returnValueForMissingStub:
-            _i17.Future<({String password, String username})?>.value(),
-      ) as _i17.Future<({String password, String username})?>);
+            _i18.Future<({String password, String username})?>.value(),
+      ) as _i18.Future<({String password, String username})?>);
 
   @override
-  _i17.Future<void> clearLoginCredentials(String? homeserver) =>
+  _i18.Future<void> clearLoginCredentials(String? homeserver) =>
       (super.noSuchMethod(
         Invocation.method(
           #clearLoginCredentials,
           [homeserver],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> migrateStorageKeys() => (super.noSuchMethod(
+  _i18.Future<void> migrateStorageKeys() => (super.noSuchMethod(
         Invocation.method(
           #migrateStorageKeys,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> persistCredentials() => (super.noSuchMethod(
+  _i18.Future<void> persistCredentials() => (super.noSuchMethod(
         Invocation.method(
           #persistCredentials,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1056,7 +1090,7 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/widgets/invite_dialog_test.mocks.dart
+++ b/test/widgets/invite_dialog_test.mocks.dart
@@ -3,15 +3,15 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i16;
-import 'dart:typed_data' as _i26;
-import 'dart:ui' as _i20;
+import 'dart:async' as _i17;
+import 'dart:typed_data' as _i27;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
-import 'package:http/http.dart' as _i15;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i13;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
+import 'package:http/http.dart' as _i16;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -27,14 +27,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i25;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i13;
+import 'package:matrix/encryption.dart' as _i26;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i17;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i14;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i18;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i15;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -168,9 +169,9 @@ class _FakeOutboxService_10 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_11 extends _i1.SmartFake
-    implements _i13.StickerPackService {
-  _FakeStickerPackService_11(
+class _FakeAvatarResolver_11 extends _i1.SmartFake
+    implements _i13.AvatarResolver {
+  _FakeAvatarResolver_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -179,8 +180,9 @@ class _FakeStickerPackService_11 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_12 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_12(
+class _FakeStickerPackService_12 extends _i1.SmartFake
+    implements _i14.StickerPackService {
+  _FakeStickerPackService_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -189,9 +191,8 @@ class _FakeRoomSummary_12 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_13<T> extends _i1.SmartFake
-    implements _i14.CachedStreamController<T> {
-  _FakeCachedStreamController_13(
+class _FakeRoomSummary_13 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -200,8 +201,9 @@ class _FakeCachedStreamController_13<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_14 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_14(
+class _FakeCachedStreamController_14<T> extends _i1.SmartFake
+    implements _i15.CachedStreamController<T> {
+  _FakeCachedStreamController_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -210,9 +212,19 @@ class _FakeDateTime_14 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_15 extends _i1.SmartFake
+class _FakeDateTime_15 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_15(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_16 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_15(
+  _FakeLatestReceiptState_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -221,8 +233,8 @@ class _FakeLatestReceiptState_15 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_16 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_16(
+class _FakeSyncUpdate_17 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -231,8 +243,8 @@ class _FakeSyncUpdate_16 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_17 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_17(
+class _FakeTimeline_18 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -241,8 +253,8 @@ class _FakeTimeline_17 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_18 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_18(
+class _FakeUser_19 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -251,8 +263,8 @@ class _FakeUser_18 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_19 extends _i1.SmartFake implements Uri {
-  _FakeUri_19(
+class _FakeUri_20 extends _i1.SmartFake implements Uri {
+  _FakeUri_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -261,8 +273,8 @@ class _FakeUri_19 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_20 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_20(
+class _FakeDatabaseApi_21 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -271,8 +283,8 @@ class _FakeDatabaseApi_20 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_21 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_21(
+class _FakeFilter_22 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -281,9 +293,9 @@ class _FakeFilter_21 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_22 extends _i1.SmartFake
+class _FakeNativeImplementations_23 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_22(
+  _FakeNativeImplementations_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -292,8 +304,8 @@ class _FakeNativeImplementations_22 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_23 extends _i1.SmartFake implements Duration {
-  _FakeDuration_23(
+class _FakeDuration_24 extends _i1.SmartFake implements Duration {
+  _FakeDuration_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -302,9 +314,9 @@ class _FakeDuration_23 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_24 extends _i1.SmartFake
+class _FakePushruleEvaluator_25 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_24(
+  _FakePushruleEvaluator_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -313,8 +325,8 @@ class _FakePushruleEvaluator_24 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_25 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_25(
+class _FakeProfile_26 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -323,8 +335,8 @@ class _FakeProfile_25 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_26 extends _i1.SmartFake implements _i15.Client {
-  _FakeClient_26(
+class _FakeClient_27 extends _i1.SmartFake implements _i16.Client {
+  _FakeClient_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -333,9 +345,9 @@ class _FakeClient_26 extends _i1.SmartFake implements _i15.Client {
         );
 }
 
-class _FakeDiscoveryInformation_27 extends _i1.SmartFake
+class _FakeDiscoveryInformation_28 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_27(
+  _FakeDiscoveryInformation_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -344,9 +356,9 @@ class _FakeDiscoveryInformation_27 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_28 extends _i1.SmartFake
+class _FakeGetVersionsResponse_29 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_28(
+  _FakeGetVersionsResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -355,9 +367,9 @@ class _FakeGetVersionsResponse_28 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_29 extends _i1.SmartFake
+class _FakeRegisterResponse_30 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_29(
+  _FakeRegisterResponse_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -366,8 +378,8 @@ class _FakeRegisterResponse_29 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_30 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_30(
+class _FakeLoginResponse_31 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -376,9 +388,9 @@ class _FakeLoginResponse_30 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_31 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_32 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_31(
+  _FakeGetAuthMetadataResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -387,8 +399,8 @@ class _FakeGetAuthMetadataResponse_31 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_32<T1> extends _i1.SmartFake implements _i16.Future<T1> {
-  _FakeFuture_32(
+class _FakeFuture_33<T1> extends _i1.SmartFake implements _i17.Future<T1> {
+  _FakeFuture_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -397,9 +409,9 @@ class _FakeFuture_32<T1> extends _i1.SmartFake implements _i16.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_33 extends _i1.SmartFake
+class _FakeCachedProfileInformation_34 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_33(
+  _FakeCachedProfileInformation_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -408,8 +420,8 @@ class _FakeCachedProfileInformation_33 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_34 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_34(
+class _FakeMediaConfig_35 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -418,8 +430,8 @@ class _FakeMediaConfig_34 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_35 extends _i1.SmartFake implements _i17.FileResponse {
-  _FakeFileResponse_35(
+class _FakeFileResponse_36 extends _i1.SmartFake implements _i18.FileResponse {
+  _FakeFileResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -428,8 +440,8 @@ class _FakeFileResponse_35 extends _i1.SmartFake implements _i17.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_36 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_36(
+class _FakePreviewForUrl_37 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -438,9 +450,9 @@ class _FakePreviewForUrl_36 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_37 extends _i1.SmartFake
+class _FakeCachedPresence_38 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_37(
+  _FakeCachedPresence_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -449,9 +461,9 @@ class _FakeCachedPresence_37 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_38 extends _i1.SmartFake
+class _FakeTurnServerCredentials_39 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_38(
+  _FakeTurnServerCredentials_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -460,9 +472,9 @@ class _FakeTurnServerCredentials_38 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_39 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_40 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_39(
+  _FakeRoomKeysUpdateResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -471,8 +483,8 @@ class _FakeRoomKeysUpdateResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_40 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_40(
+class _FakeKeyBackupData_41 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -481,9 +493,9 @@ class _FakeKeyBackupData_40 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_41 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_42 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_41(
+  _FakeGetWellknownSupportResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -492,9 +504,9 @@ class _FakeGetWellknownSupportResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_42 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_43 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_42(
+  _FakeGenerateLoginTokenResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -503,9 +515,9 @@ class _FakeGenerateLoginTokenResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_43 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_44 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_43(
+  _FakeGetRoomSummaryResponse$3_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -514,9 +526,9 @@ class _FakeGetRoomSummaryResponse$3_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_44 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_45 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_44(
+  _FakeGetSpaceHierarchyResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -525,9 +537,9 @@ class _FakeGetSpaceHierarchyResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_45 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_46 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_45(
+  _FakeGetRelatingEventsResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -536,9 +548,9 @@ class _FakeGetRelatingEventsResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_46 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_47 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_46(
+  _FakeGetRelatingEventsWithRelTypeResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -547,9 +559,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -558,9 +570,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_48 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_49 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_48(
+  _FakeGetThreadRootsResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -569,9 +581,9 @@ class _FakeGetThreadRootsResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_49 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_50 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_49(
+  _FakeGetEventByTimestampResponse_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -580,9 +592,9 @@ class _FakeGetEventByTimestampResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_50 extends _i1.SmartFake
+class _FakeRequestTokenResponse_51 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_50(
+  _FakeRequestTokenResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -591,9 +603,9 @@ class _FakeRequestTokenResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_51 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_52 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_51(
+  _FakeTokenOwnerInfo_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -602,8 +614,8 @@ class _FakeTokenOwnerInfo_51 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_52 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_52(
+class _FakeWhoIsInfo_53 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -612,8 +624,8 @@ class _FakeWhoIsInfo_52 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_53 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_53(
+class _FakeCapabilities_54 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -622,8 +634,8 @@ class _FakeCapabilities_53 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_54 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_54(
+class _FakeDevice_55 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -632,9 +644,9 @@ class _FakeDevice_54 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_55 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_56 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_55(
+  _FakeGetRoomIdByAliasResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -643,9 +655,9 @@ class _FakeGetRoomIdByAliasResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_56 extends _i1.SmartFake
+class _FakeGetEventsResponse_57 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_56(
+  _FakeGetEventsResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -654,9 +666,9 @@ class _FakeGetEventsResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_57 extends _i1.SmartFake
+class _FakePeekEventsResponse_58 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_57(
+  _FakePeekEventsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -665,8 +677,8 @@ class _FakePeekEventsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_58 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_58(
+class _FakeMatrixEvent_59 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -675,9 +687,9 @@ class _FakeMatrixEvent_58 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_59 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_60 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_59(
+  _FakeGetKeysChangesResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -686,9 +698,9 @@ class _FakeGetKeysChangesResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_60 extends _i1.SmartFake
+class _FakeClaimKeysResponse_61 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_60(
+  _FakeClaimKeysResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -697,9 +709,9 @@ class _FakeClaimKeysResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_61 extends _i1.SmartFake
+class _FakeQueryKeysResponse_62 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_61(
+  _FakeQueryKeysResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -708,9 +720,9 @@ class _FakeQueryKeysResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_62 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_63 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_62(
+  _FakeGetNotificationsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -719,9 +731,9 @@ class _FakeGetNotificationsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_63 extends _i1.SmartFake
+class _FakeGetPresenceResponse_64 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_63(
+  _FakeGetPresenceResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -730,9 +742,9 @@ class _FakeGetPresenceResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_64 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_65 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_64(
+  _FakeGetPublicRoomsResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -741,9 +753,9 @@ class _FakeGetPublicRoomsResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_65 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_66 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_65(
+  _FakeQueryPublicRoomsResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -752,8 +764,8 @@ class _FakeQueryPublicRoomsResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_66 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_66(
+class _FakePushRuleSet_67 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -762,9 +774,9 @@ class _FakePushRuleSet_66 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_67 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_68 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_67(
+  _FakeGetPushRulesGlobalResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -773,8 +785,8 @@ class _FakeGetPushRulesGlobalResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_68 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_68(
+class _FakePushRule_69 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -783,9 +795,9 @@ class _FakePushRule_68 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_69 extends _i1.SmartFake
+class _FakeRefreshResponse_70 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_69(
+  _FakeRefreshResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -794,8 +806,8 @@ class _FakeRefreshResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_70 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_70(
+class _FakeRoomKeys_71 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -804,8 +816,8 @@ class _FakeRoomKeys_70 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_71 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_71(
+class _FakeRoomKeyBackup_72 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -814,9 +826,9 @@ class _FakeRoomKeyBackup_71 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_72 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_73 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_72(
+  _FakeGetRoomKeysVersionCurrentResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -825,9 +837,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_73 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_74 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_73(
+  _FakeGetRoomKeysVersionResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -836,8 +848,8 @@ class _FakeGetRoomKeysVersionResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_74 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_74(
+class _FakeEventContext_75 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -846,9 +858,9 @@ class _FakeEventContext_74 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_75 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_76 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_75(
+  _FakeGetRoomEventsResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -857,8 +869,8 @@ class _FakeGetRoomEventsResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_76 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_76(
+class _FakeSearchResults_77 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,9 +879,9 @@ class _FakeSearchResults_76 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_77 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_78 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_77(
+  _FakeGetProtocolMetadataResponse$2_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -878,9 +890,9 @@ class _FakeGetProtocolMetadataResponse$2_77 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_78 extends _i1.SmartFake
+class _FakeOpenIdCredentials_79 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_78(
+  _FakeOpenIdCredentials_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -889,9 +901,9 @@ class _FakeOpenIdCredentials_78 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_79 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_80 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_79(
+  _FakeSearchUserDirectoryResponse_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -900,9 +912,9 @@ class _FakeSearchUserDirectoryResponse_79 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_80 extends _i1.SmartFake
+class _FakeCreateContentResponse_81 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_80(
+  _FakeCreateContentResponse_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -914,7 +926,7 @@ class _FakeCreateContentResponse_80 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -944,11 +956,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1086,17 +1098,30 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i12.OutboxService);
 
   @override
-  _i13.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i13.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i13.AvatarResolver);
+
+  @override
+  _i14.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_11(
+        returnValue: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_11(
+        returnValueForMissingStub: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i13.StickerPackService);
+      ) as _i14.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1205,7 +1230,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set stickerPacks(_i13.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i13.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i14.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -1221,14 +1255,14 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  _i16.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i17.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1258,7 +1292,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1268,18 +1302,18 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i17.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<bool> login({
+  _i17.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1296,12 +1330,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> completeSsoLogin({
+  _i17.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1314,12 +1348,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> completeRegistration(
+  _i17.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1329,32 +1363,32 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> logout() => (super.noSuchMethod(
+  _i17.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i17.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1363,7 +1397,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1372,17 +1406,17 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i17.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1393,7 +1427,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1430,26 +1464,26 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i17.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+  _i17.Future<bool> didPushRouteInformation(
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1479,7 +1513,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1488,7 +1522,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1497,16 +1531,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i17.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i16.Future<_i20.AppExitResponse>);
+            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i17.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1534,11 +1568,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1568,11 +1602,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_12(
+        returnValue: _FakeRoomSummary_13(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_12(
+        returnValueForMissingStub: _FakeRoomSummary_13(
           this,
           Invocation.getter(#summary),
         ),
@@ -1602,11 +1636,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i16.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i17.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i16.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i16.Completer<dynamic>>[],
-      ) as List<_i16.Completer<dynamic>>);
+        returnValue: <_i17.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i17.Completer<dynamic>>[],
+      ) as List<_i17.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1625,51 +1659,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i14.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i15.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i14.CachedStreamController<String> get onSessionKeyReceived =>
+  _i15.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1685,11 +1719,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1698,11 +1732,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1745,11 +1779,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1758,11 +1792,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_14(
+        returnValue: _FakeDateTime_15(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_14(
+        returnValueForMissingStub: _FakeDateTime_15(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1792,11 +1826,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_15(
+        returnValue: _FakeLatestReceiptState_16(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_15(
+        returnValueForMissingStub: _FakeLatestReceiptState_16(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1817,18 +1851,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i16.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i17.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -2015,18 +2049,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -2139,14 +2173,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i16.Future<void> postLoad() => (super.noSuchMethod(
+  _i17.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2174,15 +2208,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i16.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i17.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i16.Future<List<_i4.User>>);
+            _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i17.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2193,14 +2227,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2210,18 +2244,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i16.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i17.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Event?> refreshLastEvent(
+  _i17.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2229,9 +2263,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2243,12 +2277,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i16.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i17.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2256,22 +2290,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i17.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2279,17 +2313,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> addTag(
+  _i17.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2299,27 +2333,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i17.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i17.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2327,53 +2361,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i17.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i17.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+  _i17.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
         Invocation.method(
           #setLowPriority,
           [lowPriority],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i17.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2381,14 +2415,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2400,7 +2434,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i16.Future<String?> sendTextEvent(
+  _i17.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2432,12 +2466,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendReaction(
+  _i17.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2451,12 +2485,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendLocation(
+  _i17.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2470,12 +2504,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendFileEvent(
+  _i17.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2503,25 +2537,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i17.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i16.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i17.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i16.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i17.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i16.Future<_i4.EncryptionHealthState>);
+      ) as _i17.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i16.Future<String?> sendEvent(
+  _i17.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2545,73 +2579,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i17.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leave() => (super.noSuchMethod(
+  _i17.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> forget() => (super.noSuchMethod(
+  _i17.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> setPower(
+  _i17.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2623,7 +2657,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2634,7 +2668,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2644,10 +2678,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> invite(
+  _i17.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2657,12 +2691,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<int> requestHistory({
+  _i17.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2679,32 +2713,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
-  _i16.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i17.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setReadMarker(
+  _i17.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2718,23 +2752,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
+  _i17.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i16.Future<_i24.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i16.Future<_i24.TimelineChunk?>.value(),
-      ) as _i16.Future<_i24.TimelineChunk?>);
+        returnValue: _i17.Future<_i25.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i17.Future<_i25.TimelineChunk?>.value(),
+      ) as _i17.Future<_i25.TimelineChunk?>);
 
   @override
-  _i16.Future<void> postReceipt(
+  _i17.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2744,12 +2778,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Timeline> getTimeline({
+  _i17.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2772,7 +2806,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i16.Future<_i4.Timeline>.value(_FakeTimeline_17(
+        returnValue: _i17.Future<_i4.Timeline>.value(_FakeTimeline_18(
           this,
           Invocation.method(
             #getTimeline,
@@ -2789,7 +2823,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Timeline>.value(_FakeTimeline_17(
+            _i17.Future<_i4.Timeline>.value(_FakeTimeline_18(
           this,
           Invocation.method(
             #getTimeline,
@@ -2805,7 +2839,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Timeline>);
+      ) as _i17.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2824,7 +2858,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i16.Future<List<_i4.User>> requestParticipants([
+  _i17.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2842,10 +2876,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i16.Future<List<_i4.User>>);
+            _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i17.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2853,14 +2887,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_18(
+        returnValue: _FakeUser_19(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_18(
+        returnValueForMissingStub: _FakeUser_19(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2876,14 +2910,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_18(
+        returnValue: _FakeUser_19(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_18(
+        returnValueForMissingStub: _FakeUser_19(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2893,7 +2927,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i16.Future<_i4.User?> requestUser(
+  _i17.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2909,19 +2943,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i16.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.User?>.value(),
-      ) as _i16.Future<_i4.User?>);
+        returnValue: _i17.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.User?>.value(),
+      ) as _i17.Future<_i4.User?>);
 
   @override
-  _i16.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i17.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2934,12 +2968,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i16.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i17.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2947,14 +2981,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2977,14 +3011,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i16.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i17.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -3023,18 +3057,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i16.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i17.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEvent(
+  _i17.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -3048,12 +3082,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> setTyping(
+  _i17.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -3063,12 +3097,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setJoinRules(
+  _i17.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -3082,59 +3116,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i17.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setHistoryVisibility(
+  _i17.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i17.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i17.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i16.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i17.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i16.Future<List<_i4.DeviceKeys>>);
+            _i17.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i17.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i16.Future<void> requestSessionKey(
+  _i17.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3146,12 +3180,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setSpaceChild(
+  _i17.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3167,44 +3201,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i17.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValue: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i16.Future<Uri>);
+      ) as _i17.Future<Uri>);
 
   @override
-  _i16.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<
+  _i17.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3231,21 +3265,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i16.Future<
+        returnValue: _i17.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i16.Future<
+        returnValueForMissingStub: _i17.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i16.Future<
+      ) as _i17.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3260,23 +3294,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_20(
+        returnValue: _FakeDatabaseApi_21(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_20(
+        returnValueForMissingStub: _FakeDatabaseApi_21(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i25.KeyVerificationMethod> get verificationMethods =>
+  Set<_i26.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i25.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i25.KeyVerificationMethod>{},
-      ) as Set<_i25.KeyVerificationMethod>);
+        returnValue: <_i26.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i26.KeyVerificationMethod>{},
+      ) as Set<_i26.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3337,11 +3371,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_21(
+        returnValue: _FakeFilter_22(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_21(
+        returnValueForMissingStub: _FakeFilter_22(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3350,11 +3384,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_22(
+        returnValue: _FakeNativeImplementations_23(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_22(
+        returnValueForMissingStub: _FakeNativeImplementations_23(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3370,11 +3404,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_23(
+        returnValue: _FakeDuration_24(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_23(
+        returnValueForMissingStub: _FakeDuration_24(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3383,11 +3417,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_23(
+        returnValue: _FakeDuration_24(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_23(
+        returnValueForMissingStub: _FakeDuration_24(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3396,11 +3430,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3437,11 +3471,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3471,11 +3505,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3484,11 +3518,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3511,11 +3545,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_24(
+        returnValue: _FakePushruleEvaluator_25(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_24(
+        returnValueForMissingStub: _FakePushruleEvaluator_25(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3536,332 +3570,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i16.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i17.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i14.CachedStreamController<String> get onUserProfileUpdate =>
+  _i15.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i16.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i17.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i16.Future<List<_i4.Room>>);
+            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i17.Future<List<_i4.Room>>);
 
   @override
-  _i14.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i15.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.EventUpdate>(
+            _FakeCachedStreamController_14<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.EventUpdate>);
+      ) as _i15.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i15.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i15.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onNotification =>
+  _i15.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i15.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i15.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i14.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i15.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_13<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_13<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i14.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i15.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i14.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i15.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_13<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_14<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.LoginState>(
+            _FakeCachedStreamController_14<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i14.CachedStreamController<_i4.LoginState>);
+      ) as _i15.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i14.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i15.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_13<bool>(
+        returnValue: _FakeCachedStreamController_14<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i14.CachedStreamController<bool>);
+      ) as _i15.CachedStreamController<bool>);
 
   @override
-  _i14.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i15.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_13<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_14<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i14.CachedStreamController<_i4.SdkError>);
+      ) as _i15.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i14.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i15.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_13<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.SyncUpdate>(
+            _FakeCachedStreamController_14<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i14.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i15.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i15.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_13<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i14.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i15.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.Presence> get onPresence =>
+  _i15.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_13<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_14<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i14.CachedStreamController<_i4.Presence>);
+      ) as _i15.CachedStreamController<_i4.Presence>);
 
   @override
-  _i14.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i15.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_13<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_14<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.CachedPresence>(
+            _FakeCachedStreamController_14<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i14.CachedStreamController<_i4.CachedPresence>);
+      ) as _i15.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i14.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i15.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_13<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_14<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.BasicEvent>(
+            _FakeCachedStreamController_14<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i14.CachedStreamController<_i4.BasicEvent>);
+      ) as _i15.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i14.CachedStreamController<_i25.RoomKeyRequest> get onRoomKeyRequest =>
+  _i15.CachedStreamController<_i26.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_13<_i25.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_14<_i26.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i25.RoomKeyRequest>(
+            _FakeCachedStreamController_14<_i26.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i14.CachedStreamController<_i25.RoomKeyRequest>);
+      ) as _i15.CachedStreamController<_i26.RoomKeyRequest>);
 
   @override
-  _i14.CachedStreamController<_i25.KeyVerification>
+  _i15.CachedStreamController<_i26.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_13<_i25.KeyVerification>(
+            returnValue: _FakeCachedStreamController_14<_i26.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_13<_i25.KeyVerification>(
+                _FakeCachedStreamController_14<_i26.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i14.CachedStreamController<_i25.KeyVerification>);
+          ) as _i15.CachedStreamController<_i26.KeyVerification>);
 
   @override
-  _i14.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i15.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_13<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i14.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i15.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i15.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<String> get onCancelSendEvent =>
+  _i15.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i14.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i15.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_13<
+            returnValue: _FakeCachedStreamController_14<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_13<
+            returnValueForMissingStub: _FakeCachedStreamController_14<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i14.CachedStreamController<
+          ) as _i15.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3881,11 +3915,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_14(
+        returnValue: _FakeDateTime_15(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_14(
+        returnValueForMissingStub: _FakeDateTime_15(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3958,7 +3992,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i25.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i26.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -4013,7 +4047,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i16.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i17.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -4024,7 +4058,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i16.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i17.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -4135,7 +4169,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4144,7 +4178,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4153,7 +4187,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4180,20 +4214,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i15.Client get httpClient => (super.noSuchMethod(
+  _i16.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_26(
+        returnValue: _FakeClient_27(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_26(
+        returnValueForMissingStub: _FakeClient_27(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i15.Client);
+      ) as _i16.Client);
 
   @override
-  set httpClient(_i15.Client? value) => super.noSuchMethod(
+  set httpClient(_i16.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4220,7 +4254,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<void> refreshAccessToken(
+  _i17.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4228,9 +4262,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4248,14 +4282,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4292,33 +4326,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i16.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i17.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i16.Future<_i4.DiscoveryInformation>);
+      ) as _i17.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i16.Future<
+  _i17.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4340,7 +4374,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i16.Future<
+        returnValue: _i17.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4348,7 +4382,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_28(
+          _FakeGetVersionsResponse_29(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4363,7 +4397,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i16.Future<
+        returnValueForMissingStub: _i17.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4371,7 +4405,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_28(
+          _FakeGetVersionsResponse_29(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4386,7 +4420,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i16.Future<
+      ) as _i17.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4395,7 +4429,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i16.Future<_i4.DiscoveryInformation> getWellknown({
+  _i17.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4408,8 +4442,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getWellknown,
@@ -4420,8 +4454,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getWellknown,
@@ -4432,10 +4466,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.DiscoveryInformation>);
+      ) as _i17.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i16.Future<_i4.RegisterResponse> register({
+  _i17.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4463,7 +4497,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_29(
+            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_30(
           this,
           Invocation.method(
             #register,
@@ -4482,7 +4516,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_29(
+            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_30(
           this,
           Invocation.method(
             #register,
@@ -4500,10 +4534,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RegisterResponse>);
+      ) as _i17.Future<_i4.RegisterResponse>);
 
   @override
-  _i16.Future<_i4.LoginResponse> login(
+  _i17.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4533,7 +4567,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_30(
+        returnValue: _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_31(
           this,
           Invocation.method(
             #login,
@@ -4553,7 +4587,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_30(
+            _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_31(
           this,
           Invocation.method(
             #login,
@@ -4572,10 +4606,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.LoginResponse>);
+      ) as _i17.Future<_i4.LoginResponse>);
 
   @override
-  _i16.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i17.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4588,8 +4622,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_31(
+        returnValue: _i17.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_32(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4601,8 +4635,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_31(
+            _i17.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_32(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4613,74 +4647,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i17.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i16.Future<void> logout() => (super.noSuchMethod(
+  _i17.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> logoutAll() => (super.noSuchMethod(
+  _i17.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<T> uiaRequestBackground<T>(
-          _i16.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i17.Future<T> uiaRequestBackground<T>(
+          _i17.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i16.Future<T>.value(v),
+              (T v) => _i17.Future<T>.value(v),
             ) ??
-            _FakeFuture_32<T>(
+            _FakeFuture_33<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i16.Future<T>.value(v),
+              (T v) => _i17.Future<T>.value(v),
             ) ??
-            _FakeFuture_32<T>(
+            _FakeFuture_33<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i16.Future<T>);
+      ) as _i17.Future<T>);
 
   @override
-  _i16.Future<String> startDirectChat(
+  _i17.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4702,7 +4736,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4718,7 +4752,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4733,10 +4767,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<String> createGroupChat({
+  _i17.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4767,7 +4801,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4788,7 +4822,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4808,10 +4842,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i17.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4827,7 +4861,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4840,7 +4874,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4852,21 +4886,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i17.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<String> createSpace({
+  _i17.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4891,7 +4925,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4909,7 +4943,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4926,10 +4960,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i17.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4937,7 +4971,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4946,7 +4980,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4954,10 +4988,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i16.Future<_i4.Profile> fetchOwnProfile({
+  _i17.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4970,7 +5004,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4982,7 +5016,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4993,10 +5027,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i16.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i17.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -5010,8 +5044,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i16.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_33(
+        returnValue: _i17.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_34(
           this,
           Invocation.method(
             #getUserProfile,
@@ -5023,8 +5057,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_33(
+            _i17.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_34(
           this,
           Invocation.method(
             #getUserProfile,
@@ -5035,10 +5069,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.CachedProfileInformation>);
+      ) as _i17.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i16.Future<_i4.Profile> getProfileFromUserId(
+  _i17.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -5056,7 +5090,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5070,7 +5104,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5083,7 +5117,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -5105,31 +5139,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i16.Future<List<_i4.Room>>);
+            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i17.Future<List<_i4.Room>>);
 
   @override
-  _i16.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i17.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i16.Future<List<_i4.ArchivedRoom>>);
+            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i17.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i16.Future<_i4.GetVersionsResponse> getVersions({
+  _i17.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5142,8 +5176,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_28(
+        returnValue: _i17.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_29(
           this,
           Invocation.method(
             #getVersions,
@@ -5154,8 +5188,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_28(
+        returnValueForMissingStub: _i17.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_29(
           this,
           Invocation.method(
             #getVersions,
@@ -5166,20 +5200,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetVersionsResponse>);
+      ) as _i17.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i16.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i17.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.MediaConfig> getConfig({
+  _i17.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5192,7 +5226,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfig,
@@ -5204,7 +5238,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfig,
@@ -5215,10 +5249,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.MediaConfig>);
+      ) as _i17.Future<_i4.MediaConfig>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContent(
+  _i17.Future<_i18.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5238,7 +5272,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContent,
@@ -5254,7 +5288,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContent,
@@ -5269,10 +5303,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentOverrideName(
+  _i17.Future<_i18.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5294,7 +5328,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5311,7 +5345,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5327,10 +5361,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentThumbnail(
+  _i17.Future<_i18.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5358,7 +5392,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5378,7 +5412,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5397,10 +5431,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i17.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5410,7 +5444,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5419,7 +5453,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5427,11 +5461,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i16.Future<_i4.PreviewForUrl>);
+      ) as _i17.Future<_i4.PreviewForUrl>);
 
   @override
-  _i16.Future<Uri> uploadContent(
-    _i26.Uint8List? file, {
+  _i17.Future<Uri> uploadContent(
+    _i27.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5444,7 +5478,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValue: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #uploadContent,
@@ -5455,7 +5489,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #uploadContent,
@@ -5466,10 +5500,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<Uri>);
+      ) as _i17.Future<Uri>);
 
   @override
-  _i16.Future<void> setTyping(
+  _i17.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5485,42 +5519,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> exportDump() => (super.noSuchMethod(
+  _i17.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i17.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i17.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Event?> getEventByPushNotification(
+  _i17.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5536,12 +5570,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
-  _i16.Future<void> init({
+  _i17.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5576,9 +5610,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5590,40 +5624,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<void> clear() => (super.noSuchMethod(
+  _i17.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i17.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ensureNotSoftLoggedOut(
+  _i17.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> handleSync(
+  _i17.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5633,9 +5667,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5648,29 +5682,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i16.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i17.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i17.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDevice(
+  _i17.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5684,12 +5718,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDevicesOfUserIds(
+  _i17.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5705,12 +5739,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDeviceEncrypted(
+  _i17.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5730,12 +5764,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDeviceEncryptedChunked(
+  _i17.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5749,23 +5783,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i17.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> joinRoom(
+  _i17.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5783,7 +5817,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5797,7 +5831,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5810,10 +5844,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> changePassword(
+  _i17.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5829,22 +5863,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> clearCache() => (super.noSuchMethod(
+  _i17.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ignoreUser(
+  _i17.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5854,22 +5888,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i17.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i17.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5880,7 +5914,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_37(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_38(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5889,7 +5923,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_37(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_38(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5897,32 +5931,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i16.Future<_i4.CachedPresence>);
+      ) as _i17.Future<_i4.CachedPresence>);
 
   @override
-  _i16.Future<void> abortSync() => (super.noSuchMethod(
+  _i17.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i17.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEventWithMetadata(
+  _i17.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5942,14 +5976,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i15.BaseResponse? response,
-    _i26.Uint8List? body,
+    _i16.BaseResponse? response,
+    _i27.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5981,7 +6015,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i16.Future<Map<String, Object?>> request(
+  _i17.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -6002,13 +6036,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> postPusher(
+  _i17.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -6018,57 +6052,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i17.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i17.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i17.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i16.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_38(
+        returnValue: _i17.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_39(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_38(
+        returnValueForMissingStub: _i17.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_39(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.TurnServerCredentials>);
+      ) as _i17.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6082,8 +6116,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6095,8 +6129,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6107,10 +6141,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6126,8 +6160,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6140,8 +6174,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6153,10 +6187,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i17.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6170,7 +6204,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6182,7 +6216,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6193,17 +6227,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.KeyBackupData>);
+      ) as _i17.Future<_i4.KeyBackupData>);
 
   @override
-  _i16.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i17.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i16.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_41(
+        returnValue: _i17.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_42(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6211,18 +6245,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_41(
+            _i17.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_42(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i17.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i16.Future<int> pingAppservice(
+  _i17.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6232,12 +6266,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
-  _i16.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i17.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6245,8 +6279,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_42(
+        returnValue: _i17.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_43(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6255,8 +6289,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_42(
+            _i17.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_43(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6264,15 +6298,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i16.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i17.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i16.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i17.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6280,17 +6314,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.MediaConfig>);
+      ) as _i17.Future<_i4.MediaConfig>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentAuthed(
+  _i17.Future<_i18.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6304,7 +6338,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6316,7 +6350,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6327,10 +6361,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentOverrideNameAuthed(
+  _i17.Future<_i18.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6346,7 +6380,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6359,7 +6393,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6371,10 +6405,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i17.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6384,7 +6418,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6393,7 +6427,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6401,10 +6435,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i16.Future<_i4.PreviewForUrl>);
+      ) as _i17.Future<_i4.PreviewForUrl>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentThumbnailAuthed(
+  _i17.Future<_i18.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6428,7 +6462,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6446,7 +6480,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6463,21 +6497,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<bool> registrationTokenValidity(String? token) =>
+  _i17.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i17.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6487,8 +6521,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_43(
+        returnValue: _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_44(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6497,8 +6531,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_43(
+            _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_44(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6506,10 +6540,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i17.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i16.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i17.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6527,8 +6561,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_44(
+        returnValue: _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_45(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6542,8 +6576,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_44(
+            _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_45(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6556,10 +6590,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i17.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i17.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6583,8 +6617,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i16.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_45(
+        returnValue: _i17.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_46(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6602,8 +6636,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_45(
+            _i17.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_46(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6620,10 +6654,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i17.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6651,8 +6685,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_46(
+                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_47(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6671,8 +6705,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_46(
+                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_47(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6690,10 +6724,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i17.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6722,9 +6756,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i16.Future<
+            returnValue: _i17.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6743,9 +6777,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i16.Future<
+            returnValueForMissingStub: _i17.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6764,11 +6798,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i16
+          ) as _i17
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i16.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i17.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6784,8 +6818,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i16.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_48(
+        returnValue: _i17.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_49(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6798,8 +6832,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_48(
+            _i17.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_49(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6811,10 +6845,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetThreadRootsResponse>);
+      ) as _i17.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i16.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i17.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6828,8 +6862,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i16.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_49(
+        returnValue: _i17.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_50(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6841,8 +6875,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_49(
+            _i17.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_50(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6853,33 +6887,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i17.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i17.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i16.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i17.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i16.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i17.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i16.Future<Uri?>.value(),
-        returnValueForMissingStub: _i16.Future<Uri?>.value(),
-      ) as _i16.Future<Uri?>);
+        returnValue: _i17.Future<Uri?>.value(),
+        returnValueForMissingStub: _i17.Future<Uri?>.value(),
+      ) as _i17.Future<Uri?>);
 
   @override
-  _i16.Future<void> add3PID(
+  _i17.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6893,12 +6927,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> bind3PID(
+  _i17.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6914,12 +6948,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i17.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6933,14 +6967,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6962,8 +6996,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6979,8 +7013,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6996,10 +7030,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7023,8 +7057,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -7041,8 +7075,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -7059,10 +7093,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i17.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -7076,14 +7110,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i17.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -7098,14 +7132,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7127,8 +7161,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7144,8 +7178,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7161,10 +7195,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7188,8 +7222,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7206,8 +7240,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7224,16 +7258,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i17.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_51(
+            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_52(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7241,22 +7275,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_51(
+            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_52(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.TokenOwnerInfo>);
+      ) as _i17.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i16.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i17.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_52(
+        returnValue: _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_53(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7264,22 +7298,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_52(
+            _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_53(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i16.Future<_i4.WhoIsInfo>);
+      ) as _i17.Future<_i4.WhoIsInfo>);
 
   @override
-  _i16.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i17.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_53(
+        returnValue: _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_54(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7287,17 +7321,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_53(
+            _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_54(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.Capabilities>);
+      ) as _i17.Future<_i4.Capabilities>);
 
   @override
-  _i16.Future<String> createRoom({
+  _i17.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7330,7 +7364,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7352,7 +7386,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7373,10 +7407,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> deleteDevices(
+  _i17.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7386,22 +7420,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.Device>?>.value(),
-      ) as _i16.Future<List<_i4.Device>?>);
+        returnValue: _i17.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.Device>?>.value(),
+      ) as _i17.Future<List<_i4.Device>?>);
 
   @override
-  _i16.Future<void> deleteDevice(
+  _i17.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7411,34 +7445,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i17.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i16.Future<_i4.Device>.value(_FakeDevice_54(
+        returnValue: _i17.Future<_i4.Device>.value(_FakeDevice_55(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.Device>.value(_FakeDevice_54(
+        returnValueForMissingStub: _i17.Future<_i4.Device>.value(_FakeDevice_55(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i16.Future<_i4.Device>);
+      ) as _i17.Future<_i4.Device>);
 
   @override
-  _i16.Future<void> updateDevice(
+  _i17.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7448,12 +7482,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i17.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7468,24 +7502,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i17.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i16.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Visibility?>.value(),
-      ) as _i16.Future<_i4.Visibility?>);
+        returnValue: _i17.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Visibility?>.value(),
+      ) as _i17.Future<_i4.Visibility?>);
 
   @override
-  _i16.Future<void> setRoomVisibilityOnDirectory(
+  _i17.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7495,30 +7529,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i17.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i17.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_55(
+        returnValue: _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_56(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7526,18 +7560,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_55(
+            _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_56(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i17.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i16.Future<void> setRoomAlias(
+  _i17.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7549,12 +7583,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetEventsResponse> getEvents({
+  _i17.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7568,7 +7602,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_56(
+            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_57(
           this,
           Invocation.method(
             #getEvents,
@@ -7580,7 +7614,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_56(
+            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_57(
           this,
           Invocation.method(
             #getEvents,
@@ -7591,10 +7625,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetEventsResponse>);
+      ) as _i17.Future<_i4.GetEventsResponse>);
 
   @override
-  _i16.Future<_i4.PeekEventsResponse> peekEvents({
+  _i17.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7609,8 +7643,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i16.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_57(
+        returnValue: _i17.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_58(
           this,
           Invocation.method(
             #peekEvents,
@@ -7622,8 +7656,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_57(
+        returnValueForMissingStub: _i17.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_58(
           this,
           Invocation.method(
             #peekEvents,
@@ -7635,16 +7669,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.PeekEventsResponse>);
+      ) as _i17.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i16.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i17.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7652,27 +7686,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i16.Future<_i4.MatrixEvent>);
+      ) as _i17.Future<_i4.MatrixEvent>);
 
   @override
-  _i16.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i17.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 
   @override
-  _i16.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i17.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7684,8 +7718,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i16.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_59(
+        returnValue: _i17.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_60(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7696,8 +7730,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_59(
+            _i17.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_60(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7707,10 +7741,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.GetKeysChangesResponse>);
+      ) as _i17.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i16.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i17.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7721,7 +7755,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_60(
+            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_61(
           this,
           Invocation.method(
             #claimKeys,
@@ -7730,7 +7764,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_60(
+            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_61(
           this,
           Invocation.method(
             #claimKeys,
@@ -7738,10 +7772,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i16.Future<_i4.ClaimKeysResponse>);
+      ) as _i17.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i16.Future<void> uploadCrossSigningKeys({
+  _i17.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7758,12 +7792,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.QueryKeysResponse> queryKeys(
+  _i17.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7774,7 +7808,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_61(
+            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_62(
           this,
           Invocation.method(
             #queryKeys,
@@ -7783,7 +7817,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_61(
+            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_62(
           this,
           Invocation.method(
             #queryKeys,
@@ -7791,10 +7825,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i16.Future<_i4.QueryKeysResponse>);
+      ) as _i17.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7802,14 +7836,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i16.Future<
+            returnValue: _i17.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i16.Future<
+            returnValueForMissingStub: _i17.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i16.Future<Map<String, int>> uploadKeys({
+  _i17.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7824,13 +7858,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i16.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i17.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i16.Future<Map<String, int>>);
+            _i17.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i17.Future<Map<String, int>>);
 
   @override
-  _i16.Future<String> knockRoom(
+  _i17.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7844,7 +7878,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7856,7 +7890,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7867,20 +7901,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i17.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i16.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i17.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i17.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i16.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i17.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7895,8 +7929,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i16.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_62(
+        returnValue: _i17.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_63(
           this,
           Invocation.method(
             #getNotifications,
@@ -7909,8 +7943,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_62(
+            _i17.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_63(
           this,
           Invocation.method(
             #getNotifications,
@@ -7922,35 +7956,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetNotificationsResponse>);
+      ) as _i17.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i16.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i17.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i16.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_63(
+        returnValue: _i17.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_64(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_63(
+        returnValueForMissingStub: _i17.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_64(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i16.Future<_i4.GetPresenceResponse>);
+      ) as _i17.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i16.Future<void> setPresence(
+  _i17.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7964,12 +7998,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, Object?>> deleteProfileField(
+  _i17.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7982,13 +8016,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getProfileField(
+  _i17.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -8001,13 +8035,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<Map<String, Object?>> setProfileField(
+  _i17.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -8022,13 +8056,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i17.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -8043,8 +8077,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i16.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_64(
+        returnValue: _i17.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_65(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -8057,8 +8091,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_64(
+            _i17.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_65(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -8070,10 +8104,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i17.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i16.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i17.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -8094,8 +8128,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i16.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_65(
+        returnValue: _i17.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_66(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8111,8 +8145,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_65(
+            _i17.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_66(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8127,25 +8161,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i17.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i16.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.Pusher>?>.value(),
-      ) as _i16.Future<List<_i4.Pusher>?>);
+        returnValue: _i17.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.Pusher>?>.value(),
+      ) as _i17.Future<List<_i4.Pusher>?>);
 
   @override
-  _i16.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i17.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_66(
+        returnValue: _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_67(
           this,
           Invocation.method(
             #getPushRules,
@@ -8153,24 +8187,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_66(
+            _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_67(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.PushRuleSet>);
+      ) as _i17.Future<_i4.PushRuleSet>);
 
   @override
-  _i16.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i17.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_67(
+        returnValue: _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_68(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8178,18 +8212,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_67(
+            _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_68(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i17.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i16.Future<void> deletePushRule(
+  _i17.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8201,12 +8235,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.PushRule> getPushRule(
+  _i17.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8218,7 +8252,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<_i4.PushRule>.value(_FakePushRule_68(
+        returnValue: _i17.Future<_i4.PushRule>.value(_FakePushRule_69(
           this,
           Invocation.method(
             #getPushRule,
@@ -8229,7 +8263,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PushRule>.value(_FakePushRule_68(
+            _i17.Future<_i4.PushRule>.value(_FakePushRule_69(
           this,
           Invocation.method(
             #getPushRule,
@@ -8239,10 +8273,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.PushRule>);
+      ) as _i17.Future<_i4.PushRule>);
 
   @override
-  _i16.Future<void> setPushRule(
+  _i17.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8266,12 +8300,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<Object?>> getPushRuleActions(
+  _i17.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8283,13 +8317,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i17.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i16.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i16.Future<List<Object?>>);
+            _i17.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i17.Future<List<Object?>>);
 
   @override
-  _i16.Future<void> setPushRuleActions(
+  _i17.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8303,12 +8337,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<bool> isPushRuleEnabled(
+  _i17.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8320,12 +8354,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> setPushRuleEnabled(
+  _i17.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8339,19 +8373,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i17.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_69(
+            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_70(
           this,
           Invocation.method(
             #refresh,
@@ -8359,28 +8393,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_69(
+            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_70(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i16.Future<_i4.RefreshResponse>);
+      ) as _i17.Future<_i4.RefreshResponse>);
 
   @override
-  _i16.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i17.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i16.Future<bool?>.value(),
-        returnValueForMissingStub: _i16.Future<bool?>.value(),
-      ) as _i16.Future<bool?>);
+        returnValue: _i17.Future<bool?>.value(),
+        returnValueForMissingStub: _i17.Future<bool?>.value(),
+      ) as _i17.Future<bool?>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8402,8 +8436,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8419,8 +8453,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8436,10 +8470,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8463,8 +8497,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8481,8 +8515,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8499,17 +8533,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8517,23 +8551,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i17.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_70(
+        returnValue: _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_71(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8541,17 +8575,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_70(
+            _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_71(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeys>);
+      ) as _i17.Future<_i4.RoomKeys>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8563,8 +8597,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8575,8 +8609,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8586,10 +8620,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8601,8 +8635,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8613,8 +8647,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8624,10 +8658,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8639,7 +8673,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_71(
+        returnValue: _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_72(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8650,7 +8684,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_71(
+            _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_72(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8660,10 +8694,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeyBackup>);
+      ) as _i17.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8677,8 +8711,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8690,8 +8724,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8702,10 +8736,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8719,8 +8753,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8732,8 +8766,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8744,10 +8778,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i17.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8761,7 +8795,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8773,7 +8807,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8784,10 +8818,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.KeyBackupData>);
+      ) as _i17.Future<_i4.KeyBackupData>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8803,8 +8837,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8817,8 +8851,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8830,18 +8864,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_72(
+                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_73(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8849,18 +8883,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_72(
+                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_73(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i16.Future<String> postRoomKeysVersion(
+  _i17.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8872,7 +8906,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8883,7 +8917,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8893,29 +8927,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i17.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i17.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_73(
+        returnValue: _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_74(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8923,18 +8957,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_73(
+            _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_74(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i17.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i17.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8949,24 +8983,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i17.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 
   @override
-  _i16.Future<void> ban(
+  _i17.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8980,12 +9014,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.EventContext> getEventContext(
+  _i17.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -9003,7 +9037,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<_i4.EventContext>.value(_FakeEventContext_74(
+        returnValue: _i17.Future<_i4.EventContext>.value(_FakeEventContext_75(
           this,
           Invocation.method(
             #getEventContext,
@@ -9018,7 +9052,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.EventContext>.value(_FakeEventContext_74(
+            _i17.Future<_i4.EventContext>.value(_FakeEventContext_75(
           this,
           Invocation.method(
             #getEventContext,
@@ -9032,10 +9066,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.EventContext>);
+      ) as _i17.Future<_i4.EventContext>);
 
   @override
-  _i16.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i17.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -9047,7 +9081,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -9058,7 +9092,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -9068,20 +9102,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.MatrixEvent>);
+      ) as _i17.Future<_i4.MatrixEvent>);
 
   @override
-  _i16.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> inviteBy3PID(
+  _i17.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -9093,12 +9127,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> inviteUser(
+  _i17.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9112,12 +9146,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> joinRoomById(
+  _i17.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -9131,7 +9165,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9143,7 +9177,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9154,23 +9188,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i17.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i17.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i16.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i16.Future<Map<String, _i4.RoomMember>?>);
+            _i17.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i17.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i16.Future<void> kick(
+  _i17.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9184,12 +9218,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leaveRoom(
+  _i17.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9199,12 +9233,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i17.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9220,12 +9254,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i16.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i16.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i17.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i17.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i16.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i17.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9247,8 +9281,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_75(
+        returnValue: _i17.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_76(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9264,8 +9298,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_75(
+        returnValueForMissingStub: _i17.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_76(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9281,10 +9315,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomEventsResponse>);
+      ) as _i17.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i16.Future<void> setReadMarker(
+  _i17.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9300,12 +9334,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> postReceipt(
+  _i17.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9321,12 +9355,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEvent(
+  _i17.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9342,12 +9376,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> reportRoom(
+  _i17.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9359,12 +9393,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> reportEvent(
+  _i17.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9382,12 +9416,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> sendMessage(
+  _i17.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9403,7 +9437,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9416,7 +9450,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9428,23 +9462,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i17.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i16.Future<List<_i4.MatrixEvent>>);
+            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i17.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i17.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9461,13 +9495,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<String> setRoomStateWithKey(
+  _i17.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9483,7 +9517,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9496,7 +9530,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9508,10 +9542,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> unban(
+  _i17.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9525,12 +9559,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> upgradeRoom(
+  _i17.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9544,7 +9578,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9556,7 +9590,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9567,10 +9601,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.SearchResults> search(
+  _i17.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9580,7 +9614,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_76(
+        returnValue: _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_77(
           this,
           Invocation.method(
             #search,
@@ -9589,7 +9623,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_76(
+            _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_77(
           this,
           Invocation.method(
             #search,
@@ -9597,10 +9631,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i16.Future<_i4.SearchResults>);
+      ) as _i17.Future<_i4.SearchResults>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> sync({
+  _i17.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9621,7 +9655,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #sync,
@@ -9637,7 +9671,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #sync,
@@ -9652,22 +9686,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i17.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i16.Future<List<_i4.Location>>);
+            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i17.Future<List<_i4.Location>>);
 
   @override
-  _i16.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i17.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9677,21 +9711,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i16.Future<List<_i4.Location>>);
+            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i17.Future<List<_i4.Location>>);
 
   @override
-  _i16.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i17.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_77(
+        returnValue: _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_78(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9699,45 +9733,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_77(
+            _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_78(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i16.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i17.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i16.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i17.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9748,13 +9782,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getAccountData(
+  _i17.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9767,13 +9801,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> setAccountData(
+  _i17.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9787,12 +9821,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> defineFilter(
+  _i17.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9804,7 +9838,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9815,7 +9849,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9825,10 +9859,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.Filter> getFilter(
+  _i17.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9840,7 +9874,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i16.Future<_i4.Filter>.value(_FakeFilter_21(
+        returnValue: _i17.Future<_i4.Filter>.value(_FakeFilter_22(
           this,
           Invocation.method(
             #getFilter,
@@ -9850,7 +9884,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.Filter>.value(_FakeFilter_21(
+        returnValueForMissingStub: _i17.Future<_i4.Filter>.value(_FakeFilter_22(
           this,
           Invocation.method(
             #getFilter,
@@ -9860,10 +9894,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.Filter>);
+      ) as _i17.Future<_i4.Filter>);
 
   @override
-  _i16.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i17.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9876,7 +9910,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_78(
+            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_79(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9887,7 +9921,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_78(
+            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_79(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9897,10 +9931,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.OpenIdCredentials>);
+      ) as _i17.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i16.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i17.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9915,13 +9949,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> setAccountDataPerRoom(
+  _i17.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9937,12 +9971,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i17.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9954,12 +9988,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i16.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i16.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i16.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i17.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i17.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i17.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i16.Future<void> deleteRoomTag(
+  _i17.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9973,12 +10007,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setRoomTag(
+  _i17.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9994,12 +10028,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i17.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -10009,8 +10043,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i16.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_79(
+        returnValue: _i17.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_80(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -10019,8 +10053,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_79(
+            _i17.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_80(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -10028,10 +10062,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i16.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i17.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> reportUser(
+  _i17.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -10044,40 +10078,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i17.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i16.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_80(
+        returnValue: _i17.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_81(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_80(
+        returnValueForMissingStub: _i17.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_81(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.CreateContentResponse>);
+      ) as _i17.Future<_i4.CreateContentResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> uploadContentToMXC(
+  _i17.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i26.Uint8List? body, {
+    _i27.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10095,8 +10129,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 }

--- a/test/widgets/invite_tile_test.mocks.dart
+++ b/test/widgets/invite_tile_test.mocks.dart
@@ -3,15 +3,15 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i16;
-import 'dart:typed_data' as _i26;
-import 'dart:ui' as _i20;
+import 'dart:async' as _i17;
+import 'dart:typed_data' as _i27;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
-import 'package:http/http.dart' as _i15;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i13;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
+import 'package:http/http.dart' as _i16;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -27,14 +27,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i25;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i13;
+import 'package:matrix/encryption.dart' as _i26;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i17;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i14;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i18;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i15;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -168,9 +169,9 @@ class _FakeOutboxService_10 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_11 extends _i1.SmartFake
-    implements _i13.StickerPackService {
-  _FakeStickerPackService_11(
+class _FakeAvatarResolver_11 extends _i1.SmartFake
+    implements _i13.AvatarResolver {
+  _FakeAvatarResolver_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -179,8 +180,9 @@ class _FakeStickerPackService_11 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_12 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_12(
+class _FakeStickerPackService_12 extends _i1.SmartFake
+    implements _i14.StickerPackService {
+  _FakeStickerPackService_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -189,9 +191,8 @@ class _FakeRoomSummary_12 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_13<T> extends _i1.SmartFake
-    implements _i14.CachedStreamController<T> {
-  _FakeCachedStreamController_13(
+class _FakeRoomSummary_13 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -200,8 +201,9 @@ class _FakeCachedStreamController_13<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_14 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_14(
+class _FakeCachedStreamController_14<T> extends _i1.SmartFake
+    implements _i15.CachedStreamController<T> {
+  _FakeCachedStreamController_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -210,9 +212,19 @@ class _FakeDateTime_14 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_15 extends _i1.SmartFake
+class _FakeDateTime_15 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_15(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_16 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_15(
+  _FakeLatestReceiptState_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -221,8 +233,8 @@ class _FakeLatestReceiptState_15 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_16 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_16(
+class _FakeSyncUpdate_17 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -231,8 +243,8 @@ class _FakeSyncUpdate_16 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_17 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_17(
+class _FakeTimeline_18 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -241,8 +253,8 @@ class _FakeTimeline_17 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_18 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_18(
+class _FakeUser_19 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -251,8 +263,8 @@ class _FakeUser_18 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_19 extends _i1.SmartFake implements Uri {
-  _FakeUri_19(
+class _FakeUri_20 extends _i1.SmartFake implements Uri {
+  _FakeUri_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -261,8 +273,8 @@ class _FakeUri_19 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_20 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_20(
+class _FakeDatabaseApi_21 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -271,8 +283,8 @@ class _FakeDatabaseApi_20 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_21 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_21(
+class _FakeFilter_22 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -281,9 +293,9 @@ class _FakeFilter_21 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_22 extends _i1.SmartFake
+class _FakeNativeImplementations_23 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_22(
+  _FakeNativeImplementations_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -292,8 +304,8 @@ class _FakeNativeImplementations_22 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_23 extends _i1.SmartFake implements Duration {
-  _FakeDuration_23(
+class _FakeDuration_24 extends _i1.SmartFake implements Duration {
+  _FakeDuration_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -302,9 +314,9 @@ class _FakeDuration_23 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_24 extends _i1.SmartFake
+class _FakePushruleEvaluator_25 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_24(
+  _FakePushruleEvaluator_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -313,8 +325,8 @@ class _FakePushruleEvaluator_24 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_25 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_25(
+class _FakeProfile_26 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -323,8 +335,8 @@ class _FakeProfile_25 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_26 extends _i1.SmartFake implements _i15.Client {
-  _FakeClient_26(
+class _FakeClient_27 extends _i1.SmartFake implements _i16.Client {
+  _FakeClient_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -333,9 +345,9 @@ class _FakeClient_26 extends _i1.SmartFake implements _i15.Client {
         );
 }
 
-class _FakeDiscoveryInformation_27 extends _i1.SmartFake
+class _FakeDiscoveryInformation_28 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_27(
+  _FakeDiscoveryInformation_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -344,9 +356,9 @@ class _FakeDiscoveryInformation_27 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_28 extends _i1.SmartFake
+class _FakeGetVersionsResponse_29 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_28(
+  _FakeGetVersionsResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -355,9 +367,9 @@ class _FakeGetVersionsResponse_28 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_29 extends _i1.SmartFake
+class _FakeRegisterResponse_30 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_29(
+  _FakeRegisterResponse_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -366,8 +378,8 @@ class _FakeRegisterResponse_29 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_30 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_30(
+class _FakeLoginResponse_31 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -376,9 +388,9 @@ class _FakeLoginResponse_30 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_31 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_32 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_31(
+  _FakeGetAuthMetadataResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -387,8 +399,8 @@ class _FakeGetAuthMetadataResponse_31 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_32<T1> extends _i1.SmartFake implements _i16.Future<T1> {
-  _FakeFuture_32(
+class _FakeFuture_33<T1> extends _i1.SmartFake implements _i17.Future<T1> {
+  _FakeFuture_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -397,9 +409,9 @@ class _FakeFuture_32<T1> extends _i1.SmartFake implements _i16.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_33 extends _i1.SmartFake
+class _FakeCachedProfileInformation_34 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_33(
+  _FakeCachedProfileInformation_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -408,8 +420,8 @@ class _FakeCachedProfileInformation_33 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_34 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_34(
+class _FakeMediaConfig_35 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -418,8 +430,8 @@ class _FakeMediaConfig_34 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_35 extends _i1.SmartFake implements _i17.FileResponse {
-  _FakeFileResponse_35(
+class _FakeFileResponse_36 extends _i1.SmartFake implements _i18.FileResponse {
+  _FakeFileResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -428,8 +440,8 @@ class _FakeFileResponse_35 extends _i1.SmartFake implements _i17.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_36 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_36(
+class _FakePreviewForUrl_37 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -438,9 +450,9 @@ class _FakePreviewForUrl_36 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_37 extends _i1.SmartFake
+class _FakeCachedPresence_38 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_37(
+  _FakeCachedPresence_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -449,9 +461,9 @@ class _FakeCachedPresence_37 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_38 extends _i1.SmartFake
+class _FakeTurnServerCredentials_39 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_38(
+  _FakeTurnServerCredentials_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -460,9 +472,9 @@ class _FakeTurnServerCredentials_38 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_39 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_40 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_39(
+  _FakeRoomKeysUpdateResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -471,8 +483,8 @@ class _FakeRoomKeysUpdateResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_40 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_40(
+class _FakeKeyBackupData_41 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -481,9 +493,9 @@ class _FakeKeyBackupData_40 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_41 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_42 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_41(
+  _FakeGetWellknownSupportResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -492,9 +504,9 @@ class _FakeGetWellknownSupportResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_42 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_43 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_42(
+  _FakeGenerateLoginTokenResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -503,9 +515,9 @@ class _FakeGenerateLoginTokenResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_43 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_44 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_43(
+  _FakeGetRoomSummaryResponse$3_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -514,9 +526,9 @@ class _FakeGetRoomSummaryResponse$3_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_44 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_45 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_44(
+  _FakeGetSpaceHierarchyResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -525,9 +537,9 @@ class _FakeGetSpaceHierarchyResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_45 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_46 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_45(
+  _FakeGetRelatingEventsResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -536,9 +548,9 @@ class _FakeGetRelatingEventsResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_46 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_47 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_46(
+  _FakeGetRelatingEventsWithRelTypeResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -547,9 +559,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -558,9 +570,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_48 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_49 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_48(
+  _FakeGetThreadRootsResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -569,9 +581,9 @@ class _FakeGetThreadRootsResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_49 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_50 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_49(
+  _FakeGetEventByTimestampResponse_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -580,9 +592,9 @@ class _FakeGetEventByTimestampResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_50 extends _i1.SmartFake
+class _FakeRequestTokenResponse_51 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_50(
+  _FakeRequestTokenResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -591,9 +603,9 @@ class _FakeRequestTokenResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_51 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_52 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_51(
+  _FakeTokenOwnerInfo_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -602,8 +614,8 @@ class _FakeTokenOwnerInfo_51 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_52 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_52(
+class _FakeWhoIsInfo_53 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -612,8 +624,8 @@ class _FakeWhoIsInfo_52 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_53 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_53(
+class _FakeCapabilities_54 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -622,8 +634,8 @@ class _FakeCapabilities_53 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_54 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_54(
+class _FakeDevice_55 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -632,9 +644,9 @@ class _FakeDevice_54 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_55 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_56 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_55(
+  _FakeGetRoomIdByAliasResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -643,9 +655,9 @@ class _FakeGetRoomIdByAliasResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_56 extends _i1.SmartFake
+class _FakeGetEventsResponse_57 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_56(
+  _FakeGetEventsResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -654,9 +666,9 @@ class _FakeGetEventsResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_57 extends _i1.SmartFake
+class _FakePeekEventsResponse_58 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_57(
+  _FakePeekEventsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -665,8 +677,8 @@ class _FakePeekEventsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_58 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_58(
+class _FakeMatrixEvent_59 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -675,9 +687,9 @@ class _FakeMatrixEvent_58 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_59 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_60 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_59(
+  _FakeGetKeysChangesResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -686,9 +698,9 @@ class _FakeGetKeysChangesResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_60 extends _i1.SmartFake
+class _FakeClaimKeysResponse_61 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_60(
+  _FakeClaimKeysResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -697,9 +709,9 @@ class _FakeClaimKeysResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_61 extends _i1.SmartFake
+class _FakeQueryKeysResponse_62 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_61(
+  _FakeQueryKeysResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -708,9 +720,9 @@ class _FakeQueryKeysResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_62 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_63 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_62(
+  _FakeGetNotificationsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -719,9 +731,9 @@ class _FakeGetNotificationsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_63 extends _i1.SmartFake
+class _FakeGetPresenceResponse_64 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_63(
+  _FakeGetPresenceResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -730,9 +742,9 @@ class _FakeGetPresenceResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_64 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_65 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_64(
+  _FakeGetPublicRoomsResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -741,9 +753,9 @@ class _FakeGetPublicRoomsResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_65 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_66 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_65(
+  _FakeQueryPublicRoomsResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -752,8 +764,8 @@ class _FakeQueryPublicRoomsResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_66 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_66(
+class _FakePushRuleSet_67 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -762,9 +774,9 @@ class _FakePushRuleSet_66 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_67 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_68 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_67(
+  _FakeGetPushRulesGlobalResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -773,8 +785,8 @@ class _FakeGetPushRulesGlobalResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_68 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_68(
+class _FakePushRule_69 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -783,9 +795,9 @@ class _FakePushRule_68 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_69 extends _i1.SmartFake
+class _FakeRefreshResponse_70 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_69(
+  _FakeRefreshResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -794,8 +806,8 @@ class _FakeRefreshResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_70 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_70(
+class _FakeRoomKeys_71 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -804,8 +816,8 @@ class _FakeRoomKeys_70 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_71 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_71(
+class _FakeRoomKeyBackup_72 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -814,9 +826,9 @@ class _FakeRoomKeyBackup_71 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_72 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_73 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_72(
+  _FakeGetRoomKeysVersionCurrentResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -825,9 +837,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_73 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_74 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_73(
+  _FakeGetRoomKeysVersionResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -836,8 +848,8 @@ class _FakeGetRoomKeysVersionResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_74 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_74(
+class _FakeEventContext_75 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -846,9 +858,9 @@ class _FakeEventContext_74 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_75 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_76 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_75(
+  _FakeGetRoomEventsResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -857,8 +869,8 @@ class _FakeGetRoomEventsResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_76 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_76(
+class _FakeSearchResults_77 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,9 +879,9 @@ class _FakeSearchResults_76 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_77 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_78 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_77(
+  _FakeGetProtocolMetadataResponse$2_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -878,9 +890,9 @@ class _FakeGetProtocolMetadataResponse$2_77 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_78 extends _i1.SmartFake
+class _FakeOpenIdCredentials_79 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_78(
+  _FakeOpenIdCredentials_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -889,9 +901,9 @@ class _FakeOpenIdCredentials_78 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_79 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_80 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_79(
+  _FakeSearchUserDirectoryResponse_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -900,9 +912,9 @@ class _FakeSearchUserDirectoryResponse_79 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_80 extends _i1.SmartFake
+class _FakeCreateContentResponse_81 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_80(
+  _FakeCreateContentResponse_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -914,7 +926,7 @@ class _FakeCreateContentResponse_80 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -944,11 +956,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1086,17 +1098,30 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i12.OutboxService);
 
   @override
-  _i13.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i13.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i13.AvatarResolver);
+
+  @override
+  _i14.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_11(
+        returnValue: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_11(
+        returnValueForMissingStub: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i13.StickerPackService);
+      ) as _i14.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1205,7 +1230,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set stickerPacks(_i13.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i13.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i14.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -1221,14 +1255,14 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  _i16.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i17.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1258,7 +1292,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1268,18 +1302,18 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i17.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<bool> login({
+  _i17.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1296,12 +1330,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> completeSsoLogin({
+  _i17.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1314,12 +1348,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> completeRegistration(
+  _i17.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1329,32 +1363,32 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> logout() => (super.noSuchMethod(
+  _i17.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i17.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1363,7 +1397,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1372,17 +1406,17 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i17.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1393,7 +1427,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1430,26 +1464,26 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i17.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+  _i17.Future<bool> didPushRouteInformation(
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1479,7 +1513,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1488,7 +1522,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1497,16 +1531,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i17.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i16.Future<_i20.AppExitResponse>);
+            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i17.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1534,11 +1568,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1568,11 +1602,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_12(
+        returnValue: _FakeRoomSummary_13(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_12(
+        returnValueForMissingStub: _FakeRoomSummary_13(
           this,
           Invocation.getter(#summary),
         ),
@@ -1602,11 +1636,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i16.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i17.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i16.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i16.Completer<dynamic>>[],
-      ) as List<_i16.Completer<dynamic>>);
+        returnValue: <_i17.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i17.Completer<dynamic>>[],
+      ) as List<_i17.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1625,51 +1659,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i14.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i15.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i14.CachedStreamController<String> get onSessionKeyReceived =>
+  _i15.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1685,11 +1719,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1698,11 +1732,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1745,11 +1779,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1758,11 +1792,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_14(
+        returnValue: _FakeDateTime_15(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_14(
+        returnValueForMissingStub: _FakeDateTime_15(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1792,11 +1826,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_15(
+        returnValue: _FakeLatestReceiptState_16(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_15(
+        returnValueForMissingStub: _FakeLatestReceiptState_16(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1817,18 +1851,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i16.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i17.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -2015,18 +2049,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -2139,14 +2173,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i16.Future<void> postLoad() => (super.noSuchMethod(
+  _i17.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2174,15 +2208,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i16.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i17.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i16.Future<List<_i4.User>>);
+            _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i17.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2193,14 +2227,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2210,18 +2244,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i16.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i17.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Event?> refreshLastEvent(
+  _i17.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2229,9 +2263,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2243,12 +2277,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i16.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i17.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2256,22 +2290,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i17.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2279,17 +2313,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> addTag(
+  _i17.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2299,27 +2333,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i17.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i17.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2327,53 +2361,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i17.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i17.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+  _i17.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
         Invocation.method(
           #setLowPriority,
           [lowPriority],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i17.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2381,14 +2415,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2400,7 +2434,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i16.Future<String?> sendTextEvent(
+  _i17.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2432,12 +2466,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendReaction(
+  _i17.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2451,12 +2485,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendLocation(
+  _i17.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2470,12 +2504,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendFileEvent(
+  _i17.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2503,25 +2537,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i17.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i16.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i17.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i16.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i17.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i16.Future<_i4.EncryptionHealthState>);
+      ) as _i17.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i16.Future<String?> sendEvent(
+  _i17.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2545,73 +2579,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i17.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leave() => (super.noSuchMethod(
+  _i17.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> forget() => (super.noSuchMethod(
+  _i17.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> setPower(
+  _i17.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2623,7 +2657,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2634,7 +2668,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2644,10 +2678,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> invite(
+  _i17.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2657,12 +2691,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<int> requestHistory({
+  _i17.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2679,32 +2713,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
-  _i16.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i17.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setReadMarker(
+  _i17.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2718,23 +2752,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
+  _i17.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i16.Future<_i24.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i16.Future<_i24.TimelineChunk?>.value(),
-      ) as _i16.Future<_i24.TimelineChunk?>);
+        returnValue: _i17.Future<_i25.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i17.Future<_i25.TimelineChunk?>.value(),
+      ) as _i17.Future<_i25.TimelineChunk?>);
 
   @override
-  _i16.Future<void> postReceipt(
+  _i17.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2744,12 +2778,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Timeline> getTimeline({
+  _i17.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2772,7 +2806,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i16.Future<_i4.Timeline>.value(_FakeTimeline_17(
+        returnValue: _i17.Future<_i4.Timeline>.value(_FakeTimeline_18(
           this,
           Invocation.method(
             #getTimeline,
@@ -2789,7 +2823,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Timeline>.value(_FakeTimeline_17(
+            _i17.Future<_i4.Timeline>.value(_FakeTimeline_18(
           this,
           Invocation.method(
             #getTimeline,
@@ -2805,7 +2839,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Timeline>);
+      ) as _i17.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2824,7 +2858,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i16.Future<List<_i4.User>> requestParticipants([
+  _i17.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2842,10 +2876,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i16.Future<List<_i4.User>>);
+            _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i17.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2853,14 +2887,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_18(
+        returnValue: _FakeUser_19(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_18(
+        returnValueForMissingStub: _FakeUser_19(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2876,14 +2910,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_18(
+        returnValue: _FakeUser_19(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_18(
+        returnValueForMissingStub: _FakeUser_19(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2893,7 +2927,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i16.Future<_i4.User?> requestUser(
+  _i17.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2909,19 +2943,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i16.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.User?>.value(),
-      ) as _i16.Future<_i4.User?>);
+        returnValue: _i17.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.User?>.value(),
+      ) as _i17.Future<_i4.User?>);
 
   @override
-  _i16.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i17.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2934,12 +2968,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i16.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i17.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2947,14 +2981,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2977,14 +3011,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i16.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i17.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -3023,18 +3057,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i16.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i17.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEvent(
+  _i17.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -3048,12 +3082,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> setTyping(
+  _i17.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -3063,12 +3097,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setJoinRules(
+  _i17.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -3082,59 +3116,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i17.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setHistoryVisibility(
+  _i17.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i17.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i17.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i16.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i17.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i16.Future<List<_i4.DeviceKeys>>);
+            _i17.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i17.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i16.Future<void> requestSessionKey(
+  _i17.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3146,12 +3180,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setSpaceChild(
+  _i17.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3167,44 +3201,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i17.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValue: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i16.Future<Uri>);
+      ) as _i17.Future<Uri>);
 
   @override
-  _i16.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<
+  _i17.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3231,21 +3265,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i16.Future<
+        returnValue: _i17.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i16.Future<
+        returnValueForMissingStub: _i17.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i16.Future<
+      ) as _i17.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3260,23 +3294,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_20(
+        returnValue: _FakeDatabaseApi_21(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_20(
+        returnValueForMissingStub: _FakeDatabaseApi_21(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i25.KeyVerificationMethod> get verificationMethods =>
+  Set<_i26.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i25.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i25.KeyVerificationMethod>{},
-      ) as Set<_i25.KeyVerificationMethod>);
+        returnValue: <_i26.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i26.KeyVerificationMethod>{},
+      ) as Set<_i26.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3337,11 +3371,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_21(
+        returnValue: _FakeFilter_22(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_21(
+        returnValueForMissingStub: _FakeFilter_22(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3350,11 +3384,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_22(
+        returnValue: _FakeNativeImplementations_23(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_22(
+        returnValueForMissingStub: _FakeNativeImplementations_23(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3370,11 +3404,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_23(
+        returnValue: _FakeDuration_24(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_23(
+        returnValueForMissingStub: _FakeDuration_24(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3383,11 +3417,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_23(
+        returnValue: _FakeDuration_24(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_23(
+        returnValueForMissingStub: _FakeDuration_24(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3396,11 +3430,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3437,11 +3471,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3471,11 +3505,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3484,11 +3518,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3511,11 +3545,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_24(
+        returnValue: _FakePushruleEvaluator_25(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_24(
+        returnValueForMissingStub: _FakePushruleEvaluator_25(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3536,332 +3570,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i16.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i17.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i14.CachedStreamController<String> get onUserProfileUpdate =>
+  _i15.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i16.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i17.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i16.Future<List<_i4.Room>>);
+            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i17.Future<List<_i4.Room>>);
 
   @override
-  _i14.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i15.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.EventUpdate>(
+            _FakeCachedStreamController_14<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.EventUpdate>);
+      ) as _i15.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i15.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i15.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onNotification =>
+  _i15.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i15.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i15.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i14.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i15.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_13<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_13<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i14.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i15.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i14.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i15.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_13<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_14<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.LoginState>(
+            _FakeCachedStreamController_14<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i14.CachedStreamController<_i4.LoginState>);
+      ) as _i15.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i14.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i15.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_13<bool>(
+        returnValue: _FakeCachedStreamController_14<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i14.CachedStreamController<bool>);
+      ) as _i15.CachedStreamController<bool>);
 
   @override
-  _i14.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i15.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_13<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_14<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i14.CachedStreamController<_i4.SdkError>);
+      ) as _i15.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i14.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i15.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_13<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.SyncUpdate>(
+            _FakeCachedStreamController_14<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i14.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i15.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i15.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_13<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i14.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i15.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.Presence> get onPresence =>
+  _i15.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_13<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_14<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i14.CachedStreamController<_i4.Presence>);
+      ) as _i15.CachedStreamController<_i4.Presence>);
 
   @override
-  _i14.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i15.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_13<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_14<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.CachedPresence>(
+            _FakeCachedStreamController_14<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i14.CachedStreamController<_i4.CachedPresence>);
+      ) as _i15.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i14.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i15.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_13<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_14<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.BasicEvent>(
+            _FakeCachedStreamController_14<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i14.CachedStreamController<_i4.BasicEvent>);
+      ) as _i15.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i14.CachedStreamController<_i25.RoomKeyRequest> get onRoomKeyRequest =>
+  _i15.CachedStreamController<_i26.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_13<_i25.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_14<_i26.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i25.RoomKeyRequest>(
+            _FakeCachedStreamController_14<_i26.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i14.CachedStreamController<_i25.RoomKeyRequest>);
+      ) as _i15.CachedStreamController<_i26.RoomKeyRequest>);
 
   @override
-  _i14.CachedStreamController<_i25.KeyVerification>
+  _i15.CachedStreamController<_i26.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_13<_i25.KeyVerification>(
+            returnValue: _FakeCachedStreamController_14<_i26.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_13<_i25.KeyVerification>(
+                _FakeCachedStreamController_14<_i26.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i14.CachedStreamController<_i25.KeyVerification>);
+          ) as _i15.CachedStreamController<_i26.KeyVerification>);
 
   @override
-  _i14.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i15.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_13<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i14.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i15.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i15.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<String> get onCancelSendEvent =>
+  _i15.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i14.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i15.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_13<
+            returnValue: _FakeCachedStreamController_14<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_13<
+            returnValueForMissingStub: _FakeCachedStreamController_14<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i14.CachedStreamController<
+          ) as _i15.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3881,11 +3915,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_14(
+        returnValue: _FakeDateTime_15(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_14(
+        returnValueForMissingStub: _FakeDateTime_15(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3958,7 +3992,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i25.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i26.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -4013,7 +4047,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i16.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i17.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -4024,7 +4058,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i16.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i17.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -4135,7 +4169,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4144,7 +4178,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4153,7 +4187,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4180,20 +4214,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i15.Client get httpClient => (super.noSuchMethod(
+  _i16.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_26(
+        returnValue: _FakeClient_27(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_26(
+        returnValueForMissingStub: _FakeClient_27(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i15.Client);
+      ) as _i16.Client);
 
   @override
-  set httpClient(_i15.Client? value) => super.noSuchMethod(
+  set httpClient(_i16.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4220,7 +4254,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<void> refreshAccessToken(
+  _i17.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4228,9 +4262,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4248,14 +4282,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4292,33 +4326,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i16.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i17.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i16.Future<_i4.DiscoveryInformation>);
+      ) as _i17.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i16.Future<
+  _i17.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4340,7 +4374,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i16.Future<
+        returnValue: _i17.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4348,7 +4382,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_28(
+          _FakeGetVersionsResponse_29(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4363,7 +4397,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i16.Future<
+        returnValueForMissingStub: _i17.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4371,7 +4405,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_28(
+          _FakeGetVersionsResponse_29(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4386,7 +4420,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i16.Future<
+      ) as _i17.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4395,7 +4429,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i16.Future<_i4.DiscoveryInformation> getWellknown({
+  _i17.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4408,8 +4442,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getWellknown,
@@ -4420,8 +4454,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getWellknown,
@@ -4432,10 +4466,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.DiscoveryInformation>);
+      ) as _i17.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i16.Future<_i4.RegisterResponse> register({
+  _i17.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4463,7 +4497,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_29(
+            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_30(
           this,
           Invocation.method(
             #register,
@@ -4482,7 +4516,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_29(
+            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_30(
           this,
           Invocation.method(
             #register,
@@ -4500,10 +4534,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RegisterResponse>);
+      ) as _i17.Future<_i4.RegisterResponse>);
 
   @override
-  _i16.Future<_i4.LoginResponse> login(
+  _i17.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4533,7 +4567,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_30(
+        returnValue: _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_31(
           this,
           Invocation.method(
             #login,
@@ -4553,7 +4587,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_30(
+            _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_31(
           this,
           Invocation.method(
             #login,
@@ -4572,10 +4606,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.LoginResponse>);
+      ) as _i17.Future<_i4.LoginResponse>);
 
   @override
-  _i16.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i17.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4588,8 +4622,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_31(
+        returnValue: _i17.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_32(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4601,8 +4635,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_31(
+            _i17.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_32(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4613,74 +4647,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i17.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i16.Future<void> logout() => (super.noSuchMethod(
+  _i17.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> logoutAll() => (super.noSuchMethod(
+  _i17.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<T> uiaRequestBackground<T>(
-          _i16.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i17.Future<T> uiaRequestBackground<T>(
+          _i17.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i16.Future<T>.value(v),
+              (T v) => _i17.Future<T>.value(v),
             ) ??
-            _FakeFuture_32<T>(
+            _FakeFuture_33<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i16.Future<T>.value(v),
+              (T v) => _i17.Future<T>.value(v),
             ) ??
-            _FakeFuture_32<T>(
+            _FakeFuture_33<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i16.Future<T>);
+      ) as _i17.Future<T>);
 
   @override
-  _i16.Future<String> startDirectChat(
+  _i17.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4702,7 +4736,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4718,7 +4752,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4733,10 +4767,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<String> createGroupChat({
+  _i17.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4767,7 +4801,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4788,7 +4822,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4808,10 +4842,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i17.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4827,7 +4861,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4840,7 +4874,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4852,21 +4886,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i17.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<String> createSpace({
+  _i17.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4891,7 +4925,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4909,7 +4943,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4926,10 +4960,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i17.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4937,7 +4971,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4946,7 +4980,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4954,10 +4988,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i16.Future<_i4.Profile> fetchOwnProfile({
+  _i17.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4970,7 +5004,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4982,7 +5016,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4993,10 +5027,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i16.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i17.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -5010,8 +5044,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i16.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_33(
+        returnValue: _i17.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_34(
           this,
           Invocation.method(
             #getUserProfile,
@@ -5023,8 +5057,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_33(
+            _i17.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_34(
           this,
           Invocation.method(
             #getUserProfile,
@@ -5035,10 +5069,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.CachedProfileInformation>);
+      ) as _i17.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i16.Future<_i4.Profile> getProfileFromUserId(
+  _i17.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -5056,7 +5090,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5070,7 +5104,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5083,7 +5117,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -5105,31 +5139,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i16.Future<List<_i4.Room>>);
+            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i17.Future<List<_i4.Room>>);
 
   @override
-  _i16.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i17.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i16.Future<List<_i4.ArchivedRoom>>);
+            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i17.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i16.Future<_i4.GetVersionsResponse> getVersions({
+  _i17.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5142,8 +5176,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_28(
+        returnValue: _i17.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_29(
           this,
           Invocation.method(
             #getVersions,
@@ -5154,8 +5188,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_28(
+        returnValueForMissingStub: _i17.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_29(
           this,
           Invocation.method(
             #getVersions,
@@ -5166,20 +5200,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetVersionsResponse>);
+      ) as _i17.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i16.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i17.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.MediaConfig> getConfig({
+  _i17.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5192,7 +5226,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfig,
@@ -5204,7 +5238,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfig,
@@ -5215,10 +5249,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.MediaConfig>);
+      ) as _i17.Future<_i4.MediaConfig>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContent(
+  _i17.Future<_i18.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5238,7 +5272,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContent,
@@ -5254,7 +5288,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContent,
@@ -5269,10 +5303,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentOverrideName(
+  _i17.Future<_i18.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5294,7 +5328,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5311,7 +5345,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5327,10 +5361,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentThumbnail(
+  _i17.Future<_i18.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5358,7 +5392,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5378,7 +5412,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5397,10 +5431,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i17.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5410,7 +5444,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5419,7 +5453,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5427,11 +5461,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i16.Future<_i4.PreviewForUrl>);
+      ) as _i17.Future<_i4.PreviewForUrl>);
 
   @override
-  _i16.Future<Uri> uploadContent(
-    _i26.Uint8List? file, {
+  _i17.Future<Uri> uploadContent(
+    _i27.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5444,7 +5478,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValue: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #uploadContent,
@@ -5455,7 +5489,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #uploadContent,
@@ -5466,10 +5500,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<Uri>);
+      ) as _i17.Future<Uri>);
 
   @override
-  _i16.Future<void> setTyping(
+  _i17.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5485,42 +5519,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> exportDump() => (super.noSuchMethod(
+  _i17.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i17.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i17.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Event?> getEventByPushNotification(
+  _i17.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5536,12 +5570,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
-  _i16.Future<void> init({
+  _i17.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5576,9 +5610,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5590,40 +5624,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<void> clear() => (super.noSuchMethod(
+  _i17.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i17.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ensureNotSoftLoggedOut(
+  _i17.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> handleSync(
+  _i17.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5633,9 +5667,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5648,29 +5682,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i16.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i17.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i17.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDevice(
+  _i17.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5684,12 +5718,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDevicesOfUserIds(
+  _i17.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5705,12 +5739,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDeviceEncrypted(
+  _i17.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5730,12 +5764,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDeviceEncryptedChunked(
+  _i17.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5749,23 +5783,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i17.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> joinRoom(
+  _i17.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5783,7 +5817,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5797,7 +5831,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5810,10 +5844,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> changePassword(
+  _i17.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5829,22 +5863,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> clearCache() => (super.noSuchMethod(
+  _i17.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ignoreUser(
+  _i17.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5854,22 +5888,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i17.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i17.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5880,7 +5914,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_37(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_38(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5889,7 +5923,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_37(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_38(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5897,32 +5931,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i16.Future<_i4.CachedPresence>);
+      ) as _i17.Future<_i4.CachedPresence>);
 
   @override
-  _i16.Future<void> abortSync() => (super.noSuchMethod(
+  _i17.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i17.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEventWithMetadata(
+  _i17.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5942,14 +5976,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i15.BaseResponse? response,
-    _i26.Uint8List? body,
+    _i16.BaseResponse? response,
+    _i27.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5981,7 +6015,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i16.Future<Map<String, Object?>> request(
+  _i17.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -6002,13 +6036,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> postPusher(
+  _i17.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -6018,57 +6052,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i17.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i17.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i17.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i16.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_38(
+        returnValue: _i17.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_39(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_38(
+        returnValueForMissingStub: _i17.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_39(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.TurnServerCredentials>);
+      ) as _i17.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6082,8 +6116,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6095,8 +6129,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6107,10 +6141,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6126,8 +6160,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6140,8 +6174,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6153,10 +6187,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i17.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6170,7 +6204,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6182,7 +6216,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6193,17 +6227,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.KeyBackupData>);
+      ) as _i17.Future<_i4.KeyBackupData>);
 
   @override
-  _i16.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i17.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i16.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_41(
+        returnValue: _i17.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_42(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6211,18 +6245,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_41(
+            _i17.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_42(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i17.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i16.Future<int> pingAppservice(
+  _i17.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6232,12 +6266,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
-  _i16.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i17.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6245,8 +6279,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_42(
+        returnValue: _i17.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_43(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6255,8 +6289,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_42(
+            _i17.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_43(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6264,15 +6298,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i16.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i17.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i16.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i17.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6280,17 +6314,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.MediaConfig>);
+      ) as _i17.Future<_i4.MediaConfig>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentAuthed(
+  _i17.Future<_i18.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6304,7 +6338,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6316,7 +6350,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6327,10 +6361,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentOverrideNameAuthed(
+  _i17.Future<_i18.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6346,7 +6380,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6359,7 +6393,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6371,10 +6405,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i17.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6384,7 +6418,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6393,7 +6427,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6401,10 +6435,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i16.Future<_i4.PreviewForUrl>);
+      ) as _i17.Future<_i4.PreviewForUrl>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentThumbnailAuthed(
+  _i17.Future<_i18.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6428,7 +6462,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6446,7 +6480,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6463,21 +6497,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<bool> registrationTokenValidity(String? token) =>
+  _i17.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i17.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6487,8 +6521,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_43(
+        returnValue: _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_44(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6497,8 +6531,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_43(
+            _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_44(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6506,10 +6540,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i17.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i16.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i17.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6527,8 +6561,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_44(
+        returnValue: _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_45(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6542,8 +6576,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_44(
+            _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_45(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6556,10 +6590,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i17.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i17.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6583,8 +6617,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i16.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_45(
+        returnValue: _i17.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_46(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6602,8 +6636,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_45(
+            _i17.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_46(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6620,10 +6654,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i17.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6651,8 +6685,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_46(
+                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_47(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6671,8 +6705,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_46(
+                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_47(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6690,10 +6724,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i17.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6722,9 +6756,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i16.Future<
+            returnValue: _i17.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6743,9 +6777,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i16.Future<
+            returnValueForMissingStub: _i17.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6764,11 +6798,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i16
+          ) as _i17
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i16.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i17.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6784,8 +6818,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i16.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_48(
+        returnValue: _i17.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_49(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6798,8 +6832,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_48(
+            _i17.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_49(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6811,10 +6845,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetThreadRootsResponse>);
+      ) as _i17.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i16.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i17.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6828,8 +6862,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i16.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_49(
+        returnValue: _i17.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_50(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6841,8 +6875,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_49(
+            _i17.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_50(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6853,33 +6887,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i17.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i17.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i16.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i17.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i16.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i17.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i16.Future<Uri?>.value(),
-        returnValueForMissingStub: _i16.Future<Uri?>.value(),
-      ) as _i16.Future<Uri?>);
+        returnValue: _i17.Future<Uri?>.value(),
+        returnValueForMissingStub: _i17.Future<Uri?>.value(),
+      ) as _i17.Future<Uri?>);
 
   @override
-  _i16.Future<void> add3PID(
+  _i17.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6893,12 +6927,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> bind3PID(
+  _i17.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6914,12 +6948,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i17.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6933,14 +6967,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6962,8 +6996,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6979,8 +7013,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6996,10 +7030,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7023,8 +7057,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -7041,8 +7075,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -7059,10 +7093,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i17.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -7076,14 +7110,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i17.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -7098,14 +7132,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7127,8 +7161,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7144,8 +7178,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7161,10 +7195,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7188,8 +7222,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7206,8 +7240,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7224,16 +7258,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i17.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_51(
+            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_52(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7241,22 +7275,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_51(
+            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_52(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.TokenOwnerInfo>);
+      ) as _i17.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i16.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i17.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_52(
+        returnValue: _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_53(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7264,22 +7298,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_52(
+            _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_53(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i16.Future<_i4.WhoIsInfo>);
+      ) as _i17.Future<_i4.WhoIsInfo>);
 
   @override
-  _i16.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i17.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_53(
+        returnValue: _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_54(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7287,17 +7321,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_53(
+            _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_54(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.Capabilities>);
+      ) as _i17.Future<_i4.Capabilities>);
 
   @override
-  _i16.Future<String> createRoom({
+  _i17.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7330,7 +7364,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7352,7 +7386,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7373,10 +7407,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> deleteDevices(
+  _i17.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7386,22 +7420,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.Device>?>.value(),
-      ) as _i16.Future<List<_i4.Device>?>);
+        returnValue: _i17.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.Device>?>.value(),
+      ) as _i17.Future<List<_i4.Device>?>);
 
   @override
-  _i16.Future<void> deleteDevice(
+  _i17.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7411,34 +7445,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i17.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i16.Future<_i4.Device>.value(_FakeDevice_54(
+        returnValue: _i17.Future<_i4.Device>.value(_FakeDevice_55(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.Device>.value(_FakeDevice_54(
+        returnValueForMissingStub: _i17.Future<_i4.Device>.value(_FakeDevice_55(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i16.Future<_i4.Device>);
+      ) as _i17.Future<_i4.Device>);
 
   @override
-  _i16.Future<void> updateDevice(
+  _i17.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7448,12 +7482,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i17.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7468,24 +7502,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i17.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i16.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Visibility?>.value(),
-      ) as _i16.Future<_i4.Visibility?>);
+        returnValue: _i17.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Visibility?>.value(),
+      ) as _i17.Future<_i4.Visibility?>);
 
   @override
-  _i16.Future<void> setRoomVisibilityOnDirectory(
+  _i17.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7495,30 +7529,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i17.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i17.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_55(
+        returnValue: _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_56(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7526,18 +7560,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_55(
+            _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_56(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i17.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i16.Future<void> setRoomAlias(
+  _i17.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7549,12 +7583,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetEventsResponse> getEvents({
+  _i17.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7568,7 +7602,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_56(
+            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_57(
           this,
           Invocation.method(
             #getEvents,
@@ -7580,7 +7614,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_56(
+            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_57(
           this,
           Invocation.method(
             #getEvents,
@@ -7591,10 +7625,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetEventsResponse>);
+      ) as _i17.Future<_i4.GetEventsResponse>);
 
   @override
-  _i16.Future<_i4.PeekEventsResponse> peekEvents({
+  _i17.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7609,8 +7643,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i16.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_57(
+        returnValue: _i17.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_58(
           this,
           Invocation.method(
             #peekEvents,
@@ -7622,8 +7656,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_57(
+        returnValueForMissingStub: _i17.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_58(
           this,
           Invocation.method(
             #peekEvents,
@@ -7635,16 +7669,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.PeekEventsResponse>);
+      ) as _i17.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i16.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i17.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7652,27 +7686,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i16.Future<_i4.MatrixEvent>);
+      ) as _i17.Future<_i4.MatrixEvent>);
 
   @override
-  _i16.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i17.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 
   @override
-  _i16.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i17.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7684,8 +7718,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i16.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_59(
+        returnValue: _i17.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_60(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7696,8 +7730,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_59(
+            _i17.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_60(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7707,10 +7741,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.GetKeysChangesResponse>);
+      ) as _i17.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i16.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i17.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7721,7 +7755,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_60(
+            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_61(
           this,
           Invocation.method(
             #claimKeys,
@@ -7730,7 +7764,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_60(
+            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_61(
           this,
           Invocation.method(
             #claimKeys,
@@ -7738,10 +7772,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i16.Future<_i4.ClaimKeysResponse>);
+      ) as _i17.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i16.Future<void> uploadCrossSigningKeys({
+  _i17.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7758,12 +7792,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.QueryKeysResponse> queryKeys(
+  _i17.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7774,7 +7808,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_61(
+            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_62(
           this,
           Invocation.method(
             #queryKeys,
@@ -7783,7 +7817,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_61(
+            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_62(
           this,
           Invocation.method(
             #queryKeys,
@@ -7791,10 +7825,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i16.Future<_i4.QueryKeysResponse>);
+      ) as _i17.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7802,14 +7836,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i16.Future<
+            returnValue: _i17.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i16.Future<
+            returnValueForMissingStub: _i17.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i16.Future<Map<String, int>> uploadKeys({
+  _i17.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7824,13 +7858,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i16.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i17.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i16.Future<Map<String, int>>);
+            _i17.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i17.Future<Map<String, int>>);
 
   @override
-  _i16.Future<String> knockRoom(
+  _i17.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7844,7 +7878,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7856,7 +7890,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7867,20 +7901,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i17.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i16.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i17.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i17.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i16.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i17.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7895,8 +7929,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i16.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_62(
+        returnValue: _i17.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_63(
           this,
           Invocation.method(
             #getNotifications,
@@ -7909,8 +7943,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_62(
+            _i17.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_63(
           this,
           Invocation.method(
             #getNotifications,
@@ -7922,35 +7956,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetNotificationsResponse>);
+      ) as _i17.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i16.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i17.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i16.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_63(
+        returnValue: _i17.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_64(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_63(
+        returnValueForMissingStub: _i17.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_64(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i16.Future<_i4.GetPresenceResponse>);
+      ) as _i17.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i16.Future<void> setPresence(
+  _i17.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7964,12 +7998,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, Object?>> deleteProfileField(
+  _i17.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7982,13 +8016,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getProfileField(
+  _i17.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -8001,13 +8035,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<Map<String, Object?>> setProfileField(
+  _i17.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -8022,13 +8056,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i17.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -8043,8 +8077,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i16.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_64(
+        returnValue: _i17.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_65(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -8057,8 +8091,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_64(
+            _i17.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_65(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -8070,10 +8104,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i17.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i16.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i17.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -8094,8 +8128,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i16.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_65(
+        returnValue: _i17.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_66(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8111,8 +8145,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_65(
+            _i17.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_66(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8127,25 +8161,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i17.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i16.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.Pusher>?>.value(),
-      ) as _i16.Future<List<_i4.Pusher>?>);
+        returnValue: _i17.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.Pusher>?>.value(),
+      ) as _i17.Future<List<_i4.Pusher>?>);
 
   @override
-  _i16.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i17.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_66(
+        returnValue: _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_67(
           this,
           Invocation.method(
             #getPushRules,
@@ -8153,24 +8187,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_66(
+            _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_67(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.PushRuleSet>);
+      ) as _i17.Future<_i4.PushRuleSet>);
 
   @override
-  _i16.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i17.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_67(
+        returnValue: _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_68(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8178,18 +8212,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_67(
+            _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_68(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i17.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i16.Future<void> deletePushRule(
+  _i17.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8201,12 +8235,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.PushRule> getPushRule(
+  _i17.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8218,7 +8252,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<_i4.PushRule>.value(_FakePushRule_68(
+        returnValue: _i17.Future<_i4.PushRule>.value(_FakePushRule_69(
           this,
           Invocation.method(
             #getPushRule,
@@ -8229,7 +8263,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PushRule>.value(_FakePushRule_68(
+            _i17.Future<_i4.PushRule>.value(_FakePushRule_69(
           this,
           Invocation.method(
             #getPushRule,
@@ -8239,10 +8273,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.PushRule>);
+      ) as _i17.Future<_i4.PushRule>);
 
   @override
-  _i16.Future<void> setPushRule(
+  _i17.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8266,12 +8300,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<Object?>> getPushRuleActions(
+  _i17.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8283,13 +8317,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i17.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i16.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i16.Future<List<Object?>>);
+            _i17.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i17.Future<List<Object?>>);
 
   @override
-  _i16.Future<void> setPushRuleActions(
+  _i17.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8303,12 +8337,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<bool> isPushRuleEnabled(
+  _i17.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8320,12 +8354,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> setPushRuleEnabled(
+  _i17.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8339,19 +8373,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i17.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_69(
+            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_70(
           this,
           Invocation.method(
             #refresh,
@@ -8359,28 +8393,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_69(
+            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_70(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i16.Future<_i4.RefreshResponse>);
+      ) as _i17.Future<_i4.RefreshResponse>);
 
   @override
-  _i16.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i17.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i16.Future<bool?>.value(),
-        returnValueForMissingStub: _i16.Future<bool?>.value(),
-      ) as _i16.Future<bool?>);
+        returnValue: _i17.Future<bool?>.value(),
+        returnValueForMissingStub: _i17.Future<bool?>.value(),
+      ) as _i17.Future<bool?>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8402,8 +8436,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8419,8 +8453,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8436,10 +8470,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8463,8 +8497,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8481,8 +8515,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8499,17 +8533,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8517,23 +8551,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i17.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_70(
+        returnValue: _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_71(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8541,17 +8575,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_70(
+            _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_71(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeys>);
+      ) as _i17.Future<_i4.RoomKeys>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8563,8 +8597,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8575,8 +8609,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8586,10 +8620,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8601,8 +8635,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8613,8 +8647,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8624,10 +8658,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8639,7 +8673,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_71(
+        returnValue: _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_72(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8650,7 +8684,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_71(
+            _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_72(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8660,10 +8694,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeyBackup>);
+      ) as _i17.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8677,8 +8711,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8690,8 +8724,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8702,10 +8736,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8719,8 +8753,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8732,8 +8766,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8744,10 +8778,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i17.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8761,7 +8795,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8773,7 +8807,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8784,10 +8818,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.KeyBackupData>);
+      ) as _i17.Future<_i4.KeyBackupData>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8803,8 +8837,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8817,8 +8851,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8830,18 +8864,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_72(
+                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_73(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8849,18 +8883,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_72(
+                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_73(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i16.Future<String> postRoomKeysVersion(
+  _i17.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8872,7 +8906,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8883,7 +8917,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8893,29 +8927,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i17.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i17.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_73(
+        returnValue: _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_74(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8923,18 +8957,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_73(
+            _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_74(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i17.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i17.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8949,24 +8983,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i17.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 
   @override
-  _i16.Future<void> ban(
+  _i17.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8980,12 +9014,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.EventContext> getEventContext(
+  _i17.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -9003,7 +9037,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<_i4.EventContext>.value(_FakeEventContext_74(
+        returnValue: _i17.Future<_i4.EventContext>.value(_FakeEventContext_75(
           this,
           Invocation.method(
             #getEventContext,
@@ -9018,7 +9052,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.EventContext>.value(_FakeEventContext_74(
+            _i17.Future<_i4.EventContext>.value(_FakeEventContext_75(
           this,
           Invocation.method(
             #getEventContext,
@@ -9032,10 +9066,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.EventContext>);
+      ) as _i17.Future<_i4.EventContext>);
 
   @override
-  _i16.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i17.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -9047,7 +9081,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -9058,7 +9092,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -9068,20 +9102,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.MatrixEvent>);
+      ) as _i17.Future<_i4.MatrixEvent>);
 
   @override
-  _i16.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> inviteBy3PID(
+  _i17.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -9093,12 +9127,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> inviteUser(
+  _i17.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9112,12 +9146,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> joinRoomById(
+  _i17.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -9131,7 +9165,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9143,7 +9177,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9154,23 +9188,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i17.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i17.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i16.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i16.Future<Map<String, _i4.RoomMember>?>);
+            _i17.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i17.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i16.Future<void> kick(
+  _i17.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9184,12 +9218,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leaveRoom(
+  _i17.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9199,12 +9233,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i17.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9220,12 +9254,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i16.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i16.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i17.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i17.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i16.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i17.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9247,8 +9281,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_75(
+        returnValue: _i17.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_76(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9264,8 +9298,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_75(
+        returnValueForMissingStub: _i17.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_76(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9281,10 +9315,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomEventsResponse>);
+      ) as _i17.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i16.Future<void> setReadMarker(
+  _i17.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9300,12 +9334,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> postReceipt(
+  _i17.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9321,12 +9355,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEvent(
+  _i17.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9342,12 +9376,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> reportRoom(
+  _i17.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9359,12 +9393,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> reportEvent(
+  _i17.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9382,12 +9416,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> sendMessage(
+  _i17.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9403,7 +9437,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9416,7 +9450,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9428,23 +9462,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i17.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i16.Future<List<_i4.MatrixEvent>>);
+            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i17.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i17.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9461,13 +9495,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<String> setRoomStateWithKey(
+  _i17.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9483,7 +9517,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9496,7 +9530,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9508,10 +9542,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> unban(
+  _i17.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9525,12 +9559,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> upgradeRoom(
+  _i17.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9544,7 +9578,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9556,7 +9590,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9567,10 +9601,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.SearchResults> search(
+  _i17.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9580,7 +9614,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_76(
+        returnValue: _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_77(
           this,
           Invocation.method(
             #search,
@@ -9589,7 +9623,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_76(
+            _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_77(
           this,
           Invocation.method(
             #search,
@@ -9597,10 +9631,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i16.Future<_i4.SearchResults>);
+      ) as _i17.Future<_i4.SearchResults>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> sync({
+  _i17.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9621,7 +9655,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #sync,
@@ -9637,7 +9671,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #sync,
@@ -9652,22 +9686,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i17.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i16.Future<List<_i4.Location>>);
+            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i17.Future<List<_i4.Location>>);
 
   @override
-  _i16.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i17.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9677,21 +9711,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i16.Future<List<_i4.Location>>);
+            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i17.Future<List<_i4.Location>>);
 
   @override
-  _i16.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i17.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_77(
+        returnValue: _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_78(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9699,45 +9733,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_77(
+            _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_78(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i16.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i17.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i16.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i17.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9748,13 +9782,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getAccountData(
+  _i17.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9767,13 +9801,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> setAccountData(
+  _i17.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9787,12 +9821,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> defineFilter(
+  _i17.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9804,7 +9838,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9815,7 +9849,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9825,10 +9859,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.Filter> getFilter(
+  _i17.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9840,7 +9874,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i16.Future<_i4.Filter>.value(_FakeFilter_21(
+        returnValue: _i17.Future<_i4.Filter>.value(_FakeFilter_22(
           this,
           Invocation.method(
             #getFilter,
@@ -9850,7 +9884,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.Filter>.value(_FakeFilter_21(
+        returnValueForMissingStub: _i17.Future<_i4.Filter>.value(_FakeFilter_22(
           this,
           Invocation.method(
             #getFilter,
@@ -9860,10 +9894,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.Filter>);
+      ) as _i17.Future<_i4.Filter>);
 
   @override
-  _i16.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i17.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9876,7 +9910,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_78(
+            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_79(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9887,7 +9921,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_78(
+            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_79(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9897,10 +9931,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.OpenIdCredentials>);
+      ) as _i17.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i16.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i17.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9915,13 +9949,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> setAccountDataPerRoom(
+  _i17.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9937,12 +9971,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i17.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9954,12 +9988,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i16.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i16.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i16.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i17.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i17.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i17.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i16.Future<void> deleteRoomTag(
+  _i17.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9973,12 +10007,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setRoomTag(
+  _i17.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9994,12 +10028,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i17.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -10009,8 +10043,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i16.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_79(
+        returnValue: _i17.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_80(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -10019,8 +10053,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_79(
+            _i17.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_80(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -10028,10 +10062,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i16.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i17.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> reportUser(
+  _i17.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -10044,40 +10078,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i17.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i16.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_80(
+        returnValue: _i17.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_81(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_80(
+        returnValueForMissingStub: _i17.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_81(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.CreateContentResponse>);
+      ) as _i17.Future<_i4.CreateContentResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> uploadContentToMXC(
+  _i17.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i26.Uint8List? body, {
+    _i27.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10095,8 +10129,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 }

--- a/test/widgets/join_access_controller_test.mocks.dart
+++ b/test/widgets/join_access_controller_test.mocks.dart
@@ -3,16 +3,16 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i16;
-import 'dart:typed_data' as _i25;
-import 'dart:ui' as _i20;
+import 'dart:async' as _i17;
+import 'dart:typed_data' as _i26;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
-import 'package:http/http.dart' as _i15;
-import 'package:kohera/core/models/join_mode.dart' as _i23;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i13;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
+import 'package:http/http.dart' as _i16;
+import 'package:kohera/core/models/join_mode.dart' as _i24;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -28,14 +28,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i24;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i13;
+import 'package:matrix/encryption.dart' as _i25;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i17;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i27;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i14;
-import 'package:matrix/src/utils/space_child.dart' as _i26;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i18;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i28;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i15;
+import 'package:matrix/src/utils/space_child.dart' as _i27;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -169,9 +170,9 @@ class _FakeOutboxService_10 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_11 extends _i1.SmartFake
-    implements _i13.StickerPackService {
-  _FakeStickerPackService_11(
+class _FakeAvatarResolver_11 extends _i1.SmartFake
+    implements _i13.AvatarResolver {
+  _FakeAvatarResolver_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -180,8 +181,9 @@ class _FakeStickerPackService_11 extends _i1.SmartFake
         );
 }
 
-class _FakeStateEvent_12 extends _i1.SmartFake implements _i4.StateEvent {
-  _FakeStateEvent_12(
+class _FakeStickerPackService_12 extends _i1.SmartFake
+    implements _i14.StickerPackService {
+  _FakeStickerPackService_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -190,8 +192,8 @@ class _FakeStateEvent_12 extends _i1.SmartFake implements _i4.StateEvent {
         );
 }
 
-class _FakeDatabaseApi_13 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_13(
+class _FakeStateEvent_13 extends _i1.SmartFake implements _i4.StateEvent {
+  _FakeStateEvent_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -200,8 +202,8 @@ class _FakeDatabaseApi_13 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_14 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_14(
+class _FakeDatabaseApi_14 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -210,9 +212,19 @@ class _FakeFilter_14 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_15 extends _i1.SmartFake
+class _FakeFilter_15 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_15(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNativeImplementations_16 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_15(
+  _FakeNativeImplementations_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -221,8 +233,8 @@ class _FakeNativeImplementations_15 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_16 extends _i1.SmartFake implements Duration {
-  _FakeDuration_16(
+class _FakeDuration_17 extends _i1.SmartFake implements Duration {
+  _FakeDuration_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -231,9 +243,9 @@ class _FakeDuration_16 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_17 extends _i1.SmartFake
+class _FakePushruleEvaluator_18 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_17(
+  _FakePushruleEvaluator_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -242,8 +254,8 @@ class _FakePushruleEvaluator_17 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_18 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_18(
+class _FakeProfile_19 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -252,9 +264,9 @@ class _FakeProfile_18 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_19<T> extends _i1.SmartFake
-    implements _i14.CachedStreamController<T> {
-  _FakeCachedStreamController_19(
+class _FakeCachedStreamController_20<T> extends _i1.SmartFake
+    implements _i15.CachedStreamController<T> {
+  _FakeCachedStreamController_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -263,8 +275,8 @@ class _FakeCachedStreamController_19<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_20 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_20(
+class _FakeDateTime_21 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -273,8 +285,8 @@ class _FakeDateTime_20 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_21 extends _i1.SmartFake implements _i15.Client {
-  _FakeClient_21(
+class _FakeClient_22 extends _i1.SmartFake implements _i16.Client {
+  _FakeClient_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -283,9 +295,9 @@ class _FakeClient_21 extends _i1.SmartFake implements _i15.Client {
         );
 }
 
-class _FakeDiscoveryInformation_22 extends _i1.SmartFake
+class _FakeDiscoveryInformation_23 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_22(
+  _FakeDiscoveryInformation_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -294,9 +306,9 @@ class _FakeDiscoveryInformation_22 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_23 extends _i1.SmartFake
+class _FakeGetVersionsResponse_24 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_23(
+  _FakeGetVersionsResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -305,9 +317,9 @@ class _FakeGetVersionsResponse_23 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_24 extends _i1.SmartFake
+class _FakeRegisterResponse_25 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_24(
+  _FakeRegisterResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -316,8 +328,8 @@ class _FakeRegisterResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_25 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_25(
+class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -326,9 +338,9 @@ class _FakeLoginResponse_25 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_26(
+  _FakeGetAuthMetadataResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -337,8 +349,8 @@ class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_27<T1> extends _i1.SmartFake implements _i16.Future<T1> {
-  _FakeFuture_27(
+class _FakeFuture_28<T1> extends _i1.SmartFake implements _i17.Future<T1> {
+  _FakeFuture_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -347,8 +359,8 @@ class _FakeFuture_27<T1> extends _i1.SmartFake implements _i16.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_28 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_28(
+class _FakeSyncUpdate_29 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -357,9 +369,9 @@ class _FakeSyncUpdate_28 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_29 extends _i1.SmartFake
+class _FakeCachedProfileInformation_30 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_29(
+  _FakeCachedProfileInformation_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -368,8 +380,8 @@ class _FakeCachedProfileInformation_29 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_30(
+class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -378,8 +390,8 @@ class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_31 extends _i1.SmartFake implements _i17.FileResponse {
-  _FakeFileResponse_31(
+class _FakeFileResponse_32 extends _i1.SmartFake implements _i18.FileResponse {
+  _FakeFileResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -388,8 +400,8 @@ class _FakeFileResponse_31 extends _i1.SmartFake implements _i17.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_32(
+class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -398,8 +410,8 @@ class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_33 extends _i1.SmartFake implements Uri {
-  _FakeUri_33(
+class _FakeUri_34 extends _i1.SmartFake implements Uri {
+  _FakeUri_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -408,9 +420,9 @@ class _FakeUri_33 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_34 extends _i1.SmartFake
+class _FakeCachedPresence_35 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_34(
+  _FakeCachedPresence_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -419,9 +431,9 @@ class _FakeCachedPresence_34 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_35 extends _i1.SmartFake
+class _FakeTurnServerCredentials_36 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_35(
+  _FakeTurnServerCredentials_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -430,9 +442,9 @@ class _FakeTurnServerCredentials_35 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_36(
+  _FakeRoomKeysUpdateResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -441,8 +453,8 @@ class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_37(
+class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -451,9 +463,9 @@ class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_38(
+  _FakeGetWellknownSupportResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -462,9 +474,9 @@ class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_39(
+  _FakeGenerateLoginTokenResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -473,9 +485,9 @@ class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_40(
+  _FakeGetRoomSummaryResponse$3_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -484,9 +496,9 @@ class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_41(
+  _FakeGetSpaceHierarchyResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -495,9 +507,9 @@ class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_42(
+  _FakeGetRelatingEventsResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -506,9 +518,9 @@ class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_43(
+  _FakeGetRelatingEventsWithRelTypeResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -517,9 +529,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -528,9 +540,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_45(
+  _FakeGetThreadRootsResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -539,9 +551,9 @@ class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_46(
+  _FakeGetEventByTimestampResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -550,9 +562,9 @@ class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_47 extends _i1.SmartFake
+class _FakeRequestTokenResponse_48 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_47(
+  _FakeRequestTokenResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -561,9 +573,9 @@ class _FakeRequestTokenResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_48(
+  _FakeTokenOwnerInfo_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -572,8 +584,8 @@ class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_49(
+class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -582,8 +594,8 @@ class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_50(
+class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -592,8 +604,8 @@ class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_51(
+class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -602,9 +614,9 @@ class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_52(
+  _FakeGetRoomIdByAliasResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -613,9 +625,9 @@ class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_53 extends _i1.SmartFake
+class _FakeGetEventsResponse_54 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_53(
+  _FakeGetEventsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -624,9 +636,9 @@ class _FakeGetEventsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_54 extends _i1.SmartFake
+class _FakePeekEventsResponse_55 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_54(
+  _FakePeekEventsResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -635,8 +647,8 @@ class _FakePeekEventsResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_55(
+class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -645,9 +657,9 @@ class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_56(
+  _FakeGetKeysChangesResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -656,9 +668,9 @@ class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_57 extends _i1.SmartFake
+class _FakeClaimKeysResponse_58 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_57(
+  _FakeClaimKeysResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -667,9 +679,9 @@ class _FakeClaimKeysResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_58 extends _i1.SmartFake
+class _FakeQueryKeysResponse_59 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_58(
+  _FakeQueryKeysResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -678,9 +690,9 @@ class _FakeQueryKeysResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_59(
+  _FakeGetNotificationsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -689,9 +701,9 @@ class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_60 extends _i1.SmartFake
+class _FakeGetPresenceResponse_61 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_60(
+  _FakeGetPresenceResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -700,9 +712,9 @@ class _FakeGetPresenceResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_61(
+  _FakeGetPublicRoomsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -711,9 +723,9 @@ class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_62(
+  _FakeQueryPublicRoomsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -722,8 +734,8 @@ class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_63(
+class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -732,9 +744,9 @@ class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_64(
+  _FakeGetPushRulesGlobalResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -743,8 +755,8 @@ class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_65(
+class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -753,9 +765,9 @@ class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_66 extends _i1.SmartFake
+class _FakeRefreshResponse_67 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_66(
+  _FakeRefreshResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -764,8 +776,8 @@ class _FakeRefreshResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_67(
+class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -774,8 +786,8 @@ class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_68(
+class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -784,9 +796,9 @@ class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_69(
+  _FakeGetRoomKeysVersionCurrentResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -795,9 +807,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_70(
+  _FakeGetRoomKeysVersionResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -806,8 +818,8 @@ class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_71(
+class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -816,9 +828,9 @@ class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_72(
+  _FakeGetRoomEventsResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -827,8 +839,8 @@ class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_73(
+class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -837,9 +849,9 @@ class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_74(
+  _FakeGetProtocolMetadataResponse$2_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -848,9 +860,9 @@ class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_75 extends _i1.SmartFake
+class _FakeOpenIdCredentials_76 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_75(
+  _FakeOpenIdCredentials_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -859,9 +871,9 @@ class _FakeOpenIdCredentials_75 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_76(
+  _FakeSearchUserDirectoryResponse_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -870,9 +882,9 @@ class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_77 extends _i1.SmartFake
+class _FakeCreateContentResponse_78 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_77(
+  _FakeCreateContentResponse_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,8 +893,8 @@ class _FakeCreateContentResponse_77 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_78 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_78(
+class _FakeRoomSummary_79 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -891,9 +903,9 @@ class _FakeRoomSummary_78 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_79 extends _i1.SmartFake
+class _FakeLatestReceiptState_80 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_79(
+  _FakeLatestReceiptState_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,8 +914,8 @@ class _FakeLatestReceiptState_79 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_80 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_80(
+class _FakeTimeline_81 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -912,8 +924,8 @@ class _FakeTimeline_80 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_81 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_81(
+class _FakeUser_82 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -925,7 +937,7 @@ class _FakeUser_81 extends _i1.SmartFake implements _i4.User {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -955,11 +967,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1097,17 +1109,30 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i12.OutboxService);
 
   @override
-  _i13.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i13.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i13.AvatarResolver);
+
+  @override
+  _i14.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_11(
+        returnValue: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_11(
+        returnValueForMissingStub: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i13.StickerPackService);
+      ) as _i14.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1216,7 +1241,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set stickerPacks(_i13.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i13.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i14.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -1232,14 +1266,14 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  _i16.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i17.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1269,7 +1303,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1279,18 +1313,18 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i17.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<bool> login({
+  _i17.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1307,12 +1341,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> completeSsoLogin({
+  _i17.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1325,12 +1359,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> completeRegistration(
+  _i17.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1340,32 +1374,32 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> logout() => (super.noSuchMethod(
+  _i17.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i17.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1374,7 +1408,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1383,17 +1417,17 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i17.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1404,7 +1438,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1441,26 +1475,26 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i17.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+  _i17.Future<bool> didPushRouteInformation(
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1490,7 +1524,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1499,7 +1533,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1508,16 +1542,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i17.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i16.Future<_i20.AppExitResponse>);
+            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i17.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1544,14 +1578,14 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 class MockSpaceAccessService extends _i1.Mock
     implements _i9.SpaceAccessService {
   @override
-  _i23.JoinMode getJoinMode(_i4.Room? room) => (super.noSuchMethod(
+  _i24.JoinMode getJoinMode(_i4.Room? room) => (super.noSuchMethod(
         Invocation.method(
           #getJoinMode,
           [room],
         ),
-        returnValue: _i23.JoinMode.invite,
-        returnValueForMissingStub: _i23.JoinMode.invite,
-      ) as _i23.JoinMode);
+        returnValue: _i24.JoinMode.invite,
+        returnValueForMissingStub: _i24.JoinMode.invite,
+      ) as _i24.JoinMode);
 
   @override
   List<String> allowedSpaceIds(_i4.Room? room) => (super.noSuchMethod(
@@ -1579,27 +1613,27 @@ class MockSpaceAccessService extends _i1.Mock
       ) as bool);
 
   @override
-  _i16.Future<void> setInviteOnly(_i4.Room? room) => (super.noSuchMethod(
+  _i17.Future<void> setInviteOnly(_i4.Room? room) => (super.noSuchMethod(
         Invocation.method(
           #setInviteOnly,
           [room],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setPublic(_i4.Room? room) => (super.noSuchMethod(
+  _i17.Future<void> setPublic(_i4.Room? room) => (super.noSuchMethod(
         Invocation.method(
           #setPublic,
           [room],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setRestrictedJoin(
+  _i17.Future<void> setRestrictedJoin(
     _i4.Room? room,
     List<_i4.Room>? allowSpaces,
   ) =>
@@ -1611,12 +1645,12 @@ class MockSpaceAccessService extends _i1.Mock
             allowSpaces,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setKnockRestricted(
+  _i17.Future<void> setKnockRestricted(
     _i4.Room? room,
     List<_i4.Room>? allowSpaces,
   ) =>
@@ -1628,14 +1662,14 @@ class MockSpaceAccessService extends _i1.Mock
             allowSpaces,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> applyJoinMode({
+  _i17.Future<void> applyJoinMode({
     required String? roomId,
-    required _i23.JoinMode? mode,
+    required _i24.JoinMode? mode,
     List<String>? allowSpaceIds = const [],
   }) =>
       (super.noSuchMethod(
@@ -1648,13 +1682,13 @@ class MockSpaceAccessService extends _i1.Mock
             #allowSpaceIds: allowSpaceIds,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   Map<String, Object?> buildJoinRulesPayload(
-    _i23.JoinMode? mode,
+    _i24.JoinMode? mode,
     List<String>? allowSpaceIds, {
     List<Map<String, Object?>>? preserveEntries = const [],
   }) =>
@@ -1673,7 +1707,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   _i4.StateEvent buildJoinRulesStateEvent(
-    _i23.JoinMode? mode,
+    _i24.JoinMode? mode,
     List<String>? allowSpaceIds,
   ) =>
       (super.noSuchMethod(
@@ -1684,7 +1718,7 @@ class MockSpaceAccessService extends _i1.Mock
             allowSpaceIds,
           ],
         ),
-        returnValue: _FakeStateEvent_12(
+        returnValue: _FakeStateEvent_13(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -1694,7 +1728,7 @@ class MockSpaceAccessService extends _i1.Mock
             ],
           ),
         ),
-        returnValueForMissingStub: _FakeStateEvent_12(
+        returnValueForMissingStub: _FakeStateEvent_13(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -1707,7 +1741,7 @@ class MockSpaceAccessService extends _i1.Mock
       ) as _i4.StateEvent);
 
   @override
-  _i16.Future<String> upgradeRoomTo(
+  _i17.Future<String> upgradeRoomTo(
     _i4.Room? room,
     String? newVersion,
   ) =>
@@ -1719,7 +1753,7 @@ class MockSpaceAccessService extends _i1.Mock
             newVersion,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,
@@ -1730,7 +1764,7 @@ class MockSpaceAccessService extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,
@@ -1740,10 +1774,10 @@ class MockSpaceAccessService extends _i1.Mock
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> rewireParentSpaces({
+  _i17.Future<void> rewireParentSpaces({
     required String? oldRoomId,
     required String? newRoomId,
     required List<_i4.Room>? parents,
@@ -1758,32 +1792,32 @@ class MockSpaceAccessService extends _i1.Mock
             #parents: parents,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> pickRestrictedRoomVersion({required bool? wantKnock}) =>
+  _i17.Future<String?> pickRestrictedRoomVersion({required bool? wantKnock}) =>
       (super.noSuchMethod(
         Invocation.method(
           #pickRestrictedRoomVersion,
           [],
           {#wantKnock: wantKnock},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<List<String>> serverSupportedRoomVersions() =>
+  _i17.Future<List<String>> serverSupportedRoomVersions() =>
       (super.noSuchMethod(
         Invocation.method(
           #serverSupportedRoomVersions,
           [],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 }
 
 /// A class which mocks [Client].
@@ -1793,23 +1827,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_13(
+        returnValue: _FakeDatabaseApi_14(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_13(
+        returnValueForMissingStub: _FakeDatabaseApi_14(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i24.KeyVerificationMethod> get verificationMethods =>
+  Set<_i25.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i24.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i24.KeyVerificationMethod>{},
-      ) as Set<_i24.KeyVerificationMethod>);
+        returnValue: <_i25.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i25.KeyVerificationMethod>{},
+      ) as Set<_i25.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1870,11 +1904,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_14(
+        returnValue: _FakeFilter_15(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_14(
+        returnValueForMissingStub: _FakeFilter_15(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -1883,11 +1917,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_15(
+        returnValue: _FakeNativeImplementations_16(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_15(
+        returnValueForMissingStub: _FakeNativeImplementations_16(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -1903,11 +1937,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_16(
+        returnValue: _FakeDuration_17(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_16(
+        returnValueForMissingStub: _FakeDuration_17(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1916,11 +1950,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_16(
+        returnValue: _FakeDuration_17(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_16(
+        returnValueForMissingStub: _FakeDuration_17(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1929,11 +1963,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1970,11 +2004,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -2004,11 +2038,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -2017,11 +2051,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -2044,11 +2078,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_17(
+        returnValue: _FakePushruleEvaluator_18(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_17(
+        returnValueForMissingStub: _FakePushruleEvaluator_18(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -2069,332 +2103,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i16.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i17.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_18(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_18(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i14.CachedStreamController<String> get onUserProfileUpdate =>
+  _i15.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_19<String>(
+        returnValue: _FakeCachedStreamController_20<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i16.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i17.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i16.Future<List<_i4.Room>>);
+            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i17.Future<List<_i4.Room>>);
 
   @override
-  _i14.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i15.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_19<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_20<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.EventUpdate>(
+            _FakeCachedStreamController_20<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.EventUpdate>);
+      ) as _i15.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i15.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_19<_i4.Event>(
+        returnValue: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i15.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_19<_i4.Event>(
+        returnValue: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onNotification =>
+  _i15.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_19<_i4.Event>(
+        returnValue: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i15.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_19<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_20<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_20<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i15.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i14.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i15.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_19<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_20<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_19<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_20<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i14.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i15.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i14.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i15.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_19<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_20<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.LoginState>(
+            _FakeCachedStreamController_20<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i14.CachedStreamController<_i4.LoginState>);
+      ) as _i15.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i14.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i15.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_19<bool>(
+        returnValue: _FakeCachedStreamController_20<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i14.CachedStreamController<bool>);
+      ) as _i15.CachedStreamController<bool>);
 
   @override
-  _i14.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i15.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_19<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_20<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i14.CachedStreamController<_i4.SdkError>);
+      ) as _i15.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i14.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i15.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_19<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_20<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.SyncUpdate>(
+            _FakeCachedStreamController_20<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i14.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i15.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i15.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_19<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_20<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_20<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i14.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i15.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.Presence> get onPresence =>
+  _i15.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_19<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_20<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i14.CachedStreamController<_i4.Presence>);
+      ) as _i15.CachedStreamController<_i4.Presence>);
 
   @override
-  _i14.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i15.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_19<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_20<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.CachedPresence>(
+            _FakeCachedStreamController_20<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i14.CachedStreamController<_i4.CachedPresence>);
+      ) as _i15.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i14.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i15.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_19<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_20<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.BasicEvent>(
+            _FakeCachedStreamController_20<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i14.CachedStreamController<_i4.BasicEvent>);
+      ) as _i15.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i14.CachedStreamController<_i24.RoomKeyRequest> get onRoomKeyRequest =>
+  _i15.CachedStreamController<_i25.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_19<_i24.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_20<_i25.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i24.RoomKeyRequest>(
+            _FakeCachedStreamController_20<_i25.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i14.CachedStreamController<_i24.RoomKeyRequest>);
+      ) as _i15.CachedStreamController<_i25.RoomKeyRequest>);
 
   @override
-  _i14.CachedStreamController<_i24.KeyVerification>
+  _i15.CachedStreamController<_i25.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_19<_i24.KeyVerification>(
+            returnValue: _FakeCachedStreamController_20<_i25.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_19<_i24.KeyVerification>(
+                _FakeCachedStreamController_20<_i25.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i14.CachedStreamController<_i24.KeyVerification>);
+          ) as _i15.CachedStreamController<_i25.KeyVerification>);
 
   @override
-  _i14.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i15.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_19<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_20<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_20<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i14.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i15.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i15.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_19<_i4.Event>(
+        returnValue: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<String> get onCancelSendEvent =>
+  _i15.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_19<String>(
+        returnValue: _FakeCachedStreamController_20<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i14.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i15.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_19<
+            returnValue: _FakeCachedStreamController_20<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_19<
+            returnValueForMissingStub: _FakeCachedStreamController_20<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i14.CachedStreamController<
+          ) as _i15.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2414,11 +2448,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_20(
+        returnValue: _FakeDateTime_21(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_20(
+        returnValueForMissingStub: _FakeDateTime_21(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2491,7 +2525,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i24.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i25.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2546,7 +2580,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i16.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i17.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2557,7 +2591,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i16.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i17.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -2668,7 +2702,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2677,7 +2711,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2686,7 +2720,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2713,20 +2747,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i15.Client get httpClient => (super.noSuchMethod(
+  _i16.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_21(
+        returnValue: _FakeClient_22(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_21(
+        returnValueForMissingStub: _FakeClient_22(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i15.Client);
+      ) as _i16.Client);
 
   @override
-  set httpClient(_i15.Client? value) => super.noSuchMethod(
+  set httpClient(_i16.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2753,7 +2787,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<void> refreshAccessToken(
+  _i17.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2761,9 +2795,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2781,14 +2815,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2825,33 +2859,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i16.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i17.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i16.Future<_i4.DiscoveryInformation>);
+      ) as _i17.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i16.Future<
+  _i17.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -2873,7 +2907,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i16.Future<
+        returnValue: _i17.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2881,7 +2915,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_23(
+          _FakeGetVersionsResponse_24(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2896,7 +2930,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i16.Future<
+        returnValueForMissingStub: _i17.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2904,7 +2938,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_23(
+          _FakeGetVersionsResponse_24(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2919,7 +2953,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i16.Future<
+      ) as _i17.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -2928,7 +2962,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i16.Future<_i4.DiscoveryInformation> getWellknown({
+  _i17.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2941,8 +2975,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getWellknown,
@@ -2953,8 +2987,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getWellknown,
@@ -2965,10 +2999,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.DiscoveryInformation>);
+      ) as _i17.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i16.Future<_i4.RegisterResponse> register({
+  _i17.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -2996,7 +3030,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_24(
+            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
           this,
           Invocation.method(
             #register,
@@ -3015,7 +3049,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_24(
+            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
           this,
           Invocation.method(
             #register,
@@ -3033,10 +3067,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RegisterResponse>);
+      ) as _i17.Future<_i4.RegisterResponse>);
 
   @override
-  _i16.Future<_i4.LoginResponse> login(
+  _i17.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -3066,7 +3100,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_25(
+        returnValue: _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
           this,
           Invocation.method(
             #login,
@@ -3086,7 +3120,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_25(
+            _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
           this,
           Invocation.method(
             #login,
@@ -3105,10 +3139,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.LoginResponse>);
+      ) as _i17.Future<_i4.LoginResponse>);
 
   @override
-  _i16.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i17.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3121,8 +3155,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_26(
+        returnValue: _i17.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_27(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -3134,8 +3168,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_26(
+            _i17.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_27(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -3146,74 +3180,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i17.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i16.Future<void> logout() => (super.noSuchMethod(
+  _i17.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> logoutAll() => (super.noSuchMethod(
+  _i17.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<T> uiaRequestBackground<T>(
-          _i16.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i17.Future<T> uiaRequestBackground<T>(
+          _i17.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i16.Future<T>.value(v),
+              (T v) => _i17.Future<T>.value(v),
             ) ??
-            _FakeFuture_27<T>(
+            _FakeFuture_28<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i16.Future<T>.value(v),
+              (T v) => _i17.Future<T>.value(v),
             ) ??
-            _FakeFuture_27<T>(
+            _FakeFuture_28<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i16.Future<T>);
+      ) as _i17.Future<T>);
 
   @override
-  _i16.Future<String> startDirectChat(
+  _i17.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -3235,7 +3269,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3251,7 +3285,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3266,10 +3300,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<String> createGroupChat({
+  _i17.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -3300,7 +3334,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3321,7 +3355,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3341,10 +3375,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i17.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3360,7 +3394,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_29(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3373,7 +3407,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_29(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3385,21 +3419,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i17.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<String> createSpace({
+  _i17.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3424,7 +3458,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3442,7 +3476,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3459,10 +3493,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i17.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3470,7 +3504,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_18(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3479,7 +3513,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_18(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3487,10 +3521,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i16.Future<_i4.Profile> fetchOwnProfile({
+  _i17.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3503,7 +3537,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_18(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3515,7 +3549,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_18(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3526,10 +3560,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i16.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i17.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3543,8 +3577,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i16.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_29(
+        returnValue: _i17.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_30(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3556,8 +3590,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_29(
+            _i17.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_30(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3568,10 +3602,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.CachedProfileInformation>);
+      ) as _i17.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i16.Future<_i4.Profile> getProfileFromUserId(
+  _i17.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3589,7 +3623,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_18(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3603,7 +3637,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_18(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3616,7 +3650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3638,31 +3672,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i16.Future<List<_i4.Room>>);
+            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i17.Future<List<_i4.Room>>);
 
   @override
-  _i16.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i17.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i16.Future<List<_i4.ArchivedRoom>>);
+            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i17.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i16.Future<_i4.GetVersionsResponse> getVersions({
+  _i17.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3675,8 +3709,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_23(
+        returnValue: _i17.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_24(
           this,
           Invocation.method(
             #getVersions,
@@ -3687,8 +3721,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_23(
+        returnValueForMissingStub: _i17.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_24(
           this,
           Invocation.method(
             #getVersions,
@@ -3699,20 +3733,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetVersionsResponse>);
+      ) as _i17.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i16.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i17.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.MediaConfig> getConfig({
+  _i17.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3725,7 +3759,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfig,
@@ -3737,7 +3771,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfig,
@@ -3748,10 +3782,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.MediaConfig>);
+      ) as _i17.Future<_i4.MediaConfig>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContent(
+  _i17.Future<_i18.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3771,7 +3805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContent,
@@ -3787,7 +3821,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_31(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContent,
@@ -3802,10 +3836,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentOverrideName(
+  _i17.Future<_i18.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3827,7 +3861,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3844,7 +3878,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_31(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3860,10 +3894,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentThumbnail(
+  _i17.Future<_i18.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -3891,7 +3925,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3911,7 +3945,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_31(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3930,10 +3964,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i17.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3943,7 +3977,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3952,7 +3986,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3960,11 +3994,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i16.Future<_i4.PreviewForUrl>);
+      ) as _i17.Future<_i4.PreviewForUrl>);
 
   @override
-  _i16.Future<Uri> uploadContent(
-    _i25.Uint8List? file, {
+  _i17.Future<Uri> uploadContent(
+    _i26.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3977,7 +4011,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i16.Future<Uri>.value(_FakeUri_33(
+        returnValue: _i17.Future<Uri>.value(_FakeUri_34(
           this,
           Invocation.method(
             #uploadContent,
@@ -3988,7 +4022,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_33(
+        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_34(
           this,
           Invocation.method(
             #uploadContent,
@@ -3999,10 +4033,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<Uri>);
+      ) as _i17.Future<Uri>);
 
   @override
-  _i16.Future<void> setTyping(
+  _i17.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -4018,42 +4052,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> exportDump() => (super.noSuchMethod(
+  _i17.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i17.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i17.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Event?> getEventByPushNotification(
+  _i17.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -4069,12 +4103,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
-  _i16.Future<void> init({
+  _i17.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -4109,9 +4143,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -4123,40 +4157,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<void> clear() => (super.noSuchMethod(
+  _i17.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i17.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ensureNotSoftLoggedOut(
+  _i17.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> handleSync(
+  _i17.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -4166,9 +4200,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -4181,29 +4215,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i16.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i17.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i17.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDevice(
+  _i17.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -4217,12 +4251,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDevicesOfUserIds(
+  _i17.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4238,12 +4272,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDeviceEncrypted(
+  _i17.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4263,12 +4297,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDeviceEncryptedChunked(
+  _i17.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -4282,23 +4316,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i17.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> joinRoom(
+  _i17.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -4316,7 +4350,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4330,7 +4364,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4343,10 +4377,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> changePassword(
+  _i17.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4362,22 +4396,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> clearCache() => (super.noSuchMethod(
+  _i17.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ignoreUser(
+  _i17.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4387,22 +4421,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i17.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i17.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4413,7 +4447,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4422,7 +4456,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4430,32 +4464,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i16.Future<_i4.CachedPresence>);
+      ) as _i17.Future<_i4.CachedPresence>);
 
   @override
-  _i16.Future<void> abortSync() => (super.noSuchMethod(
+  _i17.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i17.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEventWithMetadata(
+  _i17.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4475,14 +4509,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i15.BaseResponse? response,
-    _i25.Uint8List? body,
+    _i16.BaseResponse? response,
+    _i26.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4514,7 +4548,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i16.Future<Map<String, Object?>> request(
+  _i17.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4535,13 +4569,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> postPusher(
+  _i17.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4551,57 +4585,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i17.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i17.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i17.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i16.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_35(
+        returnValue: _i17.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_36(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_35(
+        returnValueForMissingStub: _i17.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_36(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.TurnServerCredentials>);
+      ) as _i17.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4615,8 +4649,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4628,8 +4662,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4640,10 +4674,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4659,8 +4693,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4673,8 +4707,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4686,10 +4720,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i17.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4703,7 +4737,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4715,7 +4749,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4726,17 +4760,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.KeyBackupData>);
+      ) as _i17.Future<_i4.KeyBackupData>);
 
   @override
-  _i16.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i17.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i16.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_38(
+        returnValue: _i17.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_39(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4744,18 +4778,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_38(
+            _i17.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_39(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i17.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i16.Future<int> pingAppservice(
+  _i17.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4765,12 +4799,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
-  _i16.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i17.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4778,8 +4812,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_39(
+        returnValue: _i17.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_40(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4788,8 +4822,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_39(
+            _i17.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_40(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4797,15 +4831,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i16.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i17.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i16.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i17.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4813,17 +4847,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.MediaConfig>);
+      ) as _i17.Future<_i4.MediaConfig>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentAuthed(
+  _i17.Future<_i18.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4837,7 +4871,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4849,7 +4883,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_31(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4860,10 +4894,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentOverrideNameAuthed(
+  _i17.Future<_i18.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4879,7 +4913,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4892,7 +4926,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_31(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4904,10 +4938,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i17.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4917,7 +4951,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4926,7 +4960,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4934,10 +4968,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i16.Future<_i4.PreviewForUrl>);
+      ) as _i17.Future<_i4.PreviewForUrl>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentThumbnailAuthed(
+  _i17.Future<_i18.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4961,7 +4995,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4979,7 +5013,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_31(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4996,21 +5030,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<bool> registrationTokenValidity(String? token) =>
+  _i17.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i17.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -5020,8 +5054,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_40(
+        returnValue: _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_41(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -5030,8 +5064,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_40(
+            _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_41(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -5039,10 +5073,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i17.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i16.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i17.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -5060,8 +5094,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_41(
+        returnValue: _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_42(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -5075,8 +5109,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_41(
+            _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_42(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -5089,10 +5123,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i17.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i17.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -5116,8 +5150,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i16.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_42(
+        returnValue: _i17.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_43(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -5135,8 +5169,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_42(
+            _i17.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_43(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -5153,10 +5187,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i17.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -5184,8 +5218,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_43(
+                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5204,8 +5238,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_43(
+                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5223,10 +5257,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i17.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -5255,9 +5289,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i16.Future<
+            returnValue: _i17.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5276,9 +5310,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i16.Future<
+            returnValueForMissingStub: _i17.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5297,11 +5331,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i16
+          ) as _i17
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i16.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i17.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -5317,8 +5351,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i16.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_45(
+        returnValue: _i17.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_46(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5331,8 +5365,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_45(
+            _i17.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_46(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5344,10 +5378,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetThreadRootsResponse>);
+      ) as _i17.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i16.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i17.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5361,8 +5395,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i16.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_46(
+        returnValue: _i17.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_47(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5374,8 +5408,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_46(
+            _i17.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_47(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5386,33 +5420,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i17.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i17.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i16.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i17.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i16.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i17.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i16.Future<Uri?>.value(),
-        returnValueForMissingStub: _i16.Future<Uri?>.value(),
-      ) as _i16.Future<Uri?>);
+        returnValue: _i17.Future<Uri?>.value(),
+        returnValueForMissingStub: _i17.Future<Uri?>.value(),
+      ) as _i17.Future<Uri?>);
 
   @override
-  _i16.Future<void> add3PID(
+  _i17.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5426,12 +5460,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> bind3PID(
+  _i17.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5447,12 +5481,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i17.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5466,14 +5500,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5495,8 +5529,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5512,8 +5546,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5529,10 +5563,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5556,8 +5590,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5574,8 +5608,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5592,10 +5626,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i17.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5609,14 +5643,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i17.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5631,14 +5665,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5660,8 +5694,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5677,8 +5711,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5694,10 +5728,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5721,8 +5755,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5739,8 +5773,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5757,16 +5791,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i17.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
+            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5774,22 +5808,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
+            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.TokenOwnerInfo>);
+      ) as _i17.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i16.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i17.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
+        returnValue: _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5797,22 +5831,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
+            _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i16.Future<_i4.WhoIsInfo>);
+      ) as _i17.Future<_i4.WhoIsInfo>);
 
   @override
-  _i16.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i17.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
+        returnValue: _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5820,17 +5854,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
+            _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.Capabilities>);
+      ) as _i17.Future<_i4.Capabilities>);
 
   @override
-  _i16.Future<String> createRoom({
+  _i17.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -5863,7 +5897,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5885,7 +5919,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5906,10 +5940,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> deleteDevices(
+  _i17.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5919,22 +5953,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.Device>?>.value(),
-      ) as _i16.Future<List<_i4.Device>?>);
+        returnValue: _i17.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.Device>?>.value(),
+      ) as _i17.Future<List<_i4.Device>?>);
 
   @override
-  _i16.Future<void> deleteDevice(
+  _i17.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5944,34 +5978,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i17.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i16.Future<_i4.Device>.value(_FakeDevice_51(
+        returnValue: _i17.Future<_i4.Device>.value(_FakeDevice_52(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.Device>.value(_FakeDevice_51(
+        returnValueForMissingStub: _i17.Future<_i4.Device>.value(_FakeDevice_52(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i16.Future<_i4.Device>);
+      ) as _i17.Future<_i4.Device>);
 
   @override
-  _i16.Future<void> updateDevice(
+  _i17.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5981,12 +6015,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i17.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -6001,24 +6035,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i17.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i16.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Visibility?>.value(),
-      ) as _i16.Future<_i4.Visibility?>);
+        returnValue: _i17.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Visibility?>.value(),
+      ) as _i17.Future<_i4.Visibility?>);
 
   @override
-  _i16.Future<void> setRoomVisibilityOnDirectory(
+  _i17.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -6028,30 +6062,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i17.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i17.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_52(
+        returnValue: _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_53(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -6059,18 +6093,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_52(
+            _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_53(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i17.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i16.Future<void> setRoomAlias(
+  _i17.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -6082,12 +6116,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetEventsResponse> getEvents({
+  _i17.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -6101,7 +6135,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
+            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
           this,
           Invocation.method(
             #getEvents,
@@ -6113,7 +6147,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
+            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
           this,
           Invocation.method(
             #getEvents,
@@ -6124,10 +6158,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetEventsResponse>);
+      ) as _i17.Future<_i4.GetEventsResponse>);
 
   @override
-  _i16.Future<_i4.PeekEventsResponse> peekEvents({
+  _i17.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -6142,8 +6176,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i16.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_54(
+        returnValue: _i17.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_55(
           this,
           Invocation.method(
             #peekEvents,
@@ -6155,8 +6189,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_54(
+        returnValueForMissingStub: _i17.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_55(
           this,
           Invocation.method(
             #peekEvents,
@@ -6168,16 +6202,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.PeekEventsResponse>);
+      ) as _i17.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i16.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i17.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneEvent,
@@ -6185,27 +6219,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i16.Future<_i4.MatrixEvent>);
+      ) as _i17.Future<_i4.MatrixEvent>);
 
   @override
-  _i16.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i17.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 
   @override
-  _i16.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i17.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -6217,8 +6251,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i16.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_56(
+        returnValue: _i17.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_57(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6229,8 +6263,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_56(
+            _i17.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_57(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6240,10 +6274,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.GetKeysChangesResponse>);
+      ) as _i17.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i16.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i17.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -6254,7 +6288,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
+            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
           this,
           Invocation.method(
             #claimKeys,
@@ -6263,7 +6297,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
+            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
           this,
           Invocation.method(
             #claimKeys,
@@ -6271,10 +6305,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i16.Future<_i4.ClaimKeysResponse>);
+      ) as _i17.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i16.Future<void> uploadCrossSigningKeys({
+  _i17.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -6291,12 +6325,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.QueryKeysResponse> queryKeys(
+  _i17.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -6307,7 +6341,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
+            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
           this,
           Invocation.method(
             #queryKeys,
@@ -6316,7 +6350,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
+            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
           this,
           Invocation.method(
             #queryKeys,
@@ -6324,10 +6358,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i16.Future<_i4.QueryKeysResponse>);
+      ) as _i17.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6335,14 +6369,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i16.Future<
+            returnValue: _i17.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i16.Future<
+            returnValueForMissingStub: _i17.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i16.Future<Map<String, int>> uploadKeys({
+  _i17.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6357,13 +6391,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i16.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i17.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i16.Future<Map<String, int>>);
+            _i17.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i17.Future<Map<String, int>>);
 
   @override
-  _i16.Future<String> knockRoom(
+  _i17.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6377,7 +6411,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6389,7 +6423,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6400,20 +6434,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i17.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i16.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i17.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i17.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i16.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i17.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6428,8 +6462,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i16.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_59(
+        returnValue: _i17.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_60(
           this,
           Invocation.method(
             #getNotifications,
@@ -6442,8 +6476,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_59(
+            _i17.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_60(
           this,
           Invocation.method(
             #getNotifications,
@@ -6455,35 +6489,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetNotificationsResponse>);
+      ) as _i17.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i16.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i17.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i16.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_60(
+        returnValue: _i17.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_61(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_60(
+        returnValueForMissingStub: _i17.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_61(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i16.Future<_i4.GetPresenceResponse>);
+      ) as _i17.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i16.Future<void> setPresence(
+  _i17.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6497,12 +6531,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, Object?>> deleteProfileField(
+  _i17.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6515,13 +6549,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getProfileField(
+  _i17.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6534,13 +6568,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<Map<String, Object?>> setProfileField(
+  _i17.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6555,13 +6589,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i17.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6576,8 +6610,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i16.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_61(
+        returnValue: _i17.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_62(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6590,8 +6624,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_61(
+            _i17.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_62(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6603,10 +6637,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i17.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i16.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i17.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6627,8 +6661,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i16.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_62(
+        returnValue: _i17.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_63(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6644,8 +6678,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_62(
+            _i17.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_63(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6660,25 +6694,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i17.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i16.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.Pusher>?>.value(),
-      ) as _i16.Future<List<_i4.Pusher>?>);
+        returnValue: _i17.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.Pusher>?>.value(),
+      ) as _i17.Future<List<_i4.Pusher>?>);
 
   @override
-  _i16.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i17.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
+        returnValue: _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
           this,
           Invocation.method(
             #getPushRules,
@@ -6686,24 +6720,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
+            _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.PushRuleSet>);
+      ) as _i17.Future<_i4.PushRuleSet>);
 
   @override
-  _i16.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i17.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_64(
+        returnValue: _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_65(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6711,18 +6745,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_64(
+            _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_65(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i17.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i16.Future<void> deletePushRule(
+  _i17.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6734,12 +6768,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.PushRule> getPushRule(
+  _i17.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6751,7 +6785,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<_i4.PushRule>.value(_FakePushRule_65(
+        returnValue: _i17.Future<_i4.PushRule>.value(_FakePushRule_66(
           this,
           Invocation.method(
             #getPushRule,
@@ -6762,7 +6796,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PushRule>.value(_FakePushRule_65(
+            _i17.Future<_i4.PushRule>.value(_FakePushRule_66(
           this,
           Invocation.method(
             #getPushRule,
@@ -6772,10 +6806,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.PushRule>);
+      ) as _i17.Future<_i4.PushRule>);
 
   @override
-  _i16.Future<void> setPushRule(
+  _i17.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -6799,12 +6833,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<Object?>> getPushRuleActions(
+  _i17.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6816,13 +6850,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i17.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i16.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i16.Future<List<Object?>>);
+            _i17.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i17.Future<List<Object?>>);
 
   @override
-  _i16.Future<void> setPushRuleActions(
+  _i17.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -6836,12 +6870,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<bool> isPushRuleEnabled(
+  _i17.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6853,12 +6887,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> setPushRuleEnabled(
+  _i17.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -6872,19 +6906,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i17.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
+            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
           this,
           Invocation.method(
             #refresh,
@@ -6892,28 +6926,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
+            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i16.Future<_i4.RefreshResponse>);
+      ) as _i17.Future<_i4.RefreshResponse>);
 
   @override
-  _i16.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i17.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i16.Future<bool?>.value(),
-        returnValueForMissingStub: _i16.Future<bool?>.value(),
-      ) as _i16.Future<bool?>);
+        returnValue: _i17.Future<bool?>.value(),
+        returnValueForMissingStub: _i17.Future<bool?>.value(),
+      ) as _i17.Future<bool?>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6935,8 +6969,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6952,8 +6986,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6969,10 +7003,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6996,8 +7030,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -7014,8 +7048,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -7032,17 +7066,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -7050,23 +7084,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i17.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
+        returnValue: _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -7074,17 +7108,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
+            _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeys>);
+      ) as _i17.Future<_i4.RoomKeys>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -7096,8 +7130,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -7108,8 +7142,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -7119,10 +7153,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -7134,8 +7168,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -7146,8 +7180,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -7157,10 +7191,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -7172,7 +7206,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
+        returnValue: _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7183,7 +7217,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
+            _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7193,10 +7227,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeyBackup>);
+      ) as _i17.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -7210,8 +7244,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7223,8 +7257,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7235,10 +7269,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7252,8 +7286,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7265,8 +7299,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7277,10 +7311,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i17.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7294,7 +7328,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7306,7 +7340,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7317,10 +7351,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.KeyBackupData>);
+      ) as _i17.Future<_i4.KeyBackupData>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7336,8 +7370,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7350,8 +7384,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7363,18 +7397,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_69(
+                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_70(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7382,18 +7416,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_69(
+                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_70(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i16.Future<String> postRoomKeysVersion(
+  _i17.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7405,7 +7439,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7416,7 +7450,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7426,29 +7460,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i17.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i17.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_70(
+        returnValue: _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_71(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7456,18 +7490,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_70(
+            _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_71(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i17.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i17.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7482,24 +7516,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i17.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 
   @override
-  _i16.Future<void> ban(
+  _i17.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7513,12 +7547,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.EventContext> getEventContext(
+  _i17.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7536,7 +7570,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<_i4.EventContext>.value(_FakeEventContext_71(
+        returnValue: _i17.Future<_i4.EventContext>.value(_FakeEventContext_72(
           this,
           Invocation.method(
             #getEventContext,
@@ -7551,7 +7585,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.EventContext>.value(_FakeEventContext_71(
+            _i17.Future<_i4.EventContext>.value(_FakeEventContext_72(
           this,
           Invocation.method(
             #getEventContext,
@@ -7565,10 +7599,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.EventContext>);
+      ) as _i17.Future<_i4.EventContext>);
 
   @override
-  _i16.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i17.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7580,7 +7614,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7591,7 +7625,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7601,20 +7635,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.MatrixEvent>);
+      ) as _i17.Future<_i4.MatrixEvent>);
 
   @override
-  _i16.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> inviteBy3PID(
+  _i17.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7626,12 +7660,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> inviteUser(
+  _i17.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7645,12 +7679,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> joinRoomById(
+  _i17.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7664,7 +7698,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7676,7 +7710,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7687,23 +7721,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i17.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i17.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i16.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i16.Future<Map<String, _i4.RoomMember>?>);
+            _i17.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i17.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i16.Future<void> kick(
+  _i17.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7717,12 +7751,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leaveRoom(
+  _i17.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7732,12 +7766,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i17.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -7753,12 +7787,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i16.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i16.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i17.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i17.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i16.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i17.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -7780,8 +7814,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_72(
+        returnValue: _i17.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_73(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7797,8 +7831,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_72(
+        returnValueForMissingStub: _i17.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_73(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7814,10 +7848,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomEventsResponse>);
+      ) as _i17.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i16.Future<void> setReadMarker(
+  _i17.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7833,12 +7867,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> postReceipt(
+  _i17.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -7854,12 +7888,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEvent(
+  _i17.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7875,12 +7909,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> reportRoom(
+  _i17.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7892,12 +7926,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> reportEvent(
+  _i17.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7915,12 +7949,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> sendMessage(
+  _i17.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7936,7 +7970,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7949,7 +7983,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7961,23 +7995,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i17.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i16.Future<List<_i4.MatrixEvent>>);
+            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i17.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i17.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -7994,13 +8028,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<String> setRoomStateWithKey(
+  _i17.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -8016,7 +8050,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -8029,7 +8063,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -8041,10 +8075,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> unban(
+  _i17.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8058,12 +8092,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> upgradeRoom(
+  _i17.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -8077,7 +8111,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -8089,7 +8123,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -8100,10 +8134,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.SearchResults> search(
+  _i17.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -8113,7 +8147,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
+        returnValue: _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
           this,
           Invocation.method(
             #search,
@@ -8122,7 +8156,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
+            _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
           this,
           Invocation.method(
             #search,
@@ -8130,10 +8164,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i16.Future<_i4.SearchResults>);
+      ) as _i17.Future<_i4.SearchResults>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> sync({
+  _i17.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -8154,7 +8188,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_29(
           this,
           Invocation.method(
             #sync,
@@ -8170,7 +8204,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_29(
           this,
           Invocation.method(
             #sync,
@@ -8185,22 +8219,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i17.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i16.Future<List<_i4.Location>>);
+            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i17.Future<List<_i4.Location>>);
 
   @override
-  _i16.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i17.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8210,21 +8244,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i16.Future<List<_i4.Location>>);
+            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i17.Future<List<_i4.Location>>);
 
   @override
-  _i16.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i17.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_74(
+        returnValue: _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_75(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -8232,45 +8266,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_74(
+            _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_75(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i16.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i17.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i16.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i17.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8281,13 +8315,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getAccountData(
+  _i17.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -8300,13 +8334,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> setAccountData(
+  _i17.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8320,12 +8354,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> defineFilter(
+  _i17.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -8337,7 +8371,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8348,7 +8382,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8358,10 +8392,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.Filter> getFilter(
+  _i17.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8373,7 +8407,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i16.Future<_i4.Filter>.value(_FakeFilter_14(
+        returnValue: _i17.Future<_i4.Filter>.value(_FakeFilter_15(
           this,
           Invocation.method(
             #getFilter,
@@ -8383,7 +8417,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.Filter>.value(_FakeFilter_14(
+        returnValueForMissingStub: _i17.Future<_i4.Filter>.value(_FakeFilter_15(
           this,
           Invocation.method(
             #getFilter,
@@ -8393,10 +8427,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.Filter>);
+      ) as _i17.Future<_i4.Filter>);
 
   @override
-  _i16.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i17.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8409,7 +8443,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
+            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8420,7 +8454,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
+            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8430,10 +8464,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.OpenIdCredentials>);
+      ) as _i17.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i16.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i17.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8448,13 +8482,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> setAccountDataPerRoom(
+  _i17.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8470,12 +8504,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i17.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8487,12 +8521,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i16.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i16.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i16.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i17.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i17.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i17.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i16.Future<void> deleteRoomTag(
+  _i17.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8506,12 +8540,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setRoomTag(
+  _i17.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8527,12 +8561,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i17.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8542,8 +8576,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i16.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_76(
+        returnValue: _i17.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_77(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8552,8 +8586,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_76(
+            _i17.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_77(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8561,10 +8595,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i16.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i17.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> reportUser(
+  _i17.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8577,40 +8611,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i17.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i16.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_77(
+        returnValue: _i17.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_78(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_77(
+        returnValueForMissingStub: _i17.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_78(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.CreateContentResponse>);
+      ) as _i17.Future<_i4.CreateContentResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> uploadContentToMXC(
+  _i17.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i25.Uint8List? body, {
+    _i26.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8628,10 +8662,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Room].
@@ -8641,11 +8675,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8675,11 +8709,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_78(
+        returnValue: _FakeRoomSummary_79(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_78(
+        returnValueForMissingStub: _FakeRoomSummary_79(
           this,
           Invocation.getter(#summary),
         ),
@@ -8709,11 +8743,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i16.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i17.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i16.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i16.Completer<dynamic>>[],
-      ) as List<_i16.Completer<dynamic>>);
+        returnValue: <_i17.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i17.Completer<dynamic>>[],
+      ) as List<_i17.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -8732,51 +8766,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i14.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i15.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_19<String>(
+        returnValue: _FakeCachedStreamController_20<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i14.CachedStreamController<String> get onSessionKeyReceived =>
+  _i15.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_19<String>(
+        returnValue: _FakeCachedStreamController_20<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8792,11 +8826,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8805,11 +8839,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8852,11 +8886,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8865,11 +8899,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_20(
+        returnValue: _FakeDateTime_21(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_20(
+        returnValueForMissingStub: _FakeDateTime_21(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -8899,11 +8933,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_79(
+        returnValue: _FakeLatestReceiptState_80(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_79(
+        returnValueForMissingStub: _FakeLatestReceiptState_80(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8924,18 +8958,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i16.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i17.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_29(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_29(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -9122,18 +9156,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i27.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i26.SpaceParent>[],
-        returnValueForMissingStub: <_i26.SpaceParent>[],
-      ) as List<_i26.SpaceParent>);
+        returnValue: <_i27.SpaceParent>[],
+        returnValueForMissingStub: <_i27.SpaceParent>[],
+      ) as List<_i27.SpaceParent>);
 
   @override
-  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i27.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i26.SpaceChild>[],
-        returnValueForMissingStub: <_i26.SpaceChild>[],
-      ) as List<_i26.SpaceChild>);
+        returnValue: <_i27.SpaceChild>[],
+        returnValueForMissingStub: <_i27.SpaceChild>[],
+      ) as List<_i27.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -9246,14 +9280,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i16.Future<void> postLoad() => (super.noSuchMethod(
+  _i17.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -9281,15 +9315,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i16.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i17.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i16.Future<List<_i4.User>>);
+            _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i17.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -9300,14 +9334,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9317,18 +9351,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i16.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i17.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Event?> refreshLastEvent(
+  _i17.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9336,9 +9370,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -9350,12 +9384,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i16.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i17.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9363,22 +9397,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i17.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9386,17 +9420,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> addTag(
+  _i17.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -9406,27 +9440,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i17.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i17.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_29(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -9434,53 +9468,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_29(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i17.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i17.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+  _i17.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
         Invocation.method(
           #setLowPriority,
           [lowPriority],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i17.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9488,14 +9522,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -9507,7 +9541,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i16.Future<String?> sendTextEvent(
+  _i17.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -9539,12 +9573,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendReaction(
+  _i17.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -9558,12 +9592,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendLocation(
+  _i17.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -9577,12 +9611,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendFileEvent(
+  _i17.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -9610,25 +9644,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i17.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i16.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i17.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i16.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i17.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i16.Future<_i4.EncryptionHealthState>);
+      ) as _i17.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i16.Future<String?> sendEvent(
+  _i17.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -9652,73 +9686,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i17.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leave() => (super.noSuchMethod(
+  _i17.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> forget() => (super.noSuchMethod(
+  _i17.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> setPower(
+  _i17.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -9730,7 +9764,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9741,7 +9775,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9751,10 +9785,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> invite(
+  _i17.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -9764,12 +9798,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<int> requestHistory({
+  _i17.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -9786,32 +9820,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
-  _i16.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i17.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setReadMarker(
+  _i17.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -9825,23 +9859,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i27.TimelineChunk?> getEventContext(String? eventId) =>
+  _i17.Future<_i28.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i16.Future<_i27.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i16.Future<_i27.TimelineChunk?>.value(),
-      ) as _i16.Future<_i27.TimelineChunk?>);
+        returnValue: _i17.Future<_i28.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i17.Future<_i28.TimelineChunk?>.value(),
+      ) as _i17.Future<_i28.TimelineChunk?>);
 
   @override
-  _i16.Future<void> postReceipt(
+  _i17.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -9851,12 +9885,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Timeline> getTimeline({
+  _i17.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -9879,7 +9913,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i16.Future<_i4.Timeline>.value(_FakeTimeline_80(
+        returnValue: _i17.Future<_i4.Timeline>.value(_FakeTimeline_81(
           this,
           Invocation.method(
             #getTimeline,
@@ -9896,7 +9930,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Timeline>.value(_FakeTimeline_80(
+            _i17.Future<_i4.Timeline>.value(_FakeTimeline_81(
           this,
           Invocation.method(
             #getTimeline,
@@ -9912,7 +9946,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Timeline>);
+      ) as _i17.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -9931,7 +9965,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i16.Future<List<_i4.User>> requestParticipants([
+  _i17.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -9949,10 +9983,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i16.Future<List<_i4.User>>);
+            _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i17.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -9960,14 +9994,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_81(
+        returnValue: _FakeUser_82(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_81(
+        returnValueForMissingStub: _FakeUser_82(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9983,14 +10017,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_81(
+        returnValue: _FakeUser_82(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_81(
+        returnValueForMissingStub: _FakeUser_82(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -10000,7 +10034,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i16.Future<_i4.User?> requestUser(
+  _i17.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -10016,19 +10050,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i16.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.User?>.value(),
-      ) as _i16.Future<_i4.User?>);
+        returnValue: _i17.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.User?>.value(),
+      ) as _i17.Future<_i4.User?>);
 
   @override
-  _i16.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i17.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -10041,12 +10075,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i16.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i17.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10054,14 +10088,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -10084,14 +10118,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i16.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i17.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -10130,18 +10164,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i16.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i17.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEvent(
+  _i17.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -10155,12 +10189,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> setTyping(
+  _i17.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -10170,12 +10204,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setJoinRules(
+  _i17.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -10189,59 +10223,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i17.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setHistoryVisibility(
+  _i17.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i17.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i17.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i16.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i17.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i16.Future<List<_i4.DeviceKeys>>);
+            _i17.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i17.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i16.Future<void> requestSessionKey(
+  _i17.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -10253,12 +10287,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setSpaceChild(
+  _i17.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -10274,44 +10308,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i17.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i16.Future<Uri>.value(_FakeUri_33(
+        returnValue: _i17.Future<Uri>.value(_FakeUri_34(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_33(
+        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_34(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i16.Future<Uri>);
+      ) as _i17.Future<Uri>);
 
   @override
-  _i16.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<
+  _i17.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -10338,21 +10372,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i16.Future<
+        returnValue: _i17.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i16.Future<
+        returnValueForMissingStub: _i17.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i16.Future<
+      ) as _i17.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,

--- a/test/widgets/login_controller_test.mocks.dart
+++ b/test/widgets/login_controller_test.mocks.dart
@@ -3,17 +3,17 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i17;
-import 'dart:typed_data' as _i26;
-import 'dart:ui' as _i21;
+import 'dart:async' as _i18;
+import 'dart:typed_data' as _i27;
+import 'dart:ui' as _i22;
 
-import 'package:flutter/services.dart' as _i22;
-import 'package:flutter/widgets.dart' as _i23;
-import 'package:http/http.dart' as _i16;
-import 'package:kohera/core/models/server_auth_capabilities.dart' as _i19;
-import 'package:kohera/core/services/client_manager.dart' as _i24;
-import 'package:kohera/core/services/matrix_service.dart' as _i14;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i13;
+import 'package:flutter/services.dart' as _i23;
+import 'package:flutter/widgets.dart' as _i24;
+import 'package:http/http.dart' as _i17;
+import 'package:kohera/core/models/server_auth_capabilities.dart' as _i20;
+import 'package:kohera/core/services/client_manager.dart' as _i25;
+import 'package:kohera/core/services/matrix_service.dart' as _i15;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -29,12 +29,13 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i25;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i13;
+import 'package:matrix/encryption.dart' as _i26;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i18;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i15;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i19;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i16;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i20;
+import 'package:mockito/src/dummies.dart' as _i21;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -168,9 +169,9 @@ class _FakeOutboxService_10 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_11 extends _i1.SmartFake
-    implements _i13.StickerPackService {
-  _FakeStickerPackService_11(
+class _FakeAvatarResolver_11 extends _i1.SmartFake
+    implements _i13.AvatarResolver {
+  _FakeAvatarResolver_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -179,9 +180,9 @@ class _FakeStickerPackService_11 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixService_12 extends _i1.SmartFake
-    implements _i14.MatrixService {
-  _FakeMatrixService_12(
+class _FakeStickerPackService_12 extends _i1.SmartFake
+    implements _i14.StickerPackService {
+  _FakeStickerPackService_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -190,8 +191,9 @@ class _FakeMatrixService_12 extends _i1.SmartFake
         );
 }
 
-class _FakeDatabaseApi_13 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_13(
+class _FakeMatrixService_13 extends _i1.SmartFake
+    implements _i15.MatrixService {
+  _FakeMatrixService_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -200,8 +202,8 @@ class _FakeDatabaseApi_13 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_14 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_14(
+class _FakeDatabaseApi_14 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -210,9 +212,19 @@ class _FakeFilter_14 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_15 extends _i1.SmartFake
+class _FakeFilter_15 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_15(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNativeImplementations_16 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_15(
+  _FakeNativeImplementations_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -221,8 +233,8 @@ class _FakeNativeImplementations_15 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_16 extends _i1.SmartFake implements Duration {
-  _FakeDuration_16(
+class _FakeDuration_17 extends _i1.SmartFake implements Duration {
+  _FakeDuration_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -231,9 +243,9 @@ class _FakeDuration_16 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_17 extends _i1.SmartFake
+class _FakePushruleEvaluator_18 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_17(
+  _FakePushruleEvaluator_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -242,8 +254,8 @@ class _FakePushruleEvaluator_17 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_18 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_18(
+class _FakeProfile_19 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -252,9 +264,9 @@ class _FakeProfile_18 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_19<T> extends _i1.SmartFake
-    implements _i15.CachedStreamController<T> {
-  _FakeCachedStreamController_19(
+class _FakeCachedStreamController_20<T> extends _i1.SmartFake
+    implements _i16.CachedStreamController<T> {
+  _FakeCachedStreamController_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -263,8 +275,8 @@ class _FakeCachedStreamController_19<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_20 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_20(
+class _FakeDateTime_21 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -273,8 +285,8 @@ class _FakeDateTime_20 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_21 extends _i1.SmartFake implements _i16.Client {
-  _FakeClient_21(
+class _FakeClient_22 extends _i1.SmartFake implements _i17.Client {
+  _FakeClient_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -283,9 +295,9 @@ class _FakeClient_21 extends _i1.SmartFake implements _i16.Client {
         );
 }
 
-class _FakeDiscoveryInformation_22 extends _i1.SmartFake
+class _FakeDiscoveryInformation_23 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_22(
+  _FakeDiscoveryInformation_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -294,9 +306,9 @@ class _FakeDiscoveryInformation_22 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_23 extends _i1.SmartFake
+class _FakeGetVersionsResponse_24 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_23(
+  _FakeGetVersionsResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -305,9 +317,9 @@ class _FakeGetVersionsResponse_23 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_24 extends _i1.SmartFake
+class _FakeRegisterResponse_25 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_24(
+  _FakeRegisterResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -316,8 +328,8 @@ class _FakeRegisterResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_25 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_25(
+class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -326,9 +338,9 @@ class _FakeLoginResponse_25 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_26(
+  _FakeGetAuthMetadataResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -337,8 +349,8 @@ class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_27<T1> extends _i1.SmartFake implements _i17.Future<T1> {
-  _FakeFuture_27(
+class _FakeFuture_28<T1> extends _i1.SmartFake implements _i18.Future<T1> {
+  _FakeFuture_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -347,8 +359,8 @@ class _FakeFuture_27<T1> extends _i1.SmartFake implements _i17.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_28 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_28(
+class _FakeSyncUpdate_29 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -357,9 +369,9 @@ class _FakeSyncUpdate_28 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_29 extends _i1.SmartFake
+class _FakeCachedProfileInformation_30 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_29(
+  _FakeCachedProfileInformation_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -368,8 +380,8 @@ class _FakeCachedProfileInformation_29 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_30(
+class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -378,8 +390,8 @@ class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_31 extends _i1.SmartFake implements _i18.FileResponse {
-  _FakeFileResponse_31(
+class _FakeFileResponse_32 extends _i1.SmartFake implements _i19.FileResponse {
+  _FakeFileResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -388,8 +400,8 @@ class _FakeFileResponse_31 extends _i1.SmartFake implements _i18.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_32(
+class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -398,8 +410,8 @@ class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_33 extends _i1.SmartFake implements Uri {
-  _FakeUri_33(
+class _FakeUri_34 extends _i1.SmartFake implements Uri {
+  _FakeUri_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -408,9 +420,9 @@ class _FakeUri_33 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_34 extends _i1.SmartFake
+class _FakeCachedPresence_35 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_34(
+  _FakeCachedPresence_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -419,9 +431,9 @@ class _FakeCachedPresence_34 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_35 extends _i1.SmartFake
+class _FakeTurnServerCredentials_36 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_35(
+  _FakeTurnServerCredentials_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -430,9 +442,9 @@ class _FakeTurnServerCredentials_35 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_36(
+  _FakeRoomKeysUpdateResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -441,8 +453,8 @@ class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_37(
+class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -451,9 +463,9 @@ class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_38(
+  _FakeGetWellknownSupportResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -462,9 +474,9 @@ class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_39(
+  _FakeGenerateLoginTokenResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -473,9 +485,9 @@ class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_40(
+  _FakeGetRoomSummaryResponse$3_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -484,9 +496,9 @@ class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_41(
+  _FakeGetSpaceHierarchyResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -495,9 +507,9 @@ class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_42(
+  _FakeGetRelatingEventsResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -506,9 +518,9 @@ class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_43(
+  _FakeGetRelatingEventsWithRelTypeResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -517,9 +529,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -528,9 +540,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_45(
+  _FakeGetThreadRootsResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -539,9 +551,9 @@ class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_46(
+  _FakeGetEventByTimestampResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -550,9 +562,9 @@ class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_47 extends _i1.SmartFake
+class _FakeRequestTokenResponse_48 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_47(
+  _FakeRequestTokenResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -561,9 +573,9 @@ class _FakeRequestTokenResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_48(
+  _FakeTokenOwnerInfo_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -572,8 +584,8 @@ class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_49(
+class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -582,8 +594,8 @@ class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_50(
+class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -592,8 +604,8 @@ class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_51(
+class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -602,9 +614,9 @@ class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_52(
+  _FakeGetRoomIdByAliasResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -613,9 +625,9 @@ class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_53 extends _i1.SmartFake
+class _FakeGetEventsResponse_54 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_53(
+  _FakeGetEventsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -624,9 +636,9 @@ class _FakeGetEventsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_54 extends _i1.SmartFake
+class _FakePeekEventsResponse_55 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_54(
+  _FakePeekEventsResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -635,8 +647,8 @@ class _FakePeekEventsResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_55(
+class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -645,9 +657,9 @@ class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_56(
+  _FakeGetKeysChangesResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -656,9 +668,9 @@ class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_57 extends _i1.SmartFake
+class _FakeClaimKeysResponse_58 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_57(
+  _FakeClaimKeysResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -667,9 +679,9 @@ class _FakeClaimKeysResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_58 extends _i1.SmartFake
+class _FakeQueryKeysResponse_59 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_58(
+  _FakeQueryKeysResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -678,9 +690,9 @@ class _FakeQueryKeysResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_59(
+  _FakeGetNotificationsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -689,9 +701,9 @@ class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_60 extends _i1.SmartFake
+class _FakeGetPresenceResponse_61 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_60(
+  _FakeGetPresenceResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -700,9 +712,9 @@ class _FakeGetPresenceResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_61(
+  _FakeGetPublicRoomsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -711,9 +723,9 @@ class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_62(
+  _FakeQueryPublicRoomsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -722,8 +734,8 @@ class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_63(
+class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -732,9 +744,9 @@ class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_64(
+  _FakeGetPushRulesGlobalResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -743,8 +755,8 @@ class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_65(
+class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -753,9 +765,9 @@ class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_66 extends _i1.SmartFake
+class _FakeRefreshResponse_67 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_66(
+  _FakeRefreshResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -764,8 +776,8 @@ class _FakeRefreshResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_67(
+class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -774,8 +786,8 @@ class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_68(
+class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -784,9 +796,9 @@ class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_69(
+  _FakeGetRoomKeysVersionCurrentResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -795,9 +807,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_70(
+  _FakeGetRoomKeysVersionResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -806,8 +818,8 @@ class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_71(
+class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -816,9 +828,9 @@ class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_72(
+  _FakeGetRoomEventsResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -827,8 +839,8 @@ class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_73(
+class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -837,9 +849,9 @@ class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_74(
+  _FakeGetProtocolMetadataResponse$2_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -848,9 +860,9 @@ class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_75 extends _i1.SmartFake
+class _FakeOpenIdCredentials_76 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_75(
+  _FakeOpenIdCredentials_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -859,9 +871,9 @@ class _FakeOpenIdCredentials_75 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_76(
+  _FakeSearchUserDirectoryResponse_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -870,9 +882,9 @@ class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_77 extends _i1.SmartFake
+class _FakeCreateContentResponse_78 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_77(
+  _FakeCreateContentResponse_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,9 +893,9 @@ class _FakeCreateContentResponse_77 extends _i1.SmartFake
         );
 }
 
-class _FakeServerAuthCapabilities_78 extends _i1.SmartFake
-    implements _i19.ServerAuthCapabilities {
-  _FakeServerAuthCapabilities_78(
+class _FakeServerAuthCapabilities_79 extends _i1.SmartFake
+    implements _i20.ServerAuthCapabilities {
+  _FakeServerAuthCapabilities_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -895,7 +907,7 @@ class _FakeServerAuthCapabilities_78 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -925,11 +937,11 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1067,17 +1079,30 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as _i12.OutboxService);
 
   @override
-  _i13.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i13.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i13.AvatarResolver);
+
+  @override
+  _i14.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_11(
+        returnValue: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_11(
+        returnValueForMissingStub: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i13.StickerPackService);
+      ) as _i14.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1186,7 +1211,16 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  set stickerPacks(_i13.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i13.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i14.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -1202,14 +1236,14 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as bool);
 
   @override
-  _i17.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i18.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1239,7 +1273,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1249,18 +1283,18 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i17.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i18.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<bool> login({
+  _i18.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1277,12 +1311,12 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
             #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<bool> completeSsoLogin({
+  _i18.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1295,12 +1329,12 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<void> completeRegistration(
+  _i18.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1310,32 +1344,32 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> logout() => (super.noSuchMethod(
+  _i18.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i18.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1344,7 +1378,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1353,17 +1387,17 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i17.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i18.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1374,7 +1408,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1411,26 +1445,26 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i17.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i18.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<bool> didPushRouteInformation(
-          _i23.RouteInformation? routeInformation) =>
+  _i18.Future<bool> didPushRouteInformation(
+          _i24.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1460,7 +1494,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1469,7 +1503,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1478,16 +1512,16 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i17.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i18.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+            _i18.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
-      ) as _i17.Future<_i21.AppExitResponse>);
+            _i18.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+      ) as _i18.Future<_i22.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1511,13 +1545,13 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
 /// A class which mocks [ClientManager].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockClientManager extends _i1.Mock implements _i24.ClientManager {
+class MockClientManager extends _i1.Mock implements _i25.ClientManager {
   @override
-  List<_i14.MatrixService> get services => (super.noSuchMethod(
+  List<_i15.MatrixService> get services => (super.noSuchMethod(
         Invocation.getter(#services),
-        returnValue: <_i14.MatrixService>[],
-        returnValueForMissingStub: <_i14.MatrixService>[],
-      ) as List<_i14.MatrixService>);
+        returnValue: <_i15.MatrixService>[],
+        returnValueForMissingStub: <_i15.MatrixService>[],
+      ) as List<_i15.MatrixService>);
 
   @override
   int get activeIndex => (super.noSuchMethod(
@@ -1527,17 +1561,17 @@ class MockClientManager extends _i1.Mock implements _i24.ClientManager {
       ) as int);
 
   @override
-  _i14.MatrixService get activeService => (super.noSuchMethod(
+  _i15.MatrixService get activeService => (super.noSuchMethod(
         Invocation.getter(#activeService),
-        returnValue: _FakeMatrixService_12(
+        returnValue: _FakeMatrixService_13(
           this,
           Invocation.getter(#activeService),
         ),
-        returnValueForMissingStub: _FakeMatrixService_12(
+        returnValueForMissingStub: _FakeMatrixService_13(
           this,
           Invocation.getter(#activeService),
         ),
-      ) as _i14.MatrixService);
+      ) as _i15.MatrixService);
 
   @override
   bool get hasMultipleAccounts => (super.noSuchMethod(
@@ -1554,14 +1588,14 @@ class MockClientManager extends _i1.Mock implements _i24.ClientManager {
       ) as bool);
 
   @override
-  _i17.Future<void> init() => (super.noSuchMethod(
+  _i18.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   void setActiveAccount(int? index) => super.noSuchMethod(
@@ -1573,13 +1607,13 @@ class MockClientManager extends _i1.Mock implements _i24.ClientManager {
       );
 
   @override
-  _i17.Future<_i14.MatrixService> createLoginService() => (super.noSuchMethod(
+  _i18.Future<_i15.MatrixService> createLoginService() => (super.noSuchMethod(
         Invocation.method(
           #createLoginService,
           [],
         ),
         returnValue:
-            _i17.Future<_i14.MatrixService>.value(_FakeMatrixService_12(
+            _i18.Future<_i15.MatrixService>.value(_FakeMatrixService_13(
           this,
           Invocation.method(
             #createLoginService,
@@ -1587,24 +1621,24 @@ class MockClientManager extends _i1.Mock implements _i24.ClientManager {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i14.MatrixService>.value(_FakeMatrixService_12(
+            _i18.Future<_i15.MatrixService>.value(_FakeMatrixService_13(
           this,
           Invocation.method(
             #createLoginService,
             [],
           ),
         )),
-      ) as _i17.Future<_i14.MatrixService>);
+      ) as _i18.Future<_i15.MatrixService>);
 
   @override
-  _i17.Future<void> commitPendingService() => (super.noSuchMethod(
+  _i18.Future<void> commitPendingService() => (super.noSuchMethod(
         Invocation.method(
           #commitPendingService,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   void cancelPendingService() => super.noSuchMethod(
@@ -1616,36 +1650,36 @@ class MockClientManager extends _i1.Mock implements _i24.ClientManager {
       );
 
   @override
-  _i17.Future<void> addService(_i14.MatrixService? service) =>
+  _i18.Future<void> addService(_i15.MatrixService? service) =>
       (super.noSuchMethod(
         Invocation.method(
           #addService,
           [service],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> signOut(_i14.MatrixService? service) => (super.noSuchMethod(
+  _i18.Future<void> signOut(_i15.MatrixService? service) => (super.noSuchMethod(
         Invocation.method(
           #signOut,
           [service],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> removeService(_i14.MatrixService? service) =>
+  _i18.Future<void> removeService(_i15.MatrixService? service) =>
       (super.noSuchMethod(
         Invocation.method(
           #removeService,
           [service],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -1657,7 +1691,7 @@ class MockClientManager extends _i1.Mock implements _i24.ClientManager {
       );
 
   @override
-  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1666,7 +1700,7 @@ class MockClientManager extends _i1.Mock implements _i24.ClientManager {
       );
 
   @override
-  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1691,23 +1725,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_13(
+        returnValue: _FakeDatabaseApi_14(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_13(
+        returnValueForMissingStub: _FakeDatabaseApi_14(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i25.KeyVerificationMethod> get verificationMethods =>
+  Set<_i26.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i25.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i25.KeyVerificationMethod>{},
-      ) as Set<_i25.KeyVerificationMethod>);
+        returnValue: <_i26.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i26.KeyVerificationMethod>{},
+      ) as Set<_i26.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1768,11 +1802,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_14(
+        returnValue: _FakeFilter_15(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_14(
+        returnValueForMissingStub: _FakeFilter_15(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -1781,11 +1815,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_15(
+        returnValue: _FakeNativeImplementations_16(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_15(
+        returnValueForMissingStub: _FakeNativeImplementations_16(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -1801,11 +1835,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_16(
+        returnValue: _FakeDuration_17(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_16(
+        returnValueForMissingStub: _FakeDuration_17(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1814,11 +1848,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_16(
+        returnValue: _FakeDuration_17(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_16(
+        returnValueForMissingStub: _FakeDuration_17(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1827,11 +1861,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1868,11 +1902,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1902,11 +1936,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1915,11 +1949,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1942,11 +1976,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_17(
+        returnValue: _FakePushruleEvaluator_18(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_17(
+        returnValueForMissingStub: _FakePushruleEvaluator_18(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -1967,332 +2001,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i17.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i18.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_18(
+        returnValue: _i18.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.Profile>.value(_FakeProfile_18(
+            _i18.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i17.Future<_i4.Profile>);
+      ) as _i18.Future<_i4.Profile>);
 
   @override
-  _i15.CachedStreamController<String> get onUserProfileUpdate =>
+  _i16.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_19<String>(
+        returnValue: _FakeCachedStreamController_20<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i15.CachedStreamController<String>);
+      ) as _i16.CachedStreamController<String>);
 
   @override
-  _i17.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i18.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i18.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i17.Future<List<_i4.Room>>);
+            _i18.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i18.Future<List<_i4.Room>>);
 
   @override
-  _i15.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i16.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_19<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_20<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.EventUpdate>(
+            _FakeCachedStreamController_20<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i15.CachedStreamController<_i4.EventUpdate>);
+      ) as _i16.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i15.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i16.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_19<_i4.Event>(
+        returnValue: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i15.CachedStreamController<_i4.Event>);
+      ) as _i16.CachedStreamController<_i4.Event>);
 
   @override
-  _i15.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i16.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_19<_i4.Event>(
+        returnValue: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i15.CachedStreamController<_i4.Event>);
+      ) as _i16.CachedStreamController<_i4.Event>);
 
   @override
-  _i15.CachedStreamController<_i4.Event> get onNotification =>
+  _i16.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_19<_i4.Event>(
+        returnValue: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i15.CachedStreamController<_i4.Event>);
+      ) as _i16.CachedStreamController<_i4.Event>);
 
   @override
-  _i15.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i16.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_19<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_20<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_20<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i15.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i16.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i15.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i16.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_19<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_20<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_19<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_20<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i15.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i16.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i15.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i16.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_19<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_20<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.LoginState>(
+            _FakeCachedStreamController_20<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i15.CachedStreamController<_i4.LoginState>);
+      ) as _i16.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i15.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i16.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_19<bool>(
+        returnValue: _FakeCachedStreamController_20<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i15.CachedStreamController<bool>);
+      ) as _i16.CachedStreamController<bool>);
 
   @override
-  _i15.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i16.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_19<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_20<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i15.CachedStreamController<_i4.SdkError>);
+      ) as _i16.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i15.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i16.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_19<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_20<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.SyncUpdate>(
+            _FakeCachedStreamController_20<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i15.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i16.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i15.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i16.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_19<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_20<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_20<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i15.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i16.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i15.CachedStreamController<_i4.Presence> get onPresence =>
+  _i16.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_19<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_20<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i15.CachedStreamController<_i4.Presence>);
+      ) as _i16.CachedStreamController<_i4.Presence>);
 
   @override
-  _i15.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i16.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_19<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_20<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.CachedPresence>(
+            _FakeCachedStreamController_20<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i15.CachedStreamController<_i4.CachedPresence>);
+      ) as _i16.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i15.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i16.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_19<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_20<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.BasicEvent>(
+            _FakeCachedStreamController_20<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i15.CachedStreamController<_i4.BasicEvent>);
+      ) as _i16.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i15.CachedStreamController<_i25.RoomKeyRequest> get onRoomKeyRequest =>
+  _i16.CachedStreamController<_i26.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_19<_i25.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_20<_i26.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i25.RoomKeyRequest>(
+            _FakeCachedStreamController_20<_i26.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i15.CachedStreamController<_i25.RoomKeyRequest>);
+      ) as _i16.CachedStreamController<_i26.RoomKeyRequest>);
 
   @override
-  _i15.CachedStreamController<_i25.KeyVerification>
+  _i16.CachedStreamController<_i26.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_19<_i25.KeyVerification>(
+            returnValue: _FakeCachedStreamController_20<_i26.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_19<_i25.KeyVerification>(
+                _FakeCachedStreamController_20<_i26.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i15.CachedStreamController<_i25.KeyVerification>);
+          ) as _i16.CachedStreamController<_i26.KeyVerification>);
 
   @override
-  _i15.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i16.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_19<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_20<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_20<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i15.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i16.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i15.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i16.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_19<_i4.Event>(
+        returnValue: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i15.CachedStreamController<_i4.Event>);
+      ) as _i16.CachedStreamController<_i4.Event>);
 
   @override
-  _i15.CachedStreamController<String> get onCancelSendEvent =>
+  _i16.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_19<String>(
+        returnValue: _FakeCachedStreamController_20<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i15.CachedStreamController<String>);
+      ) as _i16.CachedStreamController<String>);
 
   @override
-  _i15.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i16.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_19<
+            returnValue: _FakeCachedStreamController_20<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_19<
+            returnValueForMissingStub: _FakeCachedStreamController_20<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i15.CachedStreamController<
+          ) as _i16.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2312,11 +2346,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_20(
+        returnValue: _FakeDateTime_21(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_20(
+        returnValueForMissingStub: _FakeDateTime_21(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2389,7 +2423,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i25.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i26.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2444,7 +2478,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i17.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i18.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2455,7 +2489,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i17.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i18.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -2566,7 +2600,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i18.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2575,7 +2609,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i18.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2584,7 +2618,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i17.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i18.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2611,20 +2645,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Client get httpClient => (super.noSuchMethod(
+  _i17.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_21(
+        returnValue: _FakeClient_22(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_21(
+        returnValueForMissingStub: _FakeClient_22(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i16.Client);
+      ) as _i17.Client);
 
   @override
-  set httpClient(_i16.Client? value) => super.noSuchMethod(
+  set httpClient(_i17.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2651,7 +2685,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i17.Future<void> refreshAccessToken(
+  _i18.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2659,9 +2693,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2679,14 +2713,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2723,33 +2757,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i17.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i18.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValue: _i18.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValueForMissingStub: _i18.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i17.Future<_i4.DiscoveryInformation>);
+      ) as _i18.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i17.Future<
+  _i18.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -2771,7 +2805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i17.Future<
+        returnValue: _i18.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2779,7 +2813,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_23(
+          _FakeGetVersionsResponse_24(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2794,7 +2828,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i17.Future<
+        returnValueForMissingStub: _i18.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2802,7 +2836,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_23(
+          _FakeGetVersionsResponse_24(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2817,7 +2851,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i17.Future<
+      ) as _i18.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -2826,7 +2860,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i17.Future<_i4.DiscoveryInformation> getWellknown({
+  _i18.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2839,8 +2873,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValue: _i18.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getWellknown,
@@ -2851,8 +2885,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValueForMissingStub: _i18.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getWellknown,
@@ -2863,10 +2897,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.DiscoveryInformation>);
+      ) as _i18.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i17.Future<_i4.RegisterResponse> register({
+  _i18.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -2894,7 +2928,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_24(
+            _i18.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
           this,
           Invocation.method(
             #register,
@@ -2913,7 +2947,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_24(
+            _i18.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
           this,
           Invocation.method(
             #register,
@@ -2931,10 +2965,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.RegisterResponse>);
+      ) as _i18.Future<_i4.RegisterResponse>);
 
   @override
-  _i17.Future<_i4.LoginResponse> login(
+  _i18.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -2964,7 +2998,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_25(
+        returnValue: _i18.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
           this,
           Invocation.method(
             #login,
@@ -2984,7 +3018,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_25(
+            _i18.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
           this,
           Invocation.method(
             #login,
@@ -3003,10 +3037,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.LoginResponse>);
+      ) as _i18.Future<_i4.LoginResponse>);
 
   @override
-  _i17.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i18.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3019,8 +3053,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i17.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_26(
+        returnValue: _i18.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_27(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -3032,8 +3066,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_26(
+            _i18.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_27(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -3044,74 +3078,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i18.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i17.Future<void> logout() => (super.noSuchMethod(
+  _i18.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> logoutAll() => (super.noSuchMethod(
+  _i18.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<T> uiaRequestBackground<T>(
-          _i17.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i18.Future<T> uiaRequestBackground<T>(
+          _i18.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValue: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i17.Future<T>.value(v),
+              (T v) => _i18.Future<T>.value(v),
             ) ??
-            _FakeFuture_27<T>(
+            _FakeFuture_28<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i17.Future<T>.value(v),
+              (T v) => _i18.Future<T>.value(v),
             ) ??
-            _FakeFuture_27<T>(
+            _FakeFuture_28<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i17.Future<T>);
+      ) as _i18.Future<T>);
 
   @override
-  _i17.Future<String> startDirectChat(
+  _i18.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -3133,7 +3167,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3149,7 +3183,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i20.dummyValue<String>(
+            _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3164,10 +3198,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<String> createGroupChat({
+  _i18.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -3198,7 +3232,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3219,7 +3253,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i20.dummyValue<String>(
+            _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3239,10 +3273,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i18.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3258,7 +3292,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
+        returnValue: _i18.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_29(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3271,7 +3305,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
+            _i18.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_29(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3283,21 +3317,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.SyncUpdate>);
+      ) as _i18.Future<_i4.SyncUpdate>);
 
   @override
-  _i17.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i18.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<String> createSpace({
+  _i18.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3322,7 +3356,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3340,7 +3374,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i20.dummyValue<String>(
+            _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3357,10 +3391,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i18.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3368,7 +3402,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_18(
+        returnValue: _i18.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3377,7 +3411,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.Profile>.value(_FakeProfile_18(
+            _i18.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3385,10 +3419,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i17.Future<_i4.Profile>);
+      ) as _i18.Future<_i4.Profile>);
 
   @override
-  _i17.Future<_i4.Profile> fetchOwnProfile({
+  _i18.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3401,7 +3435,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_18(
+        returnValue: _i18.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3413,7 +3447,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.Profile>.value(_FakeProfile_18(
+            _i18.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3424,10 +3458,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.Profile>);
+      ) as _i18.Future<_i4.Profile>);
 
   @override
-  _i17.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i18.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3441,8 +3475,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i17.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_29(
+        returnValue: _i18.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_30(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3454,8 +3488,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_29(
+            _i18.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_30(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3466,10 +3500,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.CachedProfileInformation>);
+      ) as _i18.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i17.Future<_i4.Profile> getProfileFromUserId(
+  _i18.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3487,7 +3521,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_18(
+        returnValue: _i18.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3501,7 +3535,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.Profile>.value(_FakeProfile_18(
+            _i18.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3514,7 +3548,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.Profile>);
+      ) as _i18.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3536,31 +3570,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i17.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i18.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i18.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i17.Future<List<_i4.Room>>);
+            _i18.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i18.Future<List<_i4.Room>>);
 
   @override
-  _i17.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i18.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i18.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i17.Future<List<_i4.ArchivedRoom>>);
+            _i18.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i18.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i17.Future<_i4.GetVersionsResponse> getVersions({
+  _i18.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3573,8 +3607,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i17.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_23(
+        returnValue: _i18.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_24(
           this,
           Invocation.method(
             #getVersions,
@@ -3585,8 +3619,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_23(
+        returnValueForMissingStub: _i18.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_24(
           this,
           Invocation.method(
             #getVersions,
@@ -3597,20 +3631,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetVersionsResponse>);
+      ) as _i18.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i17.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i18.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<_i4.MediaConfig> getConfig({
+  _i18.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3623,7 +3657,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+        returnValue: _i18.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfig,
@@ -3635,7 +3669,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+            _i18.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfig,
@@ -3646,10 +3680,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.MediaConfig>);
+      ) as _i18.Future<_i4.MediaConfig>);
 
   @override
-  _i17.Future<_i18.FileResponse> getContent(
+  _i18.Future<_i19.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3669,7 +3703,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContent,
@@ -3685,7 +3719,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
+            _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContent,
@@ -3700,10 +3734,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i18.FileResponse>);
+      ) as _i18.Future<_i19.FileResponse>);
 
   @override
-  _i17.Future<_i18.FileResponse> getContentOverrideName(
+  _i18.Future<_i19.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3725,7 +3759,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3742,7 +3776,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
+            _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3758,10 +3792,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i18.FileResponse>);
+      ) as _i18.Future<_i19.FileResponse>);
 
   @override
-  _i17.Future<_i18.FileResponse> getContentThumbnail(
+  _i18.Future<_i19.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -3789,7 +3823,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3809,7 +3843,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
+            _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3828,10 +3862,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i18.FileResponse>);
+      ) as _i18.Future<_i19.FileResponse>);
 
   @override
-  _i17.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i18.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3841,7 +3875,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+        returnValue: _i18.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3850,7 +3884,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+            _i18.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3858,11 +3892,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i17.Future<_i4.PreviewForUrl>);
+      ) as _i18.Future<_i4.PreviewForUrl>);
 
   @override
-  _i17.Future<Uri> uploadContent(
-    _i26.Uint8List? file, {
+  _i18.Future<Uri> uploadContent(
+    _i27.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3875,7 +3909,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i17.Future<Uri>.value(_FakeUri_33(
+        returnValue: _i18.Future<Uri>.value(_FakeUri_34(
           this,
           Invocation.method(
             #uploadContent,
@@ -3886,7 +3920,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_33(
+        returnValueForMissingStub: _i18.Future<Uri>.value(_FakeUri_34(
           this,
           Invocation.method(
             #uploadContent,
@@ -3897,10 +3931,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<Uri>);
+      ) as _i18.Future<Uri>);
 
   @override
-  _i17.Future<void> setTyping(
+  _i18.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -3916,42 +3950,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String?> exportDump() => (super.noSuchMethod(
+  _i18.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i17.Future<String?>.value(),
-        returnValueForMissingStub: _i17.Future<String?>.value(),
-      ) as _i17.Future<String?>);
+        returnValue: _i18.Future<String?>.value(),
+        returnValueForMissingStub: _i18.Future<String?>.value(),
+      ) as _i18.Future<String?>);
 
   @override
-  _i17.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i18.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i18.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.Event?> getEventByPushNotification(
+  _i18.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -3967,12 +4001,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i17.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
-      ) as _i17.Future<_i4.Event?>);
+        returnValue: _i18.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i18.Future<_i4.Event?>.value(),
+      ) as _i18.Future<_i4.Event?>);
 
   @override
-  _i17.Future<void> init({
+  _i18.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -4007,9 +4041,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -4021,40 +4055,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i17.Future<void> clear() => (super.noSuchMethod(
+  _i18.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i18.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> ensureNotSoftLoggedOut(
+  _i18.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> handleSync(
+  _i18.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -4064,9 +4098,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -4079,29 +4113,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i17.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i18.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i18.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> sendToDevice(
+  _i18.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -4115,12 +4149,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> sendToDevicesOfUserIds(
+  _i18.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4136,12 +4170,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> sendToDeviceEncrypted(
+  _i18.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4161,12 +4195,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> sendToDeviceEncryptedChunked(
+  _i18.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -4180,23 +4214,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i18.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String> joinRoom(
+  _i18.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -4214,7 +4248,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4228,7 +4262,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i20.dummyValue<String>(
+            _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4241,10 +4275,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<void> changePassword(
+  _i18.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4260,22 +4294,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> clearCache() => (super.noSuchMethod(
+  _i18.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> ignoreUser(
+  _i18.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4285,22 +4319,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i18.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i18.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4311,7 +4345,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i18.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4320,7 +4354,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i18.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4328,32 +4362,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i17.Future<_i4.CachedPresence>);
+      ) as _i18.Future<_i4.CachedPresence>);
 
   @override
-  _i17.Future<void> abortSync() => (super.noSuchMethod(
+  _i18.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i18.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String?> redactEventWithMetadata(
+  _i18.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4373,14 +4407,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i17.Future<String?>.value(),
-        returnValueForMissingStub: _i17.Future<String?>.value(),
-      ) as _i17.Future<String?>);
+        returnValue: _i18.Future<String?>.value(),
+        returnValueForMissingStub: _i18.Future<String?>.value(),
+      ) as _i18.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i16.BaseResponse? response,
-    _i26.Uint8List? body,
+    _i17.BaseResponse? response,
+    _i27.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4412,7 +4446,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i17.Future<Map<String, Object?>> request(
+  _i18.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4433,13 +4467,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<void> postPusher(
+  _i18.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4449,57 +4483,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i18.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i18.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i18.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i17.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_35(
+        returnValue: _i18.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_36(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_35(
+        returnValueForMissingStub: _i18.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_36(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i17.Future<_i4.TurnServerCredentials>);
+      ) as _i18.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i18.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4513,8 +4547,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4526,8 +4560,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4538,10 +4572,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i18.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i18.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4557,8 +4591,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4571,8 +4605,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4584,10 +4618,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i18.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i17.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i18.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4601,7 +4635,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+        returnValue: _i18.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4613,7 +4647,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+            _i18.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4624,17 +4658,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.KeyBackupData>);
+      ) as _i18.Future<_i4.KeyBackupData>);
 
   @override
-  _i17.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i18.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i17.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_38(
+        returnValue: _i18.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_39(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4642,18 +4676,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_38(
+            _i18.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_39(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i17.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i18.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i17.Future<int> pingAppservice(
+  _i18.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4663,12 +4697,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i17.Future<int>.value(0),
-        returnValueForMissingStub: _i17.Future<int>.value(0),
-      ) as _i17.Future<int>);
+        returnValue: _i18.Future<int>.value(0),
+        returnValueForMissingStub: _i18.Future<int>.value(0),
+      ) as _i18.Future<int>);
 
   @override
-  _i17.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i18.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4676,8 +4710,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i17.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_39(
+        returnValue: _i18.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_40(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4686,8 +4720,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_39(
+            _i18.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_40(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4695,15 +4729,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i17.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i18.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i17.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i18.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+        returnValue: _i18.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4711,17 +4745,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+            _i18.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i17.Future<_i4.MediaConfig>);
+      ) as _i18.Future<_i4.MediaConfig>);
 
   @override
-  _i17.Future<_i18.FileResponse> getContentAuthed(
+  _i18.Future<_i19.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4735,7 +4769,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4747,7 +4781,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
+            _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4758,10 +4792,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i17.Future<_i18.FileResponse>);
+      ) as _i18.Future<_i19.FileResponse>);
 
   @override
-  _i17.Future<_i18.FileResponse> getContentOverrideNameAuthed(
+  _i18.Future<_i19.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4777,7 +4811,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4790,7 +4824,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
+            _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4802,10 +4836,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i17.Future<_i18.FileResponse>);
+      ) as _i18.Future<_i19.FileResponse>);
 
   @override
-  _i17.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i18.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4815,7 +4849,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+        returnValue: _i18.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4824,7 +4858,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+            _i18.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4832,10 +4866,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i17.Future<_i4.PreviewForUrl>);
+      ) as _i18.Future<_i4.PreviewForUrl>);
 
   @override
-  _i17.Future<_i18.FileResponse> getContentThumbnailAuthed(
+  _i18.Future<_i19.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4859,7 +4893,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4877,7 +4911,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_31(
+            _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4894,21 +4928,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i18.FileResponse>);
+      ) as _i18.Future<_i19.FileResponse>);
 
   @override
-  _i17.Future<bool> registrationTokenValidity(String? token) =>
+  _i18.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i18.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -4918,8 +4952,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_40(
+        returnValue: _i18.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_41(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4928,8 +4962,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_40(
+            _i18.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_41(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4937,10 +4971,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i17.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i18.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i17.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i18.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -4958,8 +4992,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_41(
+        returnValue: _i18.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_42(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4973,8 +5007,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_41(
+            _i18.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_42(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4987,10 +5021,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i18.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i17.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i18.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -5014,8 +5048,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i17.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_42(
+        returnValue: _i18.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_43(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -5033,8 +5067,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_42(
+            _i18.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_43(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -5051,10 +5085,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i18.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i18.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -5082,8 +5116,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_43(
+                _i18.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5102,8 +5136,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_43(
+                _i18.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5121,10 +5155,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i18.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i17.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i18.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -5153,9 +5187,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i17.Future<
+            returnValue: _i18.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5174,9 +5208,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i17.Future<
+            returnValueForMissingStub: _i18.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5195,11 +5229,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i17
+          ) as _i18
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i17.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i18.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -5215,8 +5249,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i17.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_45(
+        returnValue: _i18.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_46(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5229,8 +5263,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_45(
+            _i18.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_46(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5242,10 +5276,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetThreadRootsResponse>);
+      ) as _i18.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i17.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i18.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5259,8 +5293,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i17.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_46(
+        returnValue: _i18.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_47(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5272,8 +5306,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_46(
+            _i18.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_47(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5284,33 +5318,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i18.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i17.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i18.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i18.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i17.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i18.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i18.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i17.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i18.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i17.Future<Uri?>.value(),
-        returnValueForMissingStub: _i17.Future<Uri?>.value(),
-      ) as _i17.Future<Uri?>);
+        returnValue: _i18.Future<Uri?>.value(),
+        returnValueForMissingStub: _i18.Future<Uri?>.value(),
+      ) as _i18.Future<Uri?>);
 
   @override
-  _i17.Future<void> add3PID(
+  _i18.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5324,12 +5358,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> bind3PID(
+  _i18.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5345,12 +5379,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i18.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5364,14 +5398,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i18.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i18.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i17.Future<_i4.IdServerUnbindResult>);
+      ) as _i18.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i18.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5393,8 +5427,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5410,8 +5444,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5427,10 +5461,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.RequestTokenResponse>);
+      ) as _i18.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i18.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5454,8 +5488,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5472,8 +5506,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5490,10 +5524,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.RequestTokenResponse>);
+      ) as _i18.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i17.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i18.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5507,14 +5541,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i18.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i18.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i17.Future<_i4.IdServerUnbindResult>);
+      ) as _i18.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i17.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i18.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5529,14 +5563,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i18.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i18.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i17.Future<_i4.IdServerUnbindResult>);
+      ) as _i18.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i18.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5558,8 +5592,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5575,8 +5609,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5592,10 +5626,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.RequestTokenResponse>);
+      ) as _i18.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i18.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5619,8 +5653,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5637,8 +5671,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5655,16 +5689,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.RequestTokenResponse>);
+      ) as _i18.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i17.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i18.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
+            _i18.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5672,22 +5706,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
+            _i18.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i17.Future<_i4.TokenOwnerInfo>);
+      ) as _i18.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i17.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i18.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
+        returnValue: _i18.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5695,22 +5729,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
+            _i18.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i17.Future<_i4.WhoIsInfo>);
+      ) as _i18.Future<_i4.WhoIsInfo>);
 
   @override
-  _i17.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i18.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
+        returnValue: _i18.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5718,17 +5752,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
+            _i18.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i17.Future<_i4.Capabilities>);
+      ) as _i18.Future<_i4.Capabilities>);
 
   @override
-  _i17.Future<String> createRoom({
+  _i18.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -5761,7 +5795,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5783,7 +5817,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i20.dummyValue<String>(
+            _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5804,10 +5838,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<void> deleteDevices(
+  _i18.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5817,22 +5851,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i18.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i17.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i17.Future<List<_i4.Device>?>.value(),
-      ) as _i17.Future<List<_i4.Device>?>);
+        returnValue: _i18.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i18.Future<List<_i4.Device>?>.value(),
+      ) as _i18.Future<List<_i4.Device>?>);
 
   @override
-  _i17.Future<void> deleteDevice(
+  _i18.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5842,34 +5876,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i18.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i17.Future<_i4.Device>.value(_FakeDevice_51(
+        returnValue: _i18.Future<_i4.Device>.value(_FakeDevice_52(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.Device>.value(_FakeDevice_51(
+        returnValueForMissingStub: _i18.Future<_i4.Device>.value(_FakeDevice_52(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i17.Future<_i4.Device>);
+      ) as _i18.Future<_i4.Device>);
 
   @override
-  _i17.Future<void> updateDevice(
+  _i18.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5879,12 +5913,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i18.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -5899,24 +5933,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i18.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i17.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i17.Future<_i4.Visibility?>.value(),
-      ) as _i17.Future<_i4.Visibility?>);
+        returnValue: _i18.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i18.Future<_i4.Visibility?>.value(),
+      ) as _i18.Future<_i4.Visibility?>);
 
   @override
-  _i17.Future<void> setRoomVisibilityOnDirectory(
+  _i18.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -5926,30 +5960,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i18.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i18.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_52(
+        returnValue: _i18.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_53(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -5957,18 +5991,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_52(
+            _i18.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_53(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i17.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i18.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i17.Future<void> setRoomAlias(
+  _i18.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -5980,12 +6014,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.GetEventsResponse> getEvents({
+  _i18.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -5999,7 +6033,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
+            _i18.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
           this,
           Invocation.method(
             #getEvents,
@@ -6011,7 +6045,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
+            _i18.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
           this,
           Invocation.method(
             #getEvents,
@@ -6022,10 +6056,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetEventsResponse>);
+      ) as _i18.Future<_i4.GetEventsResponse>);
 
   @override
-  _i17.Future<_i4.PeekEventsResponse> peekEvents({
+  _i18.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -6040,8 +6074,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i17.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_54(
+        returnValue: _i18.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_55(
           this,
           Invocation.method(
             #peekEvents,
@@ -6053,8 +6087,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_54(
+        returnValueForMissingStub: _i18.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_55(
           this,
           Invocation.method(
             #peekEvents,
@@ -6066,16 +6100,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.PeekEventsResponse>);
+      ) as _i18.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i17.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i18.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+        returnValue: _i18.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneEvent,
@@ -6083,27 +6117,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+            _i18.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i17.Future<_i4.MatrixEvent>);
+      ) as _i18.Future<_i4.MatrixEvent>);
 
   @override
-  _i17.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i18.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i17.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
-      ) as _i17.Future<List<String>>);
+        returnValue: _i18.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i18.Future<List<String>>.value(<String>[]),
+      ) as _i18.Future<List<String>>);
 
   @override
-  _i17.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i18.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -6115,8 +6149,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i17.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_56(
+        returnValue: _i18.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_57(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6127,8 +6161,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_56(
+            _i18.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_57(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6138,10 +6172,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.GetKeysChangesResponse>);
+      ) as _i18.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i17.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i18.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -6152,7 +6186,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
+            _i18.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
           this,
           Invocation.method(
             #claimKeys,
@@ -6161,7 +6195,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
+            _i18.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
           this,
           Invocation.method(
             #claimKeys,
@@ -6169,10 +6203,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i17.Future<_i4.ClaimKeysResponse>);
+      ) as _i18.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i17.Future<void> uploadCrossSigningKeys({
+  _i18.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -6189,12 +6223,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.QueryKeysResponse> queryKeys(
+  _i18.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -6205,7 +6239,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
+            _i18.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
           this,
           Invocation.method(
             #queryKeys,
@@ -6214,7 +6248,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
+            _i18.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
           this,
           Invocation.method(
             #queryKeys,
@@ -6222,10 +6256,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i17.Future<_i4.QueryKeysResponse>);
+      ) as _i18.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i18.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6233,14 +6267,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i17.Future<
+            returnValue: _i18.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i17.Future<
+            returnValueForMissingStub: _i18.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i18.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i17.Future<Map<String, int>> uploadKeys({
+  _i18.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6255,13 +6289,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i17.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i18.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i17.Future<Map<String, int>>);
+            _i18.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i18.Future<Map<String, int>>);
 
   @override
-  _i17.Future<String> knockRoom(
+  _i18.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6275,7 +6309,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6287,7 +6321,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i20.dummyValue<String>(
+            _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6298,20 +6332,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i18.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i17.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i17.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i17.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i18.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i18.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i18.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i17.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i18.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6326,8 +6360,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i17.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_59(
+        returnValue: _i18.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_60(
           this,
           Invocation.method(
             #getNotifications,
@@ -6340,8 +6374,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_59(
+            _i18.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_60(
           this,
           Invocation.method(
             #getNotifications,
@@ -6353,35 +6387,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetNotificationsResponse>);
+      ) as _i18.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i17.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i18.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i17.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_60(
+        returnValue: _i18.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_61(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_60(
+        returnValueForMissingStub: _i18.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_61(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i17.Future<_i4.GetPresenceResponse>);
+      ) as _i18.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i17.Future<void> setPresence(
+  _i18.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6395,12 +6429,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<Map<String, Object?>> deleteProfileField(
+  _i18.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6413,13 +6447,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<Map<String, Object?>> getProfileField(
+  _i18.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6432,13 +6466,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<Map<String, Object?>> setProfileField(
+  _i18.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6453,13 +6487,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i18.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6474,8 +6508,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i17.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_61(
+        returnValue: _i18.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_62(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6488,8 +6522,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_61(
+            _i18.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_62(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6501,10 +6535,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i18.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i17.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i18.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6525,8 +6559,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i17.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_62(
+        returnValue: _i18.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_63(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6542,8 +6576,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_62(
+            _i18.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_63(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6558,25 +6592,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i18.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i17.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i18.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i17.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i17.Future<List<_i4.Pusher>?>.value(),
-      ) as _i17.Future<List<_i4.Pusher>?>);
+        returnValue: _i18.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i18.Future<List<_i4.Pusher>?>.value(),
+      ) as _i18.Future<List<_i4.Pusher>?>);
 
   @override
-  _i17.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i18.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
+        returnValue: _i18.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
           this,
           Invocation.method(
             #getPushRules,
@@ -6584,24 +6618,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
+            _i18.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i17.Future<_i4.PushRuleSet>);
+      ) as _i18.Future<_i4.PushRuleSet>);
 
   @override
-  _i17.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i18.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_64(
+        returnValue: _i18.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_65(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6609,18 +6643,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_64(
+            _i18.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_65(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i17.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i18.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i17.Future<void> deletePushRule(
+  _i18.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6632,12 +6666,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.PushRule> getPushRule(
+  _i18.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6649,7 +6683,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i17.Future<_i4.PushRule>.value(_FakePushRule_65(
+        returnValue: _i18.Future<_i4.PushRule>.value(_FakePushRule_66(
           this,
           Invocation.method(
             #getPushRule,
@@ -6660,7 +6694,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.PushRule>.value(_FakePushRule_65(
+            _i18.Future<_i4.PushRule>.value(_FakePushRule_66(
           this,
           Invocation.method(
             #getPushRule,
@@ -6670,10 +6704,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.PushRule>);
+      ) as _i18.Future<_i4.PushRule>);
 
   @override
-  _i17.Future<void> setPushRule(
+  _i18.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -6697,12 +6731,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<List<Object?>> getPushRuleActions(
+  _i18.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6714,13 +6748,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i17.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i18.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i17.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i17.Future<List<Object?>>);
+            _i18.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i18.Future<List<Object?>>);
 
   @override
-  _i17.Future<void> setPushRuleActions(
+  _i18.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -6734,12 +6768,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<bool> isPushRuleEnabled(
+  _i18.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6751,12 +6785,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<void> setPushRuleEnabled(
+  _i18.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -6770,19 +6804,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i18.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
+            _i18.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
           this,
           Invocation.method(
             #refresh,
@@ -6790,28 +6824,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
+            _i18.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i17.Future<_i4.RefreshResponse>);
+      ) as _i18.Future<_i4.RefreshResponse>);
 
   @override
-  _i17.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i18.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i17.Future<bool?>.value(),
-        returnValueForMissingStub: _i17.Future<bool?>.value(),
-      ) as _i17.Future<bool?>);
+        returnValue: _i18.Future<bool?>.value(),
+        returnValueForMissingStub: _i18.Future<bool?>.value(),
+      ) as _i18.Future<bool?>);
 
   @override
-  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i18.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6833,8 +6867,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6850,8 +6884,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6867,10 +6901,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.RequestTokenResponse>);
+      ) as _i18.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i18.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6894,8 +6928,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6912,8 +6946,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6930,17 +6964,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.RequestTokenResponse>);
+      ) as _i18.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i18.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -6948,23 +6982,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i18.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i17.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i18.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
+        returnValue: _i18.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -6972,17 +7006,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
+            _i18.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeys>);
+      ) as _i18.Future<_i4.RoomKeys>);
 
   @override
-  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i18.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -6994,8 +7028,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -7006,8 +7040,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -7017,10 +7051,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i18.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i18.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -7032,8 +7066,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -7044,8 +7078,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -7055,10 +7089,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i18.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i17.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i18.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -7070,7 +7104,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
+        returnValue: _i18.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7081,7 +7115,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
+            _i18.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7091,10 +7125,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeyBackup>);
+      ) as _i18.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i18.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -7108,8 +7142,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7121,8 +7155,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7133,10 +7167,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i18.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i18.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7150,8 +7184,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7163,8 +7197,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7175,10 +7209,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i18.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i17.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i18.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7192,7 +7226,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+        returnValue: _i18.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7204,7 +7238,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+            _i18.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7215,10 +7249,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.KeyBackupData>);
+      ) as _i18.Future<_i4.KeyBackupData>);
 
   @override
-  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i18.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7234,8 +7268,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7248,8 +7282,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7261,18 +7295,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i18.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i18.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_69(
+                _i18.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_70(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7280,18 +7314,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_69(
+                _i18.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_70(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i18.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i17.Future<String> postRoomKeysVersion(
+  _i18.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7303,7 +7337,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7314,7 +7348,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i20.dummyValue<String>(
+            _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7324,29 +7358,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i18.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i18.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_70(
+        returnValue: _i18.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_71(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7354,18 +7388,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_70(
+            _i18.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_71(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i17.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i18.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i17.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i18.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7380,24 +7414,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i18.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i17.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
-      ) as _i17.Future<List<String>>);
+        returnValue: _i18.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i18.Future<List<String>>.value(<String>[]),
+      ) as _i18.Future<List<String>>);
 
   @override
-  _i17.Future<void> ban(
+  _i18.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7411,12 +7445,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.EventContext> getEventContext(
+  _i18.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7434,7 +7468,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i17.Future<_i4.EventContext>.value(_FakeEventContext_71(
+        returnValue: _i18.Future<_i4.EventContext>.value(_FakeEventContext_72(
           this,
           Invocation.method(
             #getEventContext,
@@ -7449,7 +7483,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.EventContext>.value(_FakeEventContext_71(
+            _i18.Future<_i4.EventContext>.value(_FakeEventContext_72(
           this,
           Invocation.method(
             #getEventContext,
@@ -7463,10 +7497,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.EventContext>);
+      ) as _i18.Future<_i4.EventContext>);
 
   @override
-  _i17.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i18.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7478,7 +7512,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+        returnValue: _i18.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7489,7 +7523,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+            _i18.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7499,20 +7533,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.MatrixEvent>);
+      ) as _i18.Future<_i4.MatrixEvent>);
 
   @override
-  _i17.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i18.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> inviteBy3PID(
+  _i18.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7524,12 +7558,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> inviteUser(
+  _i18.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7543,12 +7577,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String> joinRoomById(
+  _i18.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7562,7 +7596,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7574,7 +7608,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i20.dummyValue<String>(
+            _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7585,23 +7619,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i18.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i17.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i18.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i17.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i17.Future<Map<String, _i4.RoomMember>?>);
+            _i18.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i18.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i17.Future<void> kick(
+  _i18.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7615,12 +7649,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> leaveRoom(
+  _i18.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7630,12 +7664,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i18.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -7651,12 +7685,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i17.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i17.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i17.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i18.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i18.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i18.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i17.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i18.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -7678,8 +7712,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i17.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_72(
+        returnValue: _i18.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_73(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7695,8 +7729,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_72(
+        returnValueForMissingStub: _i18.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_73(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7712,10 +7746,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetRoomEventsResponse>);
+      ) as _i18.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i17.Future<void> setReadMarker(
+  _i18.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7731,12 +7765,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> postReceipt(
+  _i18.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -7752,12 +7786,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String?> redactEvent(
+  _i18.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7773,12 +7807,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i17.Future<String?>.value(),
-        returnValueForMissingStub: _i17.Future<String?>.value(),
-      ) as _i17.Future<String?>);
+        returnValue: _i18.Future<String?>.value(),
+        returnValueForMissingStub: _i18.Future<String?>.value(),
+      ) as _i18.Future<String?>);
 
   @override
-  _i17.Future<void> reportRoom(
+  _i18.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7790,12 +7824,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> reportEvent(
+  _i18.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7813,12 +7847,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String> sendMessage(
+  _i18.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7834,7 +7868,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7847,7 +7881,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i20.dummyValue<String>(
+            _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7859,23 +7893,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i18.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i18.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i17.Future<List<_i4.MatrixEvent>>);
+            _i18.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i18.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i17.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i18.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -7892,13 +7926,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<String> setRoomStateWithKey(
+  _i18.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -7914,7 +7948,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7927,7 +7961,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i20.dummyValue<String>(
+            _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7939,10 +7973,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<void> unban(
+  _i18.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7956,12 +7990,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String> upgradeRoom(
+  _i18.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -7975,7 +8009,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7987,7 +8021,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i20.dummyValue<String>(
+            _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7998,10 +8032,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<_i4.SearchResults> search(
+  _i18.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -8011,7 +8045,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
+        returnValue: _i18.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
           this,
           Invocation.method(
             #search,
@@ -8020,7 +8054,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
+            _i18.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
           this,
           Invocation.method(
             #search,
@@ -8028,10 +8062,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i17.Future<_i4.SearchResults>);
+      ) as _i18.Future<_i4.SearchResults>);
 
   @override
-  _i17.Future<_i4.SyncUpdate> sync({
+  _i18.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -8052,7 +8086,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
+        returnValue: _i18.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_29(
           this,
           Invocation.method(
             #sync,
@@ -8068,7 +8102,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
+            _i18.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_29(
           this,
           Invocation.method(
             #sync,
@@ -8083,22 +8117,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.SyncUpdate>);
+      ) as _i18.Future<_i4.SyncUpdate>);
 
   @override
-  _i17.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i18.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i18.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i17.Future<List<_i4.Location>>);
+            _i18.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i18.Future<List<_i4.Location>>);
 
   @override
-  _i17.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i18.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8108,21 +8142,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i18.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i17.Future<List<_i4.Location>>);
+            _i18.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i18.Future<List<_i4.Location>>);
 
   @override
-  _i17.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i18.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_74(
+        returnValue: _i18.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_75(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -8130,45 +8164,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_74(
+            _i18.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_75(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i17.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i18.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i17.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i18.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i18.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i18.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i18.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i18.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i18.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
+            _i18.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i18.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i18.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8179,13 +8213,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i18.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
+            _i18.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i18.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i17.Future<Map<String, Object?>> getAccountData(
+  _i18.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -8198,13 +8232,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<void> setAccountData(
+  _i18.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8218,12 +8252,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String> defineFilter(
+  _i18.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -8235,7 +8269,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8246,7 +8280,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i20.dummyValue<String>(
+            _i18.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8256,10 +8290,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<_i4.Filter> getFilter(
+  _i18.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8271,7 +8305,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i17.Future<_i4.Filter>.value(_FakeFilter_14(
+        returnValue: _i18.Future<_i4.Filter>.value(_FakeFilter_15(
           this,
           Invocation.method(
             #getFilter,
@@ -8281,7 +8315,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.Filter>.value(_FakeFilter_14(
+        returnValueForMissingStub: _i18.Future<_i4.Filter>.value(_FakeFilter_15(
           this,
           Invocation.method(
             #getFilter,
@@ -8291,10 +8325,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.Filter>);
+      ) as _i18.Future<_i4.Filter>);
 
   @override
-  _i17.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i18.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8307,7 +8341,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
+            _i18.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8318,7 +8352,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
+            _i18.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8328,10 +8362,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.OpenIdCredentials>);
+      ) as _i18.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i17.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i18.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8346,13 +8380,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<void> setAccountDataPerRoom(
+  _i18.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8368,12 +8402,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i18.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8385,12 +8419,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i17.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i17.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i17.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i18.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i18.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i18.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i17.Future<void> deleteRoomTag(
+  _i18.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8404,12 +8438,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> setRoomTag(
+  _i18.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8425,12 +8459,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i18.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8440,8 +8474,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i17.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_76(
+        returnValue: _i18.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_77(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8450,8 +8484,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_76(
+            _i18.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_77(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8459,10 +8493,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i17.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i18.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i17.Future<Map<String, Object?>> reportUser(
+  _i18.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8475,40 +8509,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i18.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i17.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_77(
+        returnValue: _i18.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_78(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_77(
+        returnValueForMissingStub: _i18.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_78(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i17.Future<_i4.CreateContentResponse>);
+      ) as _i18.Future<_i4.CreateContentResponse>);
 
   @override
-  _i17.Future<Map<String, Object?>> uploadContentToMXC(
+  _i18.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i26.Uint8List? body, {
+    _i27.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8526,10 +8560,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [AuthService].
@@ -8569,7 +8603,7 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
       ) as bool);
 
   @override
-  _i17.Future<bool> login({
+  _i18.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -8586,12 +8620,12 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
             #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<bool> completeSsoLogin({
+  _i18.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -8604,12 +8638,12 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<void> completeRegistration(
+  _i18.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -8619,9 +8653,9 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
           [response],
           {#password: password},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   void activateRestoredSession() => super.noSuchMethod(
@@ -8633,37 +8667,37 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
       );
 
   @override
-  _i17.Future<void> logout() => (super.noSuchMethod(
+  _i18.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> handleServerLogout() => (super.noSuchMethod(
+  _i18.Future<void> handleServerLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleServerLogout,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> saveSessionBackup() => (super.noSuchMethod(
+  _i18.Future<void> saveSessionBackup() => (super.noSuchMethod(
         Invocation.method(
           #saveSessionBackup,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i19.ServerAuthCapabilities> getServerAuthCapabilities(
+  _i18.Future<_i20.ServerAuthCapabilities> getServerAuthCapabilities(
     String? homeserver, {
     required bool? isLoggedIn,
   }) =>
@@ -8673,8 +8707,8 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
           [homeserver],
           {#isLoggedIn: isLoggedIn},
         ),
-        returnValue: _i17.Future<_i19.ServerAuthCapabilities>.value(
-            _FakeServerAuthCapabilities_78(
+        returnValue: _i18.Future<_i20.ServerAuthCapabilities>.value(
+            _FakeServerAuthCapabilities_79(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8683,8 +8717,8 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i19.ServerAuthCapabilities>.value(
-                _FakeServerAuthCapabilities_78(
+            _i18.Future<_i20.ServerAuthCapabilities>.value(
+                _FakeServerAuthCapabilities_79(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8692,7 +8726,7 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
             {#isLoggedIn: isLoggedIn},
           ),
         )),
-      ) as _i17.Future<_i19.ServerAuthCapabilities>);
+      ) as _i18.Future<_i20.ServerAuthCapabilities>);
 
   @override
   bool isPermanentAuthFailure(Object? error) => (super.noSuchMethod(
@@ -8705,17 +8739,17 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
       ) as bool);
 
   @override
-  _i17.Future<void> clearSessionKeys() => (super.noSuchMethod(
+  _i18.Future<void> clearSessionKeys() => (super.noSuchMethod(
         Invocation.method(
           #clearSessionKeys,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> saveLoginCredentials({
+  _i18.Future<void> saveLoginCredentials({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -8730,56 +8764,56 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
             #password: password,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<({String password, String username})?> loadLoginCredentials(
+  _i18.Future<({String password, String username})?> loadLoginCredentials(
           String? homeserver) =>
       (super.noSuchMethod(
         Invocation.method(
           #loadLoginCredentials,
           [homeserver],
         ),
-        returnValue: _i17.Future<({String password, String username})?>.value(),
+        returnValue: _i18.Future<({String password, String username})?>.value(),
         returnValueForMissingStub:
-            _i17.Future<({String password, String username})?>.value(),
-      ) as _i17.Future<({String password, String username})?>);
+            _i18.Future<({String password, String username})?>.value(),
+      ) as _i18.Future<({String password, String username})?>);
 
   @override
-  _i17.Future<void> clearLoginCredentials(String? homeserver) =>
+  _i18.Future<void> clearLoginCredentials(String? homeserver) =>
       (super.noSuchMethod(
         Invocation.method(
           #clearLoginCredentials,
           [homeserver],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> migrateStorageKeys() => (super.noSuchMethod(
+  _i18.Future<void> migrateStorageKeys() => (super.noSuchMethod(
         Invocation.method(
           #migrateStorageKeys,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> persistCredentials() => (super.noSuchMethod(
+  _i18.Future<void> persistCredentials() => (super.noSuchMethod(
         Invocation.method(
           #persistCredentials,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8788,7 +8822,7 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
       );
 
   @override
-  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/widgets/message_reply_test.mocks.dart
+++ b/test/widgets/message_reply_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i23;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i24;
 
-import 'package:flutter/services.dart' as _i24;
-import 'package:flutter/widgets.dart' as _i25;
+import 'package:flutter/services.dart' as _i25;
+import 'package:flutter/widgets.dart' as _i26;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i22;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i23;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,14 +28,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i19;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i18;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i26;
+import 'package:matrix/src/utils/space_child.dart' as _i27;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i20;
+import 'package:mockito/src/dummies.dart' as _i21;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -860,9 +861,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -871,8 +872,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,9 +883,19 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_78(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,8 +904,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,8 +914,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -912,8 +924,8 @@ class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_81 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_81(
+class _FakeRoom_82 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -922,9 +934,9 @@ class _FakeRoom_81 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_82 extends _i1.SmartFake
-    implements _i18.TimelineChunk {
-  _FakeTimelineChunk_82(
+class _FakeTimelineChunk_83 extends _i1.SmartFake
+    implements _i19.TimelineChunk {
+  _FakeTimelineChunk_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -933,8 +945,8 @@ class _FakeTimelineChunk_82 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixFile_83 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_83(
+class _FakeMatrixFile_84 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -943,8 +955,8 @@ class _FakeMatrixFile_83 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_84 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_84(
+class _FakeEvent_85 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_85(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -971,12 +983,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i19.KeyVerificationMethod> get verificationMethods =>
+  Set<_i20.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i19.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
-      ) as Set<_i19.KeyVerificationMethod>);
+        returnValue: <_i20.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
+      ) as Set<_i20.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1096,11 +1108,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1137,11 +1149,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1171,11 +1183,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1184,11 +1196,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1474,34 +1486,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i20.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i19.KeyVerification>
+  _i3.CachedStreamController<_i20.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i19.KeyVerification>(
+                _FakeCachedStreamController_6<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i19.KeyVerification>);
+          ) as _i3.CachedStreamController<_i20.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1657,7 +1669,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1946,14 +1958,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2341,8 +2353,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValue: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2358,8 +2370,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2400,7 +2412,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2416,7 +2428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2465,7 +2477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2486,7 +2498,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2589,7 +2601,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2607,7 +2619,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3126,7 +3138,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3478,7 +3490,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3492,7 +3504,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3643,7 +3655,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5021,7 +5033,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5043,7 +5055,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5537,7 +5549,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5549,7 +5561,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6557,7 +6569,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6568,7 +6580,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6816,7 +6828,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6828,7 +6840,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7088,7 +7100,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7101,7 +7113,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7168,7 +7180,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7181,7 +7193,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7229,7 +7241,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7241,7 +7253,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7489,7 +7501,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7500,7 +7512,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7762,7 +7774,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7789,7 +7801,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7819,11 +7831,11 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7961,17 +7973,30 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8080,7 +8105,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8133,7 +8167,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i24.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8229,7 +8263,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8238,7 +8272,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8257,7 +8291,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i25.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8268,7 +8302,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i25.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8316,7 +8350,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i25.RouteInformation? routeInformation) =>
+          _i26.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8354,7 +8388,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i24.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8363,7 +8397,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i24.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8372,16 +8406,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i24.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
-      ) as _i5.Future<_i23.AppExitResponse>);
+            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
+      ) as _i5.Future<_i24.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8409,11 +8443,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8443,11 +8477,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -8500,11 +8534,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8540,11 +8574,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8560,11 +8594,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8573,11 +8607,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8620,11 +8654,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8667,11 +8701,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8890,18 +8924,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i27.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i26.SpaceParent>[],
-        returnValueForMissingStub: <_i26.SpaceParent>[],
-      ) as List<_i26.SpaceParent>);
+        returnValue: <_i27.SpaceParent>[],
+        returnValueForMissingStub: <_i27.SpaceParent>[],
+      ) as List<_i27.SpaceParent>);
 
   @override
-  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i27.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i26.SpaceChild>[],
-        returnValueForMissingStub: <_i26.SpaceChild>[],
-      ) as List<_i26.SpaceChild>);
+        returnValue: <_i27.SpaceChild>[],
+        returnValueForMissingStub: <_i27.SpaceChild>[],
+      ) as List<_i27.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9068,14 +9102,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9123,7 +9157,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9131,7 +9165,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9146,7 +9180,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9154,7 +9188,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9248,7 +9282,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9256,7 +9290,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9498,7 +9532,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9509,7 +9543,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9598,15 +9632,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i18.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i18.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i18.TimelineChunk?>.value(),
-      ) as _i5.Future<_i18.TimelineChunk?>);
+        returnValue: _i5.Future<_i19.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i19.TimelineChunk?>.value(),
+      ) as _i5.Future<_i19.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9647,7 +9681,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9664,7 +9698,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9728,14 +9762,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9751,14 +9785,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9814,7 +9848,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9822,7 +9856,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10134,11 +10168,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -10188,17 +10222,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i18.TimelineChunk get chunk => (super.noSuchMethod(
+  _i19.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_82(
+        returnValue: _FakeTimelineChunk_83(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_82(
+        returnValueForMissingStub: _FakeTimelineChunk_83(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i18.TimelineChunk);
+      ) as _i19.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10301,7 +10335,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i18.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i19.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10500,11 +10534,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.getter(#sender),
         ),
@@ -10513,11 +10547,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10526,11 +10560,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -10553,11 +10587,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10566,11 +10600,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10579,11 +10613,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10592,11 +10626,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10605,11 +10639,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10618,11 +10652,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10687,11 +10721,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10700,11 +10734,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10757,11 +10791,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10846,11 +10880,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10868,11 +10902,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11083,7 +11117,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i21.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i22.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -11098,7 +11132,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_83(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_84(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -11112,7 +11146,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_83(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_84(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -11148,7 +11182,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11163,7 +11197,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11200,7 +11234,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11214,7 +11248,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11251,7 +11285,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11265,7 +11299,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11299,7 +11333,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11312,7 +11346,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11388,14 +11422,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_84(
+        returnValue: _FakeEvent_85(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_84(
+        returnValueForMissingStub: _FakeEvent_85(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11412,11 +11446,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -11425,11 +11459,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11495,11 +11529,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11524,11 +11558,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11546,11 +11580,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11597,7 +11631,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11609,7 +11643,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11679,7 +11713,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11692,7 +11726,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/new_dm_dialog_test.mocks.dart
+++ b/test/widgets/new_dm_dialog_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,14 +28,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i26;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i27;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i25;
+import 'package:matrix/src/utils/space_child.dart' as _i26;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -860,9 +861,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -871,8 +872,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,9 +883,19 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_78(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,8 +904,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,8 +914,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -930,12 +942,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1055,11 +1067,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1096,11 +1108,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1130,11 +1142,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1143,11 +1155,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1433,34 +1445,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1616,7 +1628,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1905,14 +1917,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2300,8 +2312,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2317,8 +2329,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2359,7 +2371,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2375,7 +2387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2424,7 +2436,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2445,7 +2457,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2548,7 +2560,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2566,7 +2578,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3085,7 +3097,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3437,7 +3449,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3451,7 +3463,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3602,7 +3614,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4980,7 +4992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5002,7 +5014,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5496,7 +5508,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5508,7 +5520,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6516,7 +6528,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6527,7 +6539,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6775,7 +6787,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6787,7 +6799,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7047,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7060,7 +7072,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7127,7 +7139,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7140,7 +7152,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7188,7 +7200,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7200,7 +7212,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7448,7 +7460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7459,7 +7471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7721,7 +7733,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7748,7 +7760,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7778,11 +7790,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7920,17 +7932,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8039,7 +8064,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8092,7 +8126,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8188,7 +8222,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8197,7 +8231,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8216,7 +8250,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8227,7 +8261,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8275,7 +8309,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8313,7 +8347,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8322,7 +8356,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8331,16 +8365,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8368,11 +8402,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8402,11 +8436,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -8459,11 +8493,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8499,11 +8533,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8519,11 +8553,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8532,11 +8566,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8579,11 +8613,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8626,11 +8660,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8849,18 +8883,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i25.SpaceParent>[],
-        returnValueForMissingStub: <_i25.SpaceParent>[],
-      ) as List<_i25.SpaceParent>);
+        returnValue: <_i26.SpaceParent>[],
+        returnValueForMissingStub: <_i26.SpaceParent>[],
+      ) as List<_i26.SpaceParent>);
 
   @override
-  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i25.SpaceChild>[],
-        returnValueForMissingStub: <_i25.SpaceChild>[],
-      ) as List<_i25.SpaceChild>);
+        returnValue: <_i26.SpaceChild>[],
+        returnValueForMissingStub: <_i26.SpaceChild>[],
+      ) as List<_i26.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9027,14 +9061,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9082,7 +9116,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9090,7 +9124,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9105,7 +9139,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9113,7 +9147,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9207,7 +9241,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9215,7 +9249,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9457,7 +9491,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9468,7 +9502,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9557,15 +9591,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i26.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i27.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i26.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i26.TimelineChunk?>.value(),
-      ) as _i5.Future<_i26.TimelineChunk?>);
+        returnValue: _i5.Future<_i27.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i27.TimelineChunk?>.value(),
+      ) as _i5.Future<_i27.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9606,7 +9640,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9623,7 +9657,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9687,14 +9721,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9710,14 +9744,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9773,7 +9807,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9781,7 +9815,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/new_room_dialog_test.mocks.dart
+++ b/test/widgets/new_room_dialog_test.mocks.dart
@@ -4,15 +4,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/models/join_mode.dart' as _i25;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/models/join_mode.dart' as _i26;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -29,14 +29,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i27;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i28;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i26;
+import 'package:matrix/src/utils/space_child.dart' as _i27;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -861,9 +862,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -872,8 +873,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeStateEvent_77 extends _i1.SmartFake implements _i2.StateEvent {
-  _FakeStateEvent_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -882,8 +884,8 @@ class _FakeStateEvent_77 extends _i1.SmartFake implements _i2.StateEvent {
         );
 }
 
-class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_78(
+class _FakeStateEvent_78 extends _i1.SmartFake implements _i2.StateEvent {
+  _FakeStateEvent_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,9 +894,19 @@ class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_79 extends _i1.SmartFake
+class _FakeRoomSummary_79 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_79(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_80 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_79(
+  _FakeLatestReceiptState_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -903,8 +915,8 @@ class _FakeLatestReceiptState_79 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_80(
+class _FakeTimeline_81 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -913,8 +925,8 @@ class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_81(
+class _FakeUser_82 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -941,12 +953,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1066,11 +1078,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1107,11 +1119,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1141,11 +1153,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1154,11 +1166,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1444,34 +1456,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1627,7 +1639,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1916,14 +1928,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2311,8 +2323,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2328,8 +2340,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2370,7 +2382,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2386,7 +2398,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2435,7 +2447,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2456,7 +2468,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2559,7 +2571,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2577,7 +2589,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3096,7 +3108,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3448,7 +3460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3462,7 +3474,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3613,7 +3625,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4991,7 +5003,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5013,7 +5025,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5507,7 +5519,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5519,7 +5531,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6527,7 +6539,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6538,7 +6550,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6786,7 +6798,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6798,7 +6810,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7058,7 +7070,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7071,7 +7083,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7138,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7151,7 +7163,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7199,7 +7211,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7211,7 +7223,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7459,7 +7471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7470,7 +7482,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7732,7 +7744,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7759,7 +7771,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7789,11 +7801,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7931,17 +7943,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8050,7 +8075,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8103,7 +8137,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8199,7 +8233,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8208,7 +8242,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8227,7 +8261,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8238,7 +8272,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8286,7 +8320,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8324,7 +8358,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8333,7 +8367,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8342,16 +8376,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8378,14 +8412,14 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 class MockSpaceAccessService extends _i1.Mock
     implements _i13.SpaceAccessService {
   @override
-  _i25.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
+  _i26.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
         Invocation.method(
           #getJoinMode,
           [room],
         ),
-        returnValue: _i25.JoinMode.invite,
-        returnValueForMissingStub: _i25.JoinMode.invite,
-      ) as _i25.JoinMode);
+        returnValue: _i26.JoinMode.invite,
+        returnValueForMissingStub: _i26.JoinMode.invite,
+      ) as _i26.JoinMode);
 
   @override
   List<String> allowedSpaceIds(_i2.Room? room) => (super.noSuchMethod(
@@ -8469,7 +8503,7 @@ class MockSpaceAccessService extends _i1.Mock
   @override
   _i5.Future<void> applyJoinMode({
     required String? roomId,
-    required _i25.JoinMode? mode,
+    required _i26.JoinMode? mode,
     List<String>? allowSpaceIds = const [],
   }) =>
       (super.noSuchMethod(
@@ -8488,7 +8522,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   Map<String, Object?> buildJoinRulesPayload(
-    _i25.JoinMode? mode,
+    _i26.JoinMode? mode,
     List<String>? allowSpaceIds, {
     List<Map<String, Object?>>? preserveEntries = const [],
   }) =>
@@ -8507,7 +8541,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   _i2.StateEvent buildJoinRulesStateEvent(
-    _i25.JoinMode? mode,
+    _i26.JoinMode? mode,
     List<String>? allowSpaceIds,
   ) =>
       (super.noSuchMethod(
@@ -8518,7 +8552,7 @@ class MockSpaceAccessService extends _i1.Mock
             allowSpaceIds,
           ],
         ),
-        returnValue: _FakeStateEvent_77(
+        returnValue: _FakeStateEvent_78(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -8528,7 +8562,7 @@ class MockSpaceAccessService extends _i1.Mock
             ],
           ),
         ),
-        returnValueForMissingStub: _FakeStateEvent_77(
+        returnValueForMissingStub: _FakeStateEvent_78(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -8553,7 +8587,7 @@ class MockSpaceAccessService extends _i1.Mock
             newVersion,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,
@@ -8564,7 +8598,7 @@ class MockSpaceAccessService extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,
@@ -8626,11 +8660,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8660,11 +8694,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_78(
+        returnValue: _FakeRoomSummary_79(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_78(
+        returnValueForMissingStub: _FakeRoomSummary_79(
           this,
           Invocation.getter(#summary),
         ),
@@ -8717,11 +8751,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8757,11 +8791,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8777,11 +8811,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8790,11 +8824,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8837,11 +8871,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8884,11 +8918,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_79(
+        returnValue: _FakeLatestReceiptState_80(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_79(
+        returnValueForMissingStub: _FakeLatestReceiptState_80(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -9107,18 +9141,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i27.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i26.SpaceParent>[],
-        returnValueForMissingStub: <_i26.SpaceParent>[],
-      ) as List<_i26.SpaceParent>);
+        returnValue: <_i27.SpaceParent>[],
+        returnValueForMissingStub: <_i27.SpaceParent>[],
+      ) as List<_i27.SpaceParent>);
 
   @override
-  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i27.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i26.SpaceChild>[],
-        returnValueForMissingStub: <_i26.SpaceChild>[],
-      ) as List<_i26.SpaceChild>);
+        returnValue: <_i27.SpaceChild>[],
+        returnValueForMissingStub: <_i27.SpaceChild>[],
+      ) as List<_i27.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9285,14 +9319,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9340,7 +9374,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9348,7 +9382,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9363,7 +9397,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9371,7 +9405,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9465,7 +9499,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9473,7 +9507,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9715,7 +9749,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9726,7 +9760,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9815,15 +9849,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i27.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i28.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i27.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i27.TimelineChunk?>.value(),
-      ) as _i5.Future<_i27.TimelineChunk?>);
+        returnValue: _i5.Future<_i28.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i28.TimelineChunk?>.value(),
+      ) as _i5.Future<_i28.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9864,7 +9898,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_81(
           this,
           Invocation.method(
             #getTimeline,
@@ -9881,7 +9915,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_81(
           this,
           Invocation.method(
             #getTimeline,
@@ -9945,14 +9979,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_81(
+        returnValue: _FakeUser_82(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_81(
+        returnValueForMissingStub: _FakeUser_82(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9968,14 +10002,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_81(
+        returnValue: _FakeUser_82(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_81(
+        returnValueForMissingStub: _FakeUser_82(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -10031,7 +10065,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10039,7 +10073,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/recovery_key_handler_test.mocks.dart
+++ b/test/widgets/recovery_key_handler_test.mocks.dart
@@ -3,15 +3,15 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i17;
-import 'dart:typed_data' as _i27;
-import 'dart:ui' as _i24;
+import 'dart:async' as _i18;
+import 'dart:typed_data' as _i28;
+import 'dart:ui' as _i25;
 
-import 'package:flutter/services.dart' as _i25;
-import 'package:flutter/widgets.dart' as _i26;
-import 'package:http/http.dart' as _i16;
-import 'package:kohera/core/services/matrix_service.dart' as _i22;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i13;
+import 'package:flutter/services.dart' as _i26;
+import 'package:flutter/widgets.dart' as _i27;
+import 'package:http/http.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i23;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -27,15 +27,16 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i14;
-import 'package:matrix/encryption/cross_signing.dart' as _i21;
-import 'package:matrix/encryption/key_verification_manager.dart' as _i20;
-import 'package:matrix/encryption/olm_manager.dart' as _i19;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i13;
+import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption/cross_signing.dart' as _i22;
+import 'package:matrix/encryption/key_verification_manager.dart' as _i21;
+import 'package:matrix/encryption/olm_manager.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i18;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i15;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i19;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i16;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i23;
+import 'package:mockito/src/dummies.dart' as _i24;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -169,9 +170,9 @@ class _FakeOutboxService_10 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_11 extends _i1.SmartFake
-    implements _i13.StickerPackService {
-  _FakeStickerPackService_11(
+class _FakeAvatarResolver_11 extends _i1.SmartFake
+    implements _i13.AvatarResolver {
+  _FakeAvatarResolver_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -180,8 +181,9 @@ class _FakeStickerPackService_11 extends _i1.SmartFake
         );
 }
 
-class _FakeEncryption_12 extends _i1.SmartFake implements _i14.Encryption {
-  _FakeEncryption_12(
+class _FakeStickerPackService_12 extends _i1.SmartFake
+    implements _i14.StickerPackService {
+  _FakeStickerPackService_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -190,8 +192,8 @@ class _FakeEncryption_12 extends _i1.SmartFake implements _i14.Encryption {
         );
 }
 
-class _FakeSSSS_13 extends _i1.SmartFake implements _i14.SSSS {
-  _FakeSSSS_13(
+class _FakeEncryption_13 extends _i1.SmartFake implements _i15.Encryption {
+  _FakeEncryption_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -200,9 +202,19 @@ class _FakeSSSS_13 extends _i1.SmartFake implements _i14.SSSS {
         );
 }
 
-class _FakeSecretStorageKeyContent_14 extends _i1.SmartFake
+class _FakeSSSS_14 extends _i1.SmartFake implements _i15.SSSS {
+  _FakeSSSS_14(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeSecretStorageKeyContent_15 extends _i1.SmartFake
     implements _i4.SecretStorageKeyContent {
-  _FakeSecretStorageKeyContent_14(
+  _FakeSecretStorageKeyContent_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -211,8 +223,8 @@ class _FakeSecretStorageKeyContent_14 extends _i1.SmartFake
         );
 }
 
-class _FakeDatabaseApi_15 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_15(
+class _FakeDatabaseApi_16 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -221,8 +233,8 @@ class _FakeDatabaseApi_15 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_16 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_16(
+class _FakeFilter_17 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -231,9 +243,9 @@ class _FakeFilter_16 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_17 extends _i1.SmartFake
+class _FakeNativeImplementations_18 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_17(
+  _FakeNativeImplementations_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -242,8 +254,8 @@ class _FakeNativeImplementations_17 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_18 extends _i1.SmartFake implements Duration {
-  _FakeDuration_18(
+class _FakeDuration_19 extends _i1.SmartFake implements Duration {
+  _FakeDuration_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -252,9 +264,9 @@ class _FakeDuration_18 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_19 extends _i1.SmartFake
+class _FakePushruleEvaluator_20 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_19(
+  _FakePushruleEvaluator_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -263,8 +275,8 @@ class _FakePushruleEvaluator_19 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_20 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_20(
+class _FakeProfile_21 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -273,9 +285,9 @@ class _FakeProfile_20 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_21<T> extends _i1.SmartFake
-    implements _i15.CachedStreamController<T> {
-  _FakeCachedStreamController_21(
+class _FakeCachedStreamController_22<T> extends _i1.SmartFake
+    implements _i16.CachedStreamController<T> {
+  _FakeCachedStreamController_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -284,8 +296,8 @@ class _FakeCachedStreamController_21<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_22 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_22(
+class _FakeDateTime_23 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -294,8 +306,8 @@ class _FakeDateTime_22 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_23 extends _i1.SmartFake implements _i16.Client {
-  _FakeClient_23(
+class _FakeClient_24 extends _i1.SmartFake implements _i17.Client {
+  _FakeClient_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -304,9 +316,9 @@ class _FakeClient_23 extends _i1.SmartFake implements _i16.Client {
         );
 }
 
-class _FakeDiscoveryInformation_24 extends _i1.SmartFake
+class _FakeDiscoveryInformation_25 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_24(
+  _FakeDiscoveryInformation_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -315,9 +327,9 @@ class _FakeDiscoveryInformation_24 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_25 extends _i1.SmartFake
+class _FakeGetVersionsResponse_26 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_25(
+  _FakeGetVersionsResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -326,9 +338,9 @@ class _FakeGetVersionsResponse_25 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_26 extends _i1.SmartFake
+class _FakeRegisterResponse_27 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_26(
+  _FakeRegisterResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -337,8 +349,8 @@ class _FakeRegisterResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_27(
+class _FakeLoginResponse_28 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -347,9 +359,9 @@ class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_29 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_28(
+  _FakeGetAuthMetadataResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -358,8 +370,8 @@ class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_29<T1> extends _i1.SmartFake implements _i17.Future<T1> {
-  _FakeFuture_29(
+class _FakeFuture_30<T1> extends _i1.SmartFake implements _i18.Future<T1> {
+  _FakeFuture_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -368,8 +380,8 @@ class _FakeFuture_29<T1> extends _i1.SmartFake implements _i17.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_30 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_30(
+class _FakeSyncUpdate_31 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -378,9 +390,9 @@ class _FakeSyncUpdate_30 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_31 extends _i1.SmartFake
+class _FakeCachedProfileInformation_32 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_31(
+  _FakeCachedProfileInformation_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -389,8 +401,8 @@ class _FakeCachedProfileInformation_31 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_32(
+class _FakeMediaConfig_33 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -399,8 +411,8 @@ class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_33 extends _i1.SmartFake implements _i18.FileResponse {
-  _FakeFileResponse_33(
+class _FakeFileResponse_34 extends _i1.SmartFake implements _i19.FileResponse {
+  _FakeFileResponse_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -409,8 +421,8 @@ class _FakeFileResponse_33 extends _i1.SmartFake implements _i18.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_34(
+class _FakePreviewForUrl_35 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -419,8 +431,8 @@ class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_35 extends _i1.SmartFake implements Uri {
-  _FakeUri_35(
+class _FakeUri_36 extends _i1.SmartFake implements Uri {
+  _FakeUri_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -429,9 +441,9 @@ class _FakeUri_35 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_36 extends _i1.SmartFake
+class _FakeCachedPresence_37 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_36(
+  _FakeCachedPresence_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -440,9 +452,9 @@ class _FakeCachedPresence_36 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_37 extends _i1.SmartFake
+class _FakeTurnServerCredentials_38 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_37(
+  _FakeTurnServerCredentials_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -451,9 +463,9 @@ class _FakeTurnServerCredentials_37 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_38 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_39 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_38(
+  _FakeRoomKeysUpdateResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -462,8 +474,8 @@ class _FakeRoomKeysUpdateResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_39 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_39(
+class _FakeKeyBackupData_40 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -472,9 +484,9 @@ class _FakeKeyBackupData_39 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_40 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_41 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_40(
+  _FakeGetWellknownSupportResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -483,9 +495,9 @@ class _FakeGetWellknownSupportResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_41 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_42 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_41(
+  _FakeGenerateLoginTokenResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -494,9 +506,9 @@ class _FakeGenerateLoginTokenResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_42 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_43 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_42(
+  _FakeGetRoomSummaryResponse$3_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -505,9 +517,9 @@ class _FakeGetRoomSummaryResponse$3_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_43 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_44 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_43(
+  _FakeGetSpaceHierarchyResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -516,9 +528,9 @@ class _FakeGetSpaceHierarchyResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_44 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_45 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_44(
+  _FakeGetRelatingEventsResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -527,9 +539,9 @@ class _FakeGetRelatingEventsResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_45 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_46 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_45(
+  _FakeGetRelatingEventsWithRelTypeResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -538,9 +550,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -549,9 +561,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_47 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_48 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_47(
+  _FakeGetThreadRootsResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -560,9 +572,9 @@ class _FakeGetThreadRootsResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_48 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_49 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_48(
+  _FakeGetEventByTimestampResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -571,9 +583,9 @@ class _FakeGetEventByTimestampResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_49 extends _i1.SmartFake
+class _FakeRequestTokenResponse_50 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_49(
+  _FakeRequestTokenResponse_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -582,9 +594,9 @@ class _FakeRequestTokenResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_50 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_51 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_50(
+  _FakeTokenOwnerInfo_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -593,8 +605,8 @@ class _FakeTokenOwnerInfo_50 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_51 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_51(
+class _FakeWhoIsInfo_52 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -603,8 +615,8 @@ class _FakeWhoIsInfo_51 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_52 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_52(
+class _FakeCapabilities_53 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -613,8 +625,8 @@ class _FakeCapabilities_52 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_53 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_53(
+class _FakeDevice_54 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -623,9 +635,9 @@ class _FakeDevice_53 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_54 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_55 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_54(
+  _FakeGetRoomIdByAliasResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -634,9 +646,9 @@ class _FakeGetRoomIdByAliasResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_55 extends _i1.SmartFake
+class _FakeGetEventsResponse_56 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_55(
+  _FakeGetEventsResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -645,9 +657,9 @@ class _FakeGetEventsResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_56 extends _i1.SmartFake
+class _FakePeekEventsResponse_57 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_56(
+  _FakePeekEventsResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -656,8 +668,8 @@ class _FakePeekEventsResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_57 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_57(
+class _FakeMatrixEvent_58 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -666,9 +678,9 @@ class _FakeMatrixEvent_57 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_58 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_59 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_58(
+  _FakeGetKeysChangesResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -677,9 +689,9 @@ class _FakeGetKeysChangesResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_59 extends _i1.SmartFake
+class _FakeClaimKeysResponse_60 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_59(
+  _FakeClaimKeysResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -688,9 +700,9 @@ class _FakeClaimKeysResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_60 extends _i1.SmartFake
+class _FakeQueryKeysResponse_61 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_60(
+  _FakeQueryKeysResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -699,9 +711,9 @@ class _FakeQueryKeysResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_61 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_62 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_61(
+  _FakeGetNotificationsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -710,9 +722,9 @@ class _FakeGetNotificationsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_62 extends _i1.SmartFake
+class _FakeGetPresenceResponse_63 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_62(
+  _FakeGetPresenceResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -721,9 +733,9 @@ class _FakeGetPresenceResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_63 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_64 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_63(
+  _FakeGetPublicRoomsResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -732,9 +744,9 @@ class _FakeGetPublicRoomsResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_64 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_65 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_64(
+  _FakeQueryPublicRoomsResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -743,8 +755,8 @@ class _FakeQueryPublicRoomsResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_65 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_65(
+class _FakePushRuleSet_66 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -753,9 +765,9 @@ class _FakePushRuleSet_65 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_66 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_67 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_66(
+  _FakeGetPushRulesGlobalResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -764,8 +776,8 @@ class _FakeGetPushRulesGlobalResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_67 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_67(
+class _FakePushRule_68 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -774,9 +786,9 @@ class _FakePushRule_67 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_68 extends _i1.SmartFake
+class _FakeRefreshResponse_69 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_68(
+  _FakeRefreshResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -785,8 +797,8 @@ class _FakeRefreshResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_69 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_69(
+class _FakeRoomKeys_70 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -795,8 +807,8 @@ class _FakeRoomKeys_69 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_70 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_70(
+class _FakeRoomKeyBackup_71 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -805,9 +817,9 @@ class _FakeRoomKeyBackup_70 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_71 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_72 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_71(
+  _FakeGetRoomKeysVersionCurrentResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -816,9 +828,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_72 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_73 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_72(
+  _FakeGetRoomKeysVersionResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -827,8 +839,8 @@ class _FakeGetRoomKeysVersionResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_73 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_73(
+class _FakeEventContext_74 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -837,9 +849,9 @@ class _FakeEventContext_73 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_74 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_75 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_74(
+  _FakeGetRoomEventsResponse_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -848,8 +860,8 @@ class _FakeGetRoomEventsResponse_74 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_75 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_75(
+class _FakeSearchResults_76 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -858,9 +870,9 @@ class _FakeSearchResults_75 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_76 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_77 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_76(
+  _FakeGetProtocolMetadataResponse$2_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -869,9 +881,9 @@ class _FakeGetProtocolMetadataResponse$2_76 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_77 extends _i1.SmartFake
+class _FakeOpenIdCredentials_78 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_77(
+  _FakeOpenIdCredentials_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,9 +892,9 @@ class _FakeOpenIdCredentials_77 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_78 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_79 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_78(
+  _FakeSearchUserDirectoryResponse_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -891,9 +903,9 @@ class _FakeSearchUserDirectoryResponse_78 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_79 extends _i1.SmartFake
+class _FakeCreateContentResponse_80 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_79(
+  _FakeCreateContentResponse_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,8 +914,8 @@ class _FakeCreateContentResponse_79 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyManager_80 extends _i1.SmartFake implements _i14.KeyManager {
-  _FakeKeyManager_80(
+class _FakeKeyManager_81 extends _i1.SmartFake implements _i15.KeyManager {
+  _FakeKeyManager_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -912,8 +924,8 @@ class _FakeKeyManager_80 extends _i1.SmartFake implements _i14.KeyManager {
         );
 }
 
-class _FakeOlmManager_81 extends _i1.SmartFake implements _i19.OlmManager {
-  _FakeOlmManager_81(
+class _FakeOlmManager_82 extends _i1.SmartFake implements _i20.OlmManager {
+  _FakeOlmManager_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -922,9 +934,9 @@ class _FakeOlmManager_81 extends _i1.SmartFake implements _i19.OlmManager {
         );
 }
 
-class _FakeKeyVerificationManager_82 extends _i1.SmartFake
-    implements _i20.KeyVerificationManager {
-  _FakeKeyVerificationManager_82(
+class _FakeKeyVerificationManager_83 extends _i1.SmartFake
+    implements _i21.KeyVerificationManager {
+  _FakeKeyVerificationManager_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -933,8 +945,8 @@ class _FakeKeyVerificationManager_82 extends _i1.SmartFake
         );
 }
 
-class _FakeCrossSigning_83 extends _i1.SmartFake implements _i21.CrossSigning {
-  _FakeCrossSigning_83(
+class _FakeCrossSigning_84 extends _i1.SmartFake implements _i22.CrossSigning {
+  _FakeCrossSigning_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -943,8 +955,8 @@ class _FakeCrossSigning_83 extends _i1.SmartFake implements _i21.CrossSigning {
         );
 }
 
-class _FakeBootstrap_84 extends _i1.SmartFake implements _i14.Bootstrap {
-  _FakeBootstrap_84(
+class _FakeBootstrap_85 extends _i1.SmartFake implements _i15.Bootstrap {
+  _FakeBootstrap_85(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -953,8 +965,8 @@ class _FakeBootstrap_84 extends _i1.SmartFake implements _i14.Bootstrap {
         );
 }
 
-class _FakeToDeviceEvent_85 extends _i1.SmartFake implements _i4.ToDeviceEvent {
-  _FakeToDeviceEvent_85(
+class _FakeToDeviceEvent_86 extends _i1.SmartFake implements _i4.ToDeviceEvent {
+  _FakeToDeviceEvent_86(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -963,8 +975,8 @@ class _FakeToDeviceEvent_85 extends _i1.SmartFake implements _i4.ToDeviceEvent {
         );
 }
 
-class _FakeEvent_86 extends _i1.SmartFake implements _i4.Event {
-  _FakeEvent_86(
+class _FakeEvent_87 extends _i1.SmartFake implements _i4.Event {
+  _FakeEvent_87(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -976,7 +988,7 @@ class _FakeEvent_86 extends _i1.SmartFake implements _i4.Event {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -1006,11 +1018,11 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1148,17 +1160,30 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i12.OutboxService);
 
   @override
-  _i13.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i13.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i13.AvatarResolver);
+
+  @override
+  _i14.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_11(
+        returnValue: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_11(
+        returnValueForMissingStub: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i13.StickerPackService);
+      ) as _i14.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1267,7 +1292,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  set stickerPacks(_i13.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i13.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i14.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -1283,14 +1317,14 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as bool);
 
   @override
-  _i17.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i18.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1320,7 +1354,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i24.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i25.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1330,18 +1364,18 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  _i17.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i18.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<bool> login({
+  _i18.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1358,12 +1392,12 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
             #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<bool> completeSsoLogin({
+  _i18.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1376,12 +1410,12 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<void> completeRegistration(
+  _i18.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1391,32 +1425,32 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> logout() => (super.noSuchMethod(
+  _i18.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i18.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  void addListener(_i24.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i25.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1425,7 +1459,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void removeListener(_i24.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i25.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1434,17 +1468,17 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  _i17.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i18.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i25.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i26.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1455,7 +1489,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i25.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i26.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1492,26 +1526,26 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  _i17.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i18.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<bool> didPushRouteInformation(
-          _i26.RouteInformation? routeInformation) =>
+  _i18.Future<bool> didPushRouteInformation(
+          _i27.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1541,7 +1575,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i24.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i25.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1550,7 +1584,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i24.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i25.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1559,16 +1593,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  _i17.Future<_i24.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i18.Future<_i25.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i17.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
+            _i18.Future<_i25.AppExitResponse>.value(_i25.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i17.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
-      ) as _i17.Future<_i24.AppExitResponse>);
+            _i18.Future<_i25.AppExitResponse>.value(_i25.AppExitResponse.exit),
+      ) as _i18.Future<_i25.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1629,64 +1663,64 @@ class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
       ) as bool);
 
   @override
-  _i17.Future<void> loadDismissalState() => (super.noSuchMethod(
+  _i18.Future<void> loadDismissalState() => (super.noSuchMethod(
         Invocation.method(
           #loadDismissalState,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> markSetupSkipped() => (super.noSuchMethod(
+  _i18.Future<void> markSetupSkipped() => (super.noSuchMethod(
         Invocation.method(
           #markSetupSkipped,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> dismissBanner() => (super.noSuchMethod(
+  _i18.Future<void> dismissBanner() => (super.noSuchMethod(
         Invocation.method(
           #dismissBanner,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> deleteDismissalState() => (super.noSuchMethod(
+  _i18.Future<void> deleteDismissalState() => (super.noSuchMethod(
         Invocation.method(
           #deleteDismissalState,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> checkChatBackupStatus() => (super.noSuchMethod(
+  _i18.Future<void> checkChatBackupStatus() => (super.noSuchMethod(
         Invocation.method(
           #checkChatBackupStatus,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> disableChatBackup() => (super.noSuchMethod(
+  _i18.Future<void> disableChatBackup() => (super.noSuchMethod(
         Invocation.method(
           #disableChatBackup,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   void resetChatBackupState() => super.noSuchMethod(
@@ -1698,71 +1732,71 @@ class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
       );
 
   @override
-  _i17.Future<void> tryAutoUnlockBackup() => (super.noSuchMethod(
+  _i18.Future<void> tryAutoUnlockBackup() => (super.noSuchMethod(
         Invocation.method(
           #tryAutoUnlockBackup,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> runKeyRecovery({_i14.OpenSSSS? ssssKey}) =>
+  _i18.Future<void> runKeyRecovery({_i15.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
           [],
           {#ssssKey: ssssKey},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> requestMissingRoomKeys({bool? force = false}) =>
+  _i18.Future<void> requestMissingRoomKeys({bool? force = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #requestMissingRoomKeys,
           [],
           {#force: force},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String?> getStoredRecoveryKey() => (super.noSuchMethod(
+  _i18.Future<String?> getStoredRecoveryKey() => (super.noSuchMethod(
         Invocation.method(
           #getStoredRecoveryKey,
           [],
         ),
-        returnValue: _i17.Future<String?>.value(),
-        returnValueForMissingStub: _i17.Future<String?>.value(),
-      ) as _i17.Future<String?>);
+        returnValue: _i18.Future<String?>.value(),
+        returnValueForMissingStub: _i18.Future<String?>.value(),
+      ) as _i18.Future<String?>);
 
   @override
-  _i17.Future<void> storeRecoveryKey(String? key) => (super.noSuchMethod(
+  _i18.Future<void> storeRecoveryKey(String? key) => (super.noSuchMethod(
         Invocation.method(
           #storeRecoveryKey,
           [key],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> deleteStoredRecoveryKey() => (super.noSuchMethod(
+  _i18.Future<void> deleteStoredRecoveryKey() => (super.noSuchMethod(
         Invocation.method(
           #deleteStoredRecoveryKey,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  void addListener(_i24.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i25.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1771,7 +1805,7 @@ class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
       );
 
   @override
-  void removeListener(_i24.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i25.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1801,19 +1835,19 @@ class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
 /// A class which mocks [Bootstrap].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
+class MockBootstrap extends _i1.Mock implements _i15.Bootstrap {
   @override
-  _i14.Encryption get encryption => (super.noSuchMethod(
+  _i15.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_12(
+        returnValue: _FakeEncryption_13(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_12(
+        returnValueForMissingStub: _FakeEncryption_13(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i14.Encryption);
+      ) as _i15.Encryption);
 
   @override
   _i4.Client get client => (super.noSuchMethod(
@@ -1829,14 +1863,14 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
       ) as _i4.Client);
 
   @override
-  _i14.BootstrapState get state => (super.noSuchMethod(
+  _i15.BootstrapState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i14.BootstrapState.loading,
-        returnValueForMissingStub: _i14.BootstrapState.loading,
-      ) as _i14.BootstrapState);
+        returnValue: _i15.BootstrapState.loading,
+        returnValueForMissingStub: _i15.BootstrapState.loading,
+      ) as _i15.BootstrapState);
 
   @override
-  set onUpdate(void Function(_i14.Bootstrap)? value) => super.noSuchMethod(
+  set onUpdate(void Function(_i15.Bootstrap)? value) => super.noSuchMethod(
         Invocation.setter(
           #onUpdate,
           value,
@@ -1845,7 +1879,7 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
       );
 
   @override
-  set oldSsssKeys(Map<String, _i14.OpenSSSS>? value) => super.noSuchMethod(
+  set oldSsssKeys(Map<String, _i15.OpenSSSS>? value) => super.noSuchMethod(
         Invocation.setter(
           #oldSsssKeys,
           value,
@@ -1854,7 +1888,7 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
       );
 
   @override
-  set newSsssKey(_i14.OpenSSSS? value) => super.noSuchMethod(
+  set newSsssKey(_i15.OpenSSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #newSsssKey,
           value,
@@ -1872,7 +1906,7 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
       );
 
   @override
-  set state(_i14.BootstrapState? newState) => super.noSuchMethod(
+  set state(_i15.BootstrapState? newState) => super.noSuchMethod(
         Invocation.setter(
           #state,
           newState,
@@ -1906,14 +1940,14 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
           #mostUsedKey,
           [secrets],
         ),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
             [secrets],
           ),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
@@ -1983,7 +2017,7 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
       );
 
   @override
-  _i17.Future<void> newSsss([
+  _i18.Future<void> newSsss([
     String? passphrase,
     String? name,
   ]) =>
@@ -1995,19 +2029,19 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
             name,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> openExistingSsss() => (super.noSuchMethod(
+  _i18.Future<void> openExistingSsss() => (super.noSuchMethod(
         Invocation.method(
           #openExistingSsss,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   void checkCrossSigning() => super.noSuchMethod(
@@ -2019,17 +2053,17 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
       );
 
   @override
-  _i17.Future<void> wipeCrossSigning(bool? wipe) => (super.noSuchMethod(
+  _i18.Future<void> wipeCrossSigning(bool? wipe) => (super.noSuchMethod(
         Invocation.method(
           #wipeCrossSigning,
           [wipe],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> askSetupCrossSigning({
+  _i18.Future<void> askSetupCrossSigning({
     bool? setupMasterKey = false,
     bool? setupSelfSigningKey = false,
     bool? setupUserSigningKey = false,
@@ -2044,9 +2078,9 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
             #setupUserSigningKey: setupUserSigningKey,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   void checkOnlineKeyBackup() => super.noSuchMethod(
@@ -2067,41 +2101,41 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
       );
 
   @override
-  _i17.Future<void> askSetupOnlineKeyBackup(bool? setup) => (super.noSuchMethod(
+  _i18.Future<void> askSetupOnlineKeyBackup(bool? setup) => (super.noSuchMethod(
         Invocation.method(
           #askSetupOnlineKeyBackup,
           [setup],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }
 
 /// A class which mocks [OpenSSSS].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockOpenSSSS extends _i1.Mock implements _i14.OpenSSSS {
+class MockOpenSSSS extends _i1.Mock implements _i15.OpenSSSS {
   @override
-  _i14.SSSS get ssss => (super.noSuchMethod(
+  _i15.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_13(
+        returnValue: _FakeSSSS_14(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_13(
+        returnValueForMissingStub: _FakeSSSS_14(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i14.SSSS);
+      ) as _i15.SSSS);
 
   @override
   String get keyId => (super.noSuchMethod(
         Invocation.getter(#keyId),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
@@ -2110,11 +2144,11 @@ class MockOpenSSSS extends _i1.Mock implements _i14.OpenSSSS {
   @override
   _i4.SecretStorageKeyContent get keyData => (super.noSuchMethod(
         Invocation.getter(#keyData),
-        returnValue: _FakeSecretStorageKeyContent_14(
+        returnValue: _FakeSecretStorageKeyContent_15(
           this,
           Invocation.getter(#keyData),
         ),
-        returnValueForMissingStub: _FakeSecretStorageKeyContent_14(
+        returnValueForMissingStub: _FakeSecretStorageKeyContent_15(
           this,
           Invocation.getter(#keyData),
         ),
@@ -2135,7 +2169,7 @@ class MockOpenSSSS extends _i1.Mock implements _i14.OpenSSSS {
       ) as bool);
 
   @override
-  set privateKey(_i27.Uint8List? value) => super.noSuchMethod(
+  set privateKey(_i28.Uint8List? value) => super.noSuchMethod(
         Invocation.setter(
           #privateKey,
           value,
@@ -2144,7 +2178,7 @@ class MockOpenSSSS extends _i1.Mock implements _i14.OpenSSSS {
       );
 
   @override
-  _i17.Future<void> unlock({
+  _i18.Future<void> unlock({
     String? passphrase,
     String? recoveryKey,
     String? keyOrPassphrase,
@@ -2161,27 +2195,27 @@ class MockOpenSSSS extends _i1.Mock implements _i14.OpenSSSS {
             #postUnlock: postUnlock,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> setPrivateKey(_i27.Uint8List? key) => (super.noSuchMethod(
+  _i18.Future<void> setPrivateKey(_i28.Uint8List? key) => (super.noSuchMethod(
         Invocation.method(
           #setPrivateKey,
           [key],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String> getStored(String? type) => (super.noSuchMethod(
+  _i18.Future<String> getStored(String? type) => (super.noSuchMethod(
         Invocation.method(
           #getStored,
           [type],
         ),
-        returnValue: _i17.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,
@@ -2189,17 +2223,17 @@ class MockOpenSSSS extends _i1.Mock implements _i14.OpenSSSS {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i23.dummyValue<String>(
+            _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,
             [type],
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<void> store(
+  _i18.Future<void> store(
     String? type,
     String? secret, {
     bool? add = false,
@@ -2213,12 +2247,12 @@ class MockOpenSSSS extends _i1.Mock implements _i14.OpenSSSS {
           ],
           {#add: add},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> validateAndStripOtherKeys(
+  _i18.Future<void> validateAndStripOtherKeys(
     String? type,
     String? secret,
   ) =>
@@ -2230,19 +2264,19 @@ class MockOpenSSSS extends _i1.Mock implements _i14.OpenSSSS {
             secret,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> maybeCacheAll() => (super.noSuchMethod(
+  _i18.Future<void> maybeCacheAll() => (super.noSuchMethod(
         Invocation.method(
           #maybeCacheAll,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }
 
 /// A class which mocks [Client].
@@ -2252,23 +2286,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_15(
+        returnValue: _FakeDatabaseApi_16(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_15(
+        returnValueForMissingStub: _FakeDatabaseApi_16(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -2329,11 +2363,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_16(
+        returnValue: _FakeFilter_17(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_16(
+        returnValueForMissingStub: _FakeFilter_17(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -2342,11 +2376,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_17(
+        returnValue: _FakeNativeImplementations_18(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_17(
+        returnValueForMissingStub: _FakeNativeImplementations_18(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -2362,11 +2396,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_18(
+        returnValue: _FakeDuration_19(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_18(
+        returnValueForMissingStub: _FakeDuration_19(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -2375,11 +2409,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_18(
+        returnValue: _FakeDuration_19(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_18(
+        returnValueForMissingStub: _FakeDuration_19(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -2388,11 +2422,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -2429,11 +2463,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -2463,11 +2497,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -2476,11 +2510,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -2503,11 +2537,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_19(
+        returnValue: _FakePushruleEvaluator_20(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_19(
+        returnValueForMissingStub: _FakePushruleEvaluator_20(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -2528,332 +2562,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i17.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i18.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_20(
+        returnValue: _i18.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.Profile>.value(_FakeProfile_20(
+            _i18.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i17.Future<_i4.Profile>);
+      ) as _i18.Future<_i4.Profile>);
 
   @override
-  _i15.CachedStreamController<String> get onUserProfileUpdate =>
+  _i16.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_21<String>(
+        returnValue: _FakeCachedStreamController_22<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_21<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_22<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i15.CachedStreamController<String>);
+      ) as _i16.CachedStreamController<String>);
 
   @override
-  _i17.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i18.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i18.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i17.Future<List<_i4.Room>>);
+            _i18.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i18.Future<List<_i4.Room>>);
 
   @override
-  _i15.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i16.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_21<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_22<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_21<_i4.EventUpdate>(
+            _FakeCachedStreamController_22<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i15.CachedStreamController<_i4.EventUpdate>);
+      ) as _i16.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i15.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i16.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_21<_i4.Event>(
+        returnValue: _FakeCachedStreamController_22<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_21<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_22<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i15.CachedStreamController<_i4.Event>);
+      ) as _i16.CachedStreamController<_i4.Event>);
 
   @override
-  _i15.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i16.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_21<_i4.Event>(
+        returnValue: _FakeCachedStreamController_22<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_21<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_22<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i15.CachedStreamController<_i4.Event>);
+      ) as _i16.CachedStreamController<_i4.Event>);
 
   @override
-  _i15.CachedStreamController<_i4.Event> get onNotification =>
+  _i16.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_21<_i4.Event>(
+        returnValue: _FakeCachedStreamController_22<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_21<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_22<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i15.CachedStreamController<_i4.Event>);
+      ) as _i16.CachedStreamController<_i4.Event>);
 
   @override
-  _i15.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i16.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_21<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_22<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_21<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_22<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i15.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i16.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i15.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i16.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_21<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_22<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_21<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_22<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i15.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i16.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i15.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i16.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_21<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_22<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_21<_i4.LoginState>(
+            _FakeCachedStreamController_22<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i15.CachedStreamController<_i4.LoginState>);
+      ) as _i16.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i15.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i16.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_21<bool>(
+        returnValue: _FakeCachedStreamController_22<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_21<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_22<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i15.CachedStreamController<bool>);
+      ) as _i16.CachedStreamController<bool>);
 
   @override
-  _i15.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i16.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_21<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_22<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_21<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_22<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i15.CachedStreamController<_i4.SdkError>);
+      ) as _i16.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i15.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i16.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_21<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_22<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_21<_i4.SyncUpdate>(
+            _FakeCachedStreamController_22<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i15.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i16.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i15.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i16.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_21<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_22<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_21<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_22<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i15.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i16.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i15.CachedStreamController<_i4.Presence> get onPresence =>
+  _i16.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_21<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_22<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_21<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_22<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i15.CachedStreamController<_i4.Presence>);
+      ) as _i16.CachedStreamController<_i4.Presence>);
 
   @override
-  _i15.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i16.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_21<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_22<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_21<_i4.CachedPresence>(
+            _FakeCachedStreamController_22<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i15.CachedStreamController<_i4.CachedPresence>);
+      ) as _i16.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i15.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i16.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_21<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_22<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_21<_i4.BasicEvent>(
+            _FakeCachedStreamController_22<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i15.CachedStreamController<_i4.BasicEvent>);
+      ) as _i16.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i15.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i16.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_21<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_22<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_21<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_22<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i15.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i16.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i15.CachedStreamController<_i14.KeyVerification>
+  _i16.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_21<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_22<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_21<_i14.KeyVerification>(
+                _FakeCachedStreamController_22<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i15.CachedStreamController<_i14.KeyVerification>);
+          ) as _i16.CachedStreamController<_i15.KeyVerification>);
 
   @override
-  _i15.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i16.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_21<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_22<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_21<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_22<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i15.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i16.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i15.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i16.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_21<_i4.Event>(
+        returnValue: _FakeCachedStreamController_22<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_21<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_22<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i15.CachedStreamController<_i4.Event>);
+      ) as _i16.CachedStreamController<_i4.Event>);
 
   @override
-  _i15.CachedStreamController<String> get onCancelSendEvent =>
+  _i16.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_21<String>(
+        returnValue: _FakeCachedStreamController_22<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_21<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_22<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i15.CachedStreamController<String>);
+      ) as _i16.CachedStreamController<String>);
 
   @override
-  _i15.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i16.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_21<
+            returnValue: _FakeCachedStreamController_22<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_21<
+            returnValueForMissingStub: _FakeCachedStreamController_22<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i15.CachedStreamController<
+          ) as _i16.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2873,11 +2907,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_22(
+        returnValue: _FakeDateTime_23(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_22(
+        returnValueForMissingStub: _FakeDateTime_23(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2950,7 +2984,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3005,7 +3039,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i17.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i18.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3016,7 +3050,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i17.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i18.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -3127,7 +3161,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i18.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -3136,7 +3170,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i18.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -3145,7 +3179,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i17.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i18.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -3172,20 +3206,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Client get httpClient => (super.noSuchMethod(
+  _i17.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_23(
+        returnValue: _FakeClient_24(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_23(
+        returnValueForMissingStub: _FakeClient_24(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i16.Client);
+      ) as _i17.Client);
 
   @override
-  set httpClient(_i16.Client? value) => super.noSuchMethod(
+  set httpClient(_i17.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -3212,7 +3246,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i17.Future<void> refreshAccessToken(
+  _i18.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3220,9 +3254,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -3240,14 +3274,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -3284,33 +3318,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i17.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i18.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValue: _i18.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValueForMissingStub: _i18.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i17.Future<_i4.DiscoveryInformation>);
+      ) as _i18.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i17.Future<
+  _i18.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -3332,7 +3366,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i17.Future<
+        returnValue: _i18.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -3340,7 +3374,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_25(
+          _FakeGetVersionsResponse_26(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -3355,7 +3389,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i17.Future<
+        returnValueForMissingStub: _i18.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -3363,7 +3397,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_25(
+          _FakeGetVersionsResponse_26(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -3378,7 +3412,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i17.Future<
+      ) as _i18.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -3387,7 +3421,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i17.Future<_i4.DiscoveryInformation> getWellknown({
+  _i18.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3400,8 +3434,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValue: _i18.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getWellknown,
@@ -3412,8 +3446,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValueForMissingStub: _i18.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getWellknown,
@@ -3424,10 +3458,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.DiscoveryInformation>);
+      ) as _i18.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i17.Future<_i4.RegisterResponse> register({
+  _i18.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -3455,7 +3489,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
+            _i18.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
           this,
           Invocation.method(
             #register,
@@ -3474,7 +3508,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
+            _i18.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
           this,
           Invocation.method(
             #register,
@@ -3492,10 +3526,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.RegisterResponse>);
+      ) as _i18.Future<_i4.RegisterResponse>);
 
   @override
-  _i17.Future<_i4.LoginResponse> login(
+  _i18.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -3525,7 +3559,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
+        returnValue: _i18.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
           this,
           Invocation.method(
             #login,
@@ -3545,7 +3579,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
+            _i18.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
           this,
           Invocation.method(
             #login,
@@ -3564,10 +3598,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.LoginResponse>);
+      ) as _i18.Future<_i4.LoginResponse>);
 
   @override
-  _i17.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i18.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3580,8 +3614,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i17.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_28(
+        returnValue: _i18.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_29(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -3593,8 +3627,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_28(
+            _i18.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_29(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -3605,74 +3639,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i18.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i17.Future<void> logout() => (super.noSuchMethod(
+  _i18.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> logoutAll() => (super.noSuchMethod(
+  _i18.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<T> uiaRequestBackground<T>(
-          _i17.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i18.Future<T> uiaRequestBackground<T>(
+          _i18.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i23.ifNotNull(
-              _i23.dummyValueOrNull<T>(
+        returnValue: _i24.ifNotNull(
+              _i24.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i17.Future<T>.value(v),
+              (T v) => _i18.Future<T>.value(v),
             ) ??
-            _FakeFuture_29<T>(
+            _FakeFuture_30<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i23.ifNotNull(
-              _i23.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i24.ifNotNull(
+              _i24.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i17.Future<T>.value(v),
+              (T v) => _i18.Future<T>.value(v),
             ) ??
-            _FakeFuture_29<T>(
+            _FakeFuture_30<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i17.Future<T>);
+      ) as _i18.Future<T>);
 
   @override
-  _i17.Future<String> startDirectChat(
+  _i18.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -3694,7 +3728,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i17.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3710,7 +3744,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i23.dummyValue<String>(
+            _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3725,10 +3759,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<String> createGroupChat({
+  _i18.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -3759,7 +3793,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i17.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3780,7 +3814,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i23.dummyValue<String>(
+            _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3800,10 +3834,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i18.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3819,7 +3853,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_30(
+        returnValue: _i18.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_31(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3832,7 +3866,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_30(
+            _i18.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_31(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3844,21 +3878,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.SyncUpdate>);
+      ) as _i18.Future<_i4.SyncUpdate>);
 
   @override
-  _i17.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i18.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<String> createSpace({
+  _i18.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3883,7 +3917,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i17.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3901,7 +3935,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i23.dummyValue<String>(
+            _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3918,10 +3952,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i18.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3929,7 +3963,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_20(
+        returnValue: _i18.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3938,7 +3972,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.Profile>.value(_FakeProfile_20(
+            _i18.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3946,10 +3980,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i17.Future<_i4.Profile>);
+      ) as _i18.Future<_i4.Profile>);
 
   @override
-  _i17.Future<_i4.Profile> fetchOwnProfile({
+  _i18.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3962,7 +3996,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_20(
+        returnValue: _i18.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3974,7 +4008,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.Profile>.value(_FakeProfile_20(
+            _i18.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3985,10 +4019,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.Profile>);
+      ) as _i18.Future<_i4.Profile>);
 
   @override
-  _i17.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i18.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4002,8 +4036,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i17.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_31(
+        returnValue: _i18.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_32(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4015,8 +4049,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_31(
+            _i18.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_32(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4027,10 +4061,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.CachedProfileInformation>);
+      ) as _i18.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i17.Future<_i4.Profile> getProfileFromUserId(
+  _i18.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4048,7 +4082,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_20(
+        returnValue: _i18.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4062,7 +4096,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.Profile>.value(_FakeProfile_20(
+            _i18.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4075,7 +4109,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.Profile>);
+      ) as _i18.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -4097,31 +4131,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i17.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i18.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i18.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i17.Future<List<_i4.Room>>);
+            _i18.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i18.Future<List<_i4.Room>>);
 
   @override
-  _i17.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i18.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i18.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i17.Future<List<_i4.ArchivedRoom>>);
+            _i18.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i18.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i17.Future<_i4.GetVersionsResponse> getVersions({
+  _i18.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4134,8 +4168,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i17.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_25(
+        returnValue: _i18.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_26(
           this,
           Invocation.method(
             #getVersions,
@@ -4146,8 +4180,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_25(
+        returnValueForMissingStub: _i18.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_26(
           this,
           Invocation.method(
             #getVersions,
@@ -4158,20 +4192,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetVersionsResponse>);
+      ) as _i18.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i17.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i18.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<_i4.MediaConfig> getConfig({
+  _i18.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4184,7 +4218,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+        returnValue: _i18.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfig,
@@ -4196,7 +4230,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+            _i18.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfig,
@@ -4207,10 +4241,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.MediaConfig>);
+      ) as _i18.Future<_i4.MediaConfig>);
 
   @override
-  _i17.Future<_i18.FileResponse> getContent(
+  _i18.Future<_i19.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -4230,7 +4264,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContent,
@@ -4246,7 +4280,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_33(
+            _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContent,
@@ -4261,10 +4295,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i18.FileResponse>);
+      ) as _i18.Future<_i19.FileResponse>);
 
   @override
-  _i17.Future<_i18.FileResponse> getContentOverrideName(
+  _i18.Future<_i19.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4286,7 +4320,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -4303,7 +4337,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_33(
+            _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -4319,10 +4353,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i18.FileResponse>);
+      ) as _i18.Future<_i19.FileResponse>);
 
   @override
-  _i17.Future<_i18.FileResponse> getContentThumbnail(
+  _i18.Future<_i19.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4350,7 +4384,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -4370,7 +4404,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_33(
+            _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -4389,10 +4423,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i18.FileResponse>);
+      ) as _i18.Future<_i19.FileResponse>);
 
   @override
-  _i17.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i18.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -4402,7 +4436,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+        returnValue: _i18.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -4411,7 +4445,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+            _i18.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -4419,11 +4453,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i17.Future<_i4.PreviewForUrl>);
+      ) as _i18.Future<_i4.PreviewForUrl>);
 
   @override
-  _i17.Future<Uri> uploadContent(
-    _i27.Uint8List? file, {
+  _i18.Future<Uri> uploadContent(
+    _i28.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -4436,7 +4470,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i17.Future<Uri>.value(_FakeUri_35(
+        returnValue: _i18.Future<Uri>.value(_FakeUri_36(
           this,
           Invocation.method(
             #uploadContent,
@@ -4447,7 +4481,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_35(
+        returnValueForMissingStub: _i18.Future<Uri>.value(_FakeUri_36(
           this,
           Invocation.method(
             #uploadContent,
@@ -4458,10 +4492,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<Uri>);
+      ) as _i18.Future<Uri>);
 
   @override
-  _i17.Future<void> setTyping(
+  _i18.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -4477,42 +4511,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String?> exportDump() => (super.noSuchMethod(
+  _i18.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i17.Future<String?>.value(),
-        returnValueForMissingStub: _i17.Future<String?>.value(),
-      ) as _i17.Future<String?>);
+        returnValue: _i18.Future<String?>.value(),
+        returnValueForMissingStub: _i18.Future<String?>.value(),
+      ) as _i18.Future<String?>);
 
   @override
-  _i17.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i18.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i18.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.Event?> getEventByPushNotification(
+  _i18.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -4528,12 +4562,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i17.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
-      ) as _i17.Future<_i4.Event?>);
+        returnValue: _i18.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i18.Future<_i4.Event?>.value(),
+      ) as _i18.Future<_i4.Event?>);
 
   @override
-  _i17.Future<void> init({
+  _i18.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -4568,9 +4602,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -4582,40 +4616,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i17.Future<void> clear() => (super.noSuchMethod(
+  _i18.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i18.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> ensureNotSoftLoggedOut(
+  _i18.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> handleSync(
+  _i18.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -4625,9 +4659,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -4640,29 +4674,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i17.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i18.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i18.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> sendToDevice(
+  _i18.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -4676,12 +4710,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> sendToDevicesOfUserIds(
+  _i18.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4697,12 +4731,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> sendToDeviceEncrypted(
+  _i18.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4722,12 +4756,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> sendToDeviceEncryptedChunked(
+  _i18.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -4741,23 +4775,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i18.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String> joinRoom(
+  _i18.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -4775,7 +4809,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i17.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4789,7 +4823,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i23.dummyValue<String>(
+            _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4802,10 +4836,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<void> changePassword(
+  _i18.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4821,22 +4855,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> clearCache() => (super.noSuchMethod(
+  _i18.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> ignoreUser(
+  _i18.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4846,22 +4880,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i18.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i18.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4872,7 +4906,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_36(
+            _i18.Future<_i4.CachedPresence>.value(_FakeCachedPresence_37(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4881,7 +4915,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_36(
+            _i18.Future<_i4.CachedPresence>.value(_FakeCachedPresence_37(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4889,32 +4923,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i17.Future<_i4.CachedPresence>);
+      ) as _i18.Future<_i4.CachedPresence>);
 
   @override
-  _i17.Future<void> abortSync() => (super.noSuchMethod(
+  _i18.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i18.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String?> redactEventWithMetadata(
+  _i18.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4934,14 +4968,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i17.Future<String?>.value(),
-        returnValueForMissingStub: _i17.Future<String?>.value(),
-      ) as _i17.Future<String?>);
+        returnValue: _i18.Future<String?>.value(),
+        returnValueForMissingStub: _i18.Future<String?>.value(),
+      ) as _i18.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i16.BaseResponse? response,
-    _i27.Uint8List? body,
+    _i17.BaseResponse? response,
+    _i28.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4973,7 +5007,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i17.Future<Map<String, Object?>> request(
+  _i18.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4994,13 +5028,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<void> postPusher(
+  _i18.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -5010,57 +5044,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i18.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i18.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i18.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i17.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_37(
+        returnValue: _i18.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_38(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_37(
+        returnValueForMissingStub: _i18.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_38(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i17.Future<_i4.TurnServerCredentials>);
+      ) as _i18.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i18.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5074,8 +5108,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_38(
+        returnValue: _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_39(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5087,8 +5121,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_38(
+            _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_39(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5099,10 +5133,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i18.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i18.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5118,8 +5152,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_38(
+        returnValue: _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_39(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5132,8 +5166,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_38(
+            _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_39(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5145,10 +5179,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i18.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i17.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i18.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5162,7 +5196,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
+        returnValue: _i18.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -5174,7 +5208,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
+            _i18.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -5185,17 +5219,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.KeyBackupData>);
+      ) as _i18.Future<_i4.KeyBackupData>);
 
   @override
-  _i17.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i18.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i17.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_40(
+        returnValue: _i18.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_41(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -5203,18 +5237,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_40(
+            _i18.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_41(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i17.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i18.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i17.Future<int> pingAppservice(
+  _i18.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -5224,12 +5258,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i17.Future<int>.value(0),
-        returnValueForMissingStub: _i17.Future<int>.value(0),
-      ) as _i17.Future<int>);
+        returnValue: _i18.Future<int>.value(0),
+        returnValueForMissingStub: _i18.Future<int>.value(0),
+      ) as _i18.Future<int>);
 
   @override
-  _i17.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i18.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5237,8 +5271,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i17.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_41(
+        returnValue: _i18.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_42(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -5247,8 +5281,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_41(
+            _i18.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_42(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -5256,15 +5290,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i17.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i18.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i17.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i18.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+        returnValue: _i18.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -5272,17 +5306,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+            _i18.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i17.Future<_i4.MediaConfig>);
+      ) as _i18.Future<_i4.MediaConfig>);
 
   @override
-  _i17.Future<_i18.FileResponse> getContentAuthed(
+  _i18.Future<_i19.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -5296,7 +5330,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -5308,7 +5342,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_33(
+            _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -5319,10 +5353,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i17.Future<_i18.FileResponse>);
+      ) as _i18.Future<_i19.FileResponse>);
 
   @override
-  _i17.Future<_i18.FileResponse> getContentOverrideNameAuthed(
+  _i18.Future<_i19.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5338,7 +5372,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -5351,7 +5385,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_33(
+            _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -5363,10 +5397,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i17.Future<_i18.FileResponse>);
+      ) as _i18.Future<_i19.FileResponse>);
 
   @override
-  _i17.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i18.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -5376,7 +5410,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+        returnValue: _i18.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -5385,7 +5419,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+            _i18.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -5393,10 +5427,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i17.Future<_i4.PreviewForUrl>);
+      ) as _i18.Future<_i4.PreviewForUrl>);
 
   @override
-  _i17.Future<_i18.FileResponse> getContentThumbnailAuthed(
+  _i18.Future<_i19.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5420,7 +5454,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -5438,7 +5472,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_33(
+            _i18.Future<_i19.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -5455,21 +5489,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i18.FileResponse>);
+      ) as _i18.Future<_i19.FileResponse>);
 
   @override
-  _i17.Future<bool> registrationTokenValidity(String? token) =>
+  _i18.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i18.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -5479,8 +5513,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_42(
+        returnValue: _i18.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_43(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -5489,8 +5523,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_42(
+            _i18.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_43(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -5498,10 +5532,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i17.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i18.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i17.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i18.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -5519,8 +5553,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_43(
+        returnValue: _i18.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_44(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -5534,8 +5568,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_43(
+            _i18.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_44(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -5548,10 +5582,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i18.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i17.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i18.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -5575,8 +5609,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i17.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_44(
+        returnValue: _i18.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_45(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -5594,8 +5628,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_44(
+            _i18.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_45(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -5612,10 +5646,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i18.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i18.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -5643,8 +5677,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_45(
+                _i18.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_46(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5663,8 +5697,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_45(
+                _i18.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_46(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5682,10 +5716,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i18.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i17.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i18.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -5714,9 +5748,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i17.Future<
+            returnValue: _i18.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5735,9 +5769,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i17.Future<
+            returnValueForMissingStub: _i18.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5756,11 +5790,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i17
+          ) as _i18
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i17.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i18.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -5776,8 +5810,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i17.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_47(
+        returnValue: _i18.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_48(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5790,8 +5824,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_47(
+            _i18.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_48(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5803,10 +5837,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetThreadRootsResponse>);
+      ) as _i18.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i17.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i18.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5820,8 +5854,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i17.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_48(
+        returnValue: _i18.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_49(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5833,8 +5867,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_48(
+            _i18.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_49(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5845,33 +5879,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i18.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i17.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i18.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i18.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i17.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i18.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i18.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i17.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i18.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i17.Future<Uri?>.value(),
-        returnValueForMissingStub: _i17.Future<Uri?>.value(),
-      ) as _i17.Future<Uri?>);
+        returnValue: _i18.Future<Uri?>.value(),
+        returnValueForMissingStub: _i18.Future<Uri?>.value(),
+      ) as _i18.Future<Uri?>);
 
   @override
-  _i17.Future<void> add3PID(
+  _i18.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5885,12 +5919,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> bind3PID(
+  _i18.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5906,12 +5940,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i18.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5925,14 +5959,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i18.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i18.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i17.Future<_i4.IdServerUnbindResult>);
+      ) as _i18.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i18.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5954,8 +5988,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_49(
+        returnValue: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_50(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5971,8 +6005,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_49(
+        returnValueForMissingStub: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_50(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5988,10 +6022,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.RequestTokenResponse>);
+      ) as _i18.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i18.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6015,8 +6049,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_49(
+        returnValue: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_50(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6033,8 +6067,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_49(
+        returnValueForMissingStub: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_50(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6051,10 +6085,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.RequestTokenResponse>);
+      ) as _i18.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i17.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i18.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6068,14 +6102,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i18.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i18.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i17.Future<_i4.IdServerUnbindResult>);
+      ) as _i18.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i17.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i18.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -6090,14 +6124,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i18.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i18.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i17.Future<_i4.IdServerUnbindResult>);
+      ) as _i18.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i18.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6119,8 +6153,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_49(
+        returnValue: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_50(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -6136,8 +6170,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_49(
+        returnValueForMissingStub: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_50(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -6153,10 +6187,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.RequestTokenResponse>);
+      ) as _i18.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i18.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6180,8 +6214,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_49(
+        returnValue: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_50(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -6198,8 +6232,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_49(
+        returnValueForMissingStub: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_50(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -6216,16 +6250,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.RequestTokenResponse>);
+      ) as _i18.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i17.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i18.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_50(
+            _i18.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_51(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -6233,22 +6267,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_50(
+            _i18.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_51(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i17.Future<_i4.TokenOwnerInfo>);
+      ) as _i18.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i17.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i18.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_51(
+        returnValue: _i18.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_52(
           this,
           Invocation.method(
             #getWhoIs,
@@ -6256,22 +6290,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_51(
+            _i18.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_52(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i17.Future<_i4.WhoIsInfo>);
+      ) as _i18.Future<_i4.WhoIsInfo>);
 
   @override
-  _i17.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i18.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_52(
+        returnValue: _i18.Future<_i4.Capabilities>.value(_FakeCapabilities_53(
           this,
           Invocation.method(
             #getCapabilities,
@@ -6279,17 +6313,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_52(
+            _i18.Future<_i4.Capabilities>.value(_FakeCapabilities_53(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i17.Future<_i4.Capabilities>);
+      ) as _i18.Future<_i4.Capabilities>);
 
   @override
-  _i17.Future<String> createRoom({
+  _i18.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -6322,7 +6356,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i17.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -6344,7 +6378,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i23.dummyValue<String>(
+            _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -6365,10 +6399,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<void> deleteDevices(
+  _i18.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -6378,22 +6412,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i18.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i17.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i17.Future<List<_i4.Device>?>.value(),
-      ) as _i17.Future<List<_i4.Device>?>);
+        returnValue: _i18.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i18.Future<List<_i4.Device>?>.value(),
+      ) as _i18.Future<List<_i4.Device>?>);
 
   @override
-  _i17.Future<void> deleteDevice(
+  _i18.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -6403,34 +6437,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i18.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i17.Future<_i4.Device>.value(_FakeDevice_53(
+        returnValue: _i18.Future<_i4.Device>.value(_FakeDevice_54(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.Device>.value(_FakeDevice_53(
+        returnValueForMissingStub: _i18.Future<_i4.Device>.value(_FakeDevice_54(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i17.Future<_i4.Device>);
+      ) as _i18.Future<_i4.Device>);
 
   @override
-  _i17.Future<void> updateDevice(
+  _i18.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -6440,12 +6474,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i18.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -6460,24 +6494,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i18.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i17.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i17.Future<_i4.Visibility?>.value(),
-      ) as _i17.Future<_i4.Visibility?>);
+        returnValue: _i18.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i18.Future<_i4.Visibility?>.value(),
+      ) as _i18.Future<_i4.Visibility?>);
 
   @override
-  _i17.Future<void> setRoomVisibilityOnDirectory(
+  _i18.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -6487,30 +6521,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i18.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i18.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_54(
+        returnValue: _i18.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_55(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -6518,18 +6552,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_54(
+            _i18.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_55(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i17.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i18.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i17.Future<void> setRoomAlias(
+  _i18.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -6541,12 +6575,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.GetEventsResponse> getEvents({
+  _i18.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -6560,7 +6594,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_55(
+            _i18.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_56(
           this,
           Invocation.method(
             #getEvents,
@@ -6572,7 +6606,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_55(
+            _i18.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_56(
           this,
           Invocation.method(
             #getEvents,
@@ -6583,10 +6617,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetEventsResponse>);
+      ) as _i18.Future<_i4.GetEventsResponse>);
 
   @override
-  _i17.Future<_i4.PeekEventsResponse> peekEvents({
+  _i18.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -6601,8 +6635,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i17.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_56(
+        returnValue: _i18.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_57(
           this,
           Invocation.method(
             #peekEvents,
@@ -6614,8 +6648,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_56(
+        returnValueForMissingStub: _i18.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_57(
           this,
           Invocation.method(
             #peekEvents,
@@ -6627,16 +6661,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.PeekEventsResponse>);
+      ) as _i18.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i17.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i18.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
+        returnValue: _i18.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
           this,
           Invocation.method(
             #getOneEvent,
@@ -6644,27 +6678,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
+            _i18.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i17.Future<_i4.MatrixEvent>);
+      ) as _i18.Future<_i4.MatrixEvent>);
 
   @override
-  _i17.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i18.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i17.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
-      ) as _i17.Future<List<String>>);
+        returnValue: _i18.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i18.Future<List<String>>.value(<String>[]),
+      ) as _i18.Future<List<String>>);
 
   @override
-  _i17.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i18.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -6676,8 +6710,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i17.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_58(
+        returnValue: _i18.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_59(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6688,8 +6722,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_58(
+            _i18.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_59(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6699,10 +6733,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.GetKeysChangesResponse>);
+      ) as _i18.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i17.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i18.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -6713,7 +6747,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_59(
+            _i18.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_60(
           this,
           Invocation.method(
             #claimKeys,
@@ -6722,7 +6756,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_59(
+            _i18.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_60(
           this,
           Invocation.method(
             #claimKeys,
@@ -6730,10 +6764,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i17.Future<_i4.ClaimKeysResponse>);
+      ) as _i18.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i17.Future<void> uploadCrossSigningKeys({
+  _i18.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -6750,12 +6784,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.QueryKeysResponse> queryKeys(
+  _i18.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -6766,7 +6800,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_60(
+            _i18.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_61(
           this,
           Invocation.method(
             #queryKeys,
@@ -6775,7 +6809,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_60(
+            _i18.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_61(
           this,
           Invocation.method(
             #queryKeys,
@@ -6783,10 +6817,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i17.Future<_i4.QueryKeysResponse>);
+      ) as _i18.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i18.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6794,14 +6828,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i17.Future<
+            returnValue: _i18.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i17.Future<
+            returnValueForMissingStub: _i18.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i18.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i17.Future<Map<String, int>> uploadKeys({
+  _i18.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6816,13 +6850,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i17.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i18.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i17.Future<Map<String, int>>);
+            _i18.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i18.Future<Map<String, int>>);
 
   @override
-  _i17.Future<String> knockRoom(
+  _i18.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6836,7 +6870,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i17.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6848,7 +6882,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i23.dummyValue<String>(
+            _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6859,20 +6893,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i18.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i17.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i17.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i17.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i18.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i18.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i18.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i17.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i18.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6887,8 +6921,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i17.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_61(
+        returnValue: _i18.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_62(
           this,
           Invocation.method(
             #getNotifications,
@@ -6901,8 +6935,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_61(
+            _i18.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_62(
           this,
           Invocation.method(
             #getNotifications,
@@ -6914,35 +6948,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetNotificationsResponse>);
+      ) as _i18.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i17.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i18.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i17.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_62(
+        returnValue: _i18.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_63(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_62(
+        returnValueForMissingStub: _i18.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_63(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i17.Future<_i4.GetPresenceResponse>);
+      ) as _i18.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i17.Future<void> setPresence(
+  _i18.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6956,12 +6990,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<Map<String, Object?>> deleteProfileField(
+  _i18.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6974,13 +7008,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<Map<String, Object?>> getProfileField(
+  _i18.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6993,13 +7027,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<Map<String, Object?>> setProfileField(
+  _i18.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7014,13 +7048,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i18.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7035,8 +7069,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i17.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_63(
+        returnValue: _i18.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_64(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7049,8 +7083,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_63(
+            _i18.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_64(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7062,10 +7096,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i18.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i17.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i18.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -7086,8 +7120,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i17.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_64(
+        returnValue: _i18.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_65(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7103,8 +7137,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_64(
+            _i18.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_65(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7119,25 +7153,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i18.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i17.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i18.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i17.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i17.Future<List<_i4.Pusher>?>.value(),
-      ) as _i17.Future<List<_i4.Pusher>?>);
+        returnValue: _i18.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i18.Future<List<_i4.Pusher>?>.value(),
+      ) as _i18.Future<List<_i4.Pusher>?>);
 
   @override
-  _i17.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i18.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_65(
+        returnValue: _i18.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_66(
           this,
           Invocation.method(
             #getPushRules,
@@ -7145,24 +7179,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_65(
+            _i18.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_66(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i17.Future<_i4.PushRuleSet>);
+      ) as _i18.Future<_i4.PushRuleSet>);
 
   @override
-  _i17.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i18.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_66(
+        returnValue: _i18.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_67(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -7170,18 +7204,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_66(
+            _i18.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_67(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i17.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i18.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i17.Future<void> deletePushRule(
+  _i18.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -7193,12 +7227,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.PushRule> getPushRule(
+  _i18.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -7210,7 +7244,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i17.Future<_i4.PushRule>.value(_FakePushRule_67(
+        returnValue: _i18.Future<_i4.PushRule>.value(_FakePushRule_68(
           this,
           Invocation.method(
             #getPushRule,
@@ -7221,7 +7255,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.PushRule>.value(_FakePushRule_67(
+            _i18.Future<_i4.PushRule>.value(_FakePushRule_68(
           this,
           Invocation.method(
             #getPushRule,
@@ -7231,10 +7265,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.PushRule>);
+      ) as _i18.Future<_i4.PushRule>);
 
   @override
-  _i17.Future<void> setPushRule(
+  _i18.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -7258,12 +7292,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<List<Object?>> getPushRuleActions(
+  _i18.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -7275,13 +7309,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i17.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i18.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i17.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i17.Future<List<Object?>>);
+            _i18.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i18.Future<List<Object?>>);
 
   @override
-  _i17.Future<void> setPushRuleActions(
+  _i18.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -7295,12 +7329,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<bool> isPushRuleEnabled(
+  _i18.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -7312,12 +7346,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<void> setPushRuleEnabled(
+  _i18.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -7331,19 +7365,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i18.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_68(
+            _i18.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_69(
           this,
           Invocation.method(
             #refresh,
@@ -7351,28 +7385,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_68(
+            _i18.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_69(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i17.Future<_i4.RefreshResponse>);
+      ) as _i18.Future<_i4.RefreshResponse>);
 
   @override
-  _i17.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i18.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i17.Future<bool?>.value(),
-        returnValueForMissingStub: _i17.Future<bool?>.value(),
-      ) as _i17.Future<bool?>);
+        returnValue: _i18.Future<bool?>.value(),
+        returnValueForMissingStub: _i18.Future<bool?>.value(),
+      ) as _i18.Future<bool?>);
 
   @override
-  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i18.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7394,8 +7428,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_49(
+        returnValue: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_50(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -7411,8 +7445,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_49(
+        returnValueForMissingStub: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_50(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -7428,10 +7462,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.RequestTokenResponse>);
+      ) as _i18.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i18.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7455,8 +7489,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_49(
+        returnValue: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_50(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -7473,8 +7507,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_49(
+        returnValueForMissingStub: _i18.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_50(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -7491,17 +7525,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.RequestTokenResponse>);
+      ) as _i18.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i18.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_38(
+        returnValue: _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_39(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -7509,23 +7543,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_38(
+            _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_39(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i18.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i17.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i18.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_69(
+        returnValue: _i18.Future<_i4.RoomKeys>.value(_FakeRoomKeys_70(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -7533,17 +7567,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_69(
+            _i18.Future<_i4.RoomKeys>.value(_FakeRoomKeys_70(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeys>);
+      ) as _i18.Future<_i4.RoomKeys>);
 
   @override
-  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i18.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -7555,8 +7589,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_38(
+        returnValue: _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_39(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -7567,8 +7601,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_38(
+            _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_39(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -7578,10 +7612,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i18.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i18.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -7593,8 +7627,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_38(
+        returnValue: _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_39(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -7605,8 +7639,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_38(
+            _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_39(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -7616,10 +7650,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i18.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i17.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i18.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -7631,7 +7665,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_70(
+        returnValue: _i18.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_71(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7642,7 +7676,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_70(
+            _i18.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_71(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7652,10 +7686,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeyBackup>);
+      ) as _i18.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i18.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -7669,8 +7703,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_38(
+        returnValue: _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_39(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7682,8 +7716,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_38(
+            _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_39(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7694,10 +7728,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i18.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i18.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7711,8 +7745,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_38(
+        returnValue: _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_39(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7724,8 +7758,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_38(
+            _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_39(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7736,10 +7770,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i18.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i17.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i18.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7753,7 +7787,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
+        returnValue: _i18.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7765,7 +7799,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
+            _i18.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7776,10 +7810,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.KeyBackupData>);
+      ) as _i18.Future<_i4.KeyBackupData>);
 
   @override
-  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i18.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7795,8 +7829,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_38(
+        returnValue: _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_39(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7809,8 +7843,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_38(
+            _i18.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_39(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7822,18 +7856,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i18.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i18.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_71(
+                _i18.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_72(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7841,18 +7875,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_71(
+                _i18.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_72(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i18.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i17.Future<String> postRoomKeysVersion(
+  _i18.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7864,7 +7898,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i17.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7875,7 +7909,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i23.dummyValue<String>(
+            _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7885,29 +7919,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i18.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i18.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_72(
+        returnValue: _i18.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_73(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7915,18 +7949,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_72(
+            _i18.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_73(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i17.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i18.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i17.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i18.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7941,24 +7975,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i18.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i17.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
-      ) as _i17.Future<List<String>>);
+        returnValue: _i18.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i18.Future<List<String>>.value(<String>[]),
+      ) as _i18.Future<List<String>>);
 
   @override
-  _i17.Future<void> ban(
+  _i18.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7972,12 +8006,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.EventContext> getEventContext(
+  _i18.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7995,7 +8029,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i17.Future<_i4.EventContext>.value(_FakeEventContext_73(
+        returnValue: _i18.Future<_i4.EventContext>.value(_FakeEventContext_74(
           this,
           Invocation.method(
             #getEventContext,
@@ -8010,7 +8044,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.EventContext>.value(_FakeEventContext_73(
+            _i18.Future<_i4.EventContext>.value(_FakeEventContext_74(
           this,
           Invocation.method(
             #getEventContext,
@@ -8024,10 +8058,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.EventContext>);
+      ) as _i18.Future<_i4.EventContext>);
 
   @override
-  _i17.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i18.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8039,7 +8073,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
+        returnValue: _i18.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8050,7 +8084,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
+            _i18.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8060,20 +8094,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.MatrixEvent>);
+      ) as _i18.Future<_i4.MatrixEvent>);
 
   @override
-  _i17.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i18.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> inviteBy3PID(
+  _i18.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -8085,12 +8119,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> inviteUser(
+  _i18.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8104,12 +8138,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String> joinRoomById(
+  _i18.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -8123,7 +8157,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i17.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8135,7 +8169,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i23.dummyValue<String>(
+            _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8146,23 +8180,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i18.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i17.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i18.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i17.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i17.Future<Map<String, _i4.RoomMember>?>);
+            _i18.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i18.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i17.Future<void> kick(
+  _i18.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8176,12 +8210,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> leaveRoom(
+  _i18.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -8191,12 +8225,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i18.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -8212,12 +8246,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i17.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i17.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i17.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i18.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i18.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i18.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i17.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i18.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -8239,8 +8273,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i17.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_74(
+        returnValue: _i18.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_75(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -8256,8 +8290,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_74(
+        returnValueForMissingStub: _i18.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_75(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -8273,10 +8307,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.GetRoomEventsResponse>);
+      ) as _i18.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i17.Future<void> setReadMarker(
+  _i18.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -8292,12 +8326,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> postReceipt(
+  _i18.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -8313,12 +8347,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String?> redactEvent(
+  _i18.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -8334,12 +8368,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i17.Future<String?>.value(),
-        returnValueForMissingStub: _i17.Future<String?>.value(),
-      ) as _i17.Future<String?>);
+        returnValue: _i18.Future<String?>.value(),
+        returnValueForMissingStub: _i18.Future<String?>.value(),
+      ) as _i18.Future<String?>);
 
   @override
-  _i17.Future<void> reportRoom(
+  _i18.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -8351,12 +8385,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> reportEvent(
+  _i18.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -8374,12 +8408,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String> sendMessage(
+  _i18.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -8395,7 +8429,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -8408,7 +8442,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i23.dummyValue<String>(
+            _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -8420,23 +8454,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i18.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i18.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i17.Future<List<_i4.MatrixEvent>>);
+            _i18.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i18.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i17.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i18.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -8453,13 +8487,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<String> setRoomStateWithKey(
+  _i18.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -8475,7 +8509,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -8488,7 +8522,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i23.dummyValue<String>(
+            _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -8500,10 +8534,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<void> unban(
+  _i18.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8517,12 +8551,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String> upgradeRoom(
+  _i18.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -8536,7 +8570,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i17.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -8548,7 +8582,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i23.dummyValue<String>(
+            _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -8559,10 +8593,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<_i4.SearchResults> search(
+  _i18.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -8572,7 +8606,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_75(
+        returnValue: _i18.Future<_i4.SearchResults>.value(_FakeSearchResults_76(
           this,
           Invocation.method(
             #search,
@@ -8581,7 +8615,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_75(
+            _i18.Future<_i4.SearchResults>.value(_FakeSearchResults_76(
           this,
           Invocation.method(
             #search,
@@ -8589,10 +8623,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i17.Future<_i4.SearchResults>);
+      ) as _i18.Future<_i4.SearchResults>);
 
   @override
-  _i17.Future<_i4.SyncUpdate> sync({
+  _i18.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -8613,7 +8647,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_30(
+        returnValue: _i18.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_31(
           this,
           Invocation.method(
             #sync,
@@ -8629,7 +8663,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_30(
+            _i18.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_31(
           this,
           Invocation.method(
             #sync,
@@ -8644,22 +8678,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i17.Future<_i4.SyncUpdate>);
+      ) as _i18.Future<_i4.SyncUpdate>);
 
   @override
-  _i17.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i18.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i18.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i17.Future<List<_i4.Location>>);
+            _i18.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i18.Future<List<_i4.Location>>);
 
   @override
-  _i17.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i18.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8669,21 +8703,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i18.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i17.Future<List<_i4.Location>>);
+            _i18.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i18.Future<List<_i4.Location>>);
 
   @override
-  _i17.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i18.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_76(
+        returnValue: _i18.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_77(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -8691,45 +8725,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_76(
+            _i18.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_77(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i17.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i18.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i17.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i18.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i18.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i18.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i18.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i18.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i18.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
+            _i18.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i18.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i18.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8740,13 +8774,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i18.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
+            _i18.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i18.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i17.Future<Map<String, Object?>> getAccountData(
+  _i18.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -8759,13 +8793,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<void> setAccountData(
+  _i18.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8779,12 +8813,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<String> defineFilter(
+  _i18.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -8796,7 +8830,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<String>.value(_i23.dummyValue<String>(
+        returnValue: _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8807,7 +8841,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<String>.value(_i23.dummyValue<String>(
+            _i18.Future<String>.value(_i24.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8817,10 +8851,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<String>);
+      ) as _i18.Future<String>);
 
   @override
-  _i17.Future<_i4.Filter> getFilter(
+  _i18.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8832,7 +8866,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i17.Future<_i4.Filter>.value(_FakeFilter_16(
+        returnValue: _i18.Future<_i4.Filter>.value(_FakeFilter_17(
           this,
           Invocation.method(
             #getFilter,
@@ -8842,7 +8876,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.Filter>.value(_FakeFilter_16(
+        returnValueForMissingStub: _i18.Future<_i4.Filter>.value(_FakeFilter_17(
           this,
           Invocation.method(
             #getFilter,
@@ -8852,10 +8886,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.Filter>);
+      ) as _i18.Future<_i4.Filter>);
 
   @override
-  _i17.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i18.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8868,7 +8902,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_77(
+            _i18.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_78(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8879,7 +8913,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_77(
+            _i18.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_78(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8889,10 +8923,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i17.Future<_i4.OpenIdCredentials>);
+      ) as _i18.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i17.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i18.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8907,13 +8941,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<void> setAccountDataPerRoom(
+  _i18.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8929,12 +8963,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i18.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8946,12 +8980,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i17.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i17.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i17.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i18.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i18.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i18.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i17.Future<void> deleteRoomTag(
+  _i18.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8965,12 +8999,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> setRoomTag(
+  _i18.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8986,12 +9020,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i18.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9001,8 +9035,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i17.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_78(
+        returnValue: _i18.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_79(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9011,8 +9045,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_78(
+            _i18.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_79(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9020,10 +9054,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i17.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i18.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i17.Future<Map<String, Object?>> reportUser(
+  _i18.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9036,40 +9070,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 
   @override
-  _i17.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i18.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i17.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_79(
+        returnValue: _i18.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_80(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_79(
+        returnValueForMissingStub: _i18.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_80(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i17.Future<_i4.CreateContentResponse>);
+      ) as _i18.Future<_i4.CreateContentResponse>);
 
   @override
-  _i17.Future<Map<String, Object?>> uploadContentToMXC(
+  _i18.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i27.Uint8List? body, {
+    _i28.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9087,16 +9121,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i17.Future<Map<String, Object?>>);
+            _i18.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i18.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Encryption].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEncryption extends _i1.Mock implements _i14.Encryption {
+class MockEncryption extends _i1.Mock implements _i15.Encryption {
   @override
   _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -9125,85 +9159,85 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       ) as bool);
 
   @override
-  _i14.KeyManager get keyManager => (super.noSuchMethod(
+  _i15.KeyManager get keyManager => (super.noSuchMethod(
         Invocation.getter(#keyManager),
-        returnValue: _FakeKeyManager_80(
+        returnValue: _FakeKeyManager_81(
           this,
           Invocation.getter(#keyManager),
         ),
-        returnValueForMissingStub: _FakeKeyManager_80(
+        returnValueForMissingStub: _FakeKeyManager_81(
           this,
           Invocation.getter(#keyManager),
         ),
-      ) as _i14.KeyManager);
+      ) as _i15.KeyManager);
 
   @override
-  _i19.OlmManager get olmManager => (super.noSuchMethod(
+  _i20.OlmManager get olmManager => (super.noSuchMethod(
         Invocation.getter(#olmManager),
-        returnValue: _FakeOlmManager_81(
+        returnValue: _FakeOlmManager_82(
           this,
           Invocation.getter(#olmManager),
         ),
-        returnValueForMissingStub: _FakeOlmManager_81(
+        returnValueForMissingStub: _FakeOlmManager_82(
           this,
           Invocation.getter(#olmManager),
         ),
-      ) as _i19.OlmManager);
+      ) as _i20.OlmManager);
 
   @override
-  _i20.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
+  _i21.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
         Invocation.getter(#keyVerificationManager),
-        returnValue: _FakeKeyVerificationManager_82(
+        returnValue: _FakeKeyVerificationManager_83(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-        returnValueForMissingStub: _FakeKeyVerificationManager_82(
+        returnValueForMissingStub: _FakeKeyVerificationManager_83(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-      ) as _i20.KeyVerificationManager);
+      ) as _i21.KeyVerificationManager);
 
   @override
-  _i21.CrossSigning get crossSigning => (super.noSuchMethod(
+  _i22.CrossSigning get crossSigning => (super.noSuchMethod(
         Invocation.getter(#crossSigning),
-        returnValue: _FakeCrossSigning_83(
+        returnValue: _FakeCrossSigning_84(
           this,
           Invocation.getter(#crossSigning),
         ),
-        returnValueForMissingStub: _FakeCrossSigning_83(
+        returnValueForMissingStub: _FakeCrossSigning_84(
           this,
           Invocation.getter(#crossSigning),
         ),
-      ) as _i21.CrossSigning);
+      ) as _i22.CrossSigning);
 
   @override
-  _i14.SSSS get ssss => (super.noSuchMethod(
+  _i15.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_13(
+        returnValue: _FakeSSSS_14(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_13(
+        returnValueForMissingStub: _FakeSSSS_14(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i14.SSSS);
+      ) as _i15.SSSS);
 
   @override
   String get ourDeviceId => (super.noSuchMethod(
         Invocation.getter(#ourDeviceId),
-        returnValue: _i23.dummyValue<String>(
+        returnValue: _i24.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
-        returnValueForMissingStub: _i23.dummyValue<String>(
+        returnValueForMissingStub: _i24.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
       ) as String);
 
   @override
-  set keyManager(_i14.KeyManager? value) => super.noSuchMethod(
+  set keyManager(_i15.KeyManager? value) => super.noSuchMethod(
         Invocation.setter(
           #keyManager,
           value,
@@ -9212,7 +9246,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       );
 
   @override
-  set olmManager(_i19.OlmManager? value) => super.noSuchMethod(
+  set olmManager(_i20.OlmManager? value) => super.noSuchMethod(
         Invocation.setter(
           #olmManager,
           value,
@@ -9221,7 +9255,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       );
 
   @override
-  set keyVerificationManager(_i20.KeyVerificationManager? value) =>
+  set keyVerificationManager(_i21.KeyVerificationManager? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #keyVerificationManager,
@@ -9231,7 +9265,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       );
 
   @override
-  set crossSigning(_i21.CrossSigning? value) => super.noSuchMethod(
+  set crossSigning(_i22.CrossSigning? value) => super.noSuchMethod(
         Invocation.setter(
           #crossSigning,
           value,
@@ -9240,7 +9274,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       );
 
   @override
-  set ssss(_i14.SSSS? value) => super.noSuchMethod(
+  set ssss(_i15.SSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #ssss,
           value,
@@ -9258,7 +9292,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       );
 
   @override
-  _i17.Future<void> init(
+  _i18.Future<void> init(
     String? olmAccount, {
     String? deviceId,
     String? pickleKey,
@@ -9274,19 +9308,19 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
             #dehydratedDeviceAlgorithm: dehydratedDeviceAlgorithm,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i14.Bootstrap bootstrap({void Function(_i14.Bootstrap)? onUpdate}) =>
+  _i15.Bootstrap bootstrap({void Function(_i15.Bootstrap)? onUpdate}) =>
       (super.noSuchMethod(
         Invocation.method(
           #bootstrap,
           [],
           {#onUpdate: onUpdate},
         ),
-        returnValue: _FakeBootstrap_84(
+        returnValue: _FakeBootstrap_85(
           this,
           Invocation.method(
             #bootstrap,
@@ -9294,7 +9328,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-        returnValueForMissingStub: _FakeBootstrap_84(
+        returnValueForMissingStub: _FakeBootstrap_85(
           this,
           Invocation.method(
             #bootstrap,
@@ -9302,7 +9336,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-      ) as _i14.Bootstrap);
+      ) as _i15.Bootstrap);
 
   @override
   void handleDeviceOneTimeKeysCount(
@@ -9330,18 +9364,18 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       );
 
   @override
-  _i17.Future<void> handleToDeviceEvent(_i4.ToDeviceEvent? event) =>
+  _i18.Future<void> handleToDeviceEvent(_i4.ToDeviceEvent? event) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleToDeviceEvent,
           [event],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> handleEventUpdate(
+  _i18.Future<void> handleEventUpdate(
     _i4.Event? event,
     _i4.EventUpdateType? type,
   ) =>
@@ -9353,19 +9387,19 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
             type,
           ],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<_i4.ToDeviceEvent> decryptToDeviceEvent(
+  _i18.Future<_i4.ToDeviceEvent> decryptToDeviceEvent(
           _i4.ToDeviceEvent? event) =>
       (super.noSuchMethod(
         Invocation.method(
           #decryptToDeviceEvent,
           [event],
         ),
-        returnValue: _i17.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_85(
+        returnValue: _i18.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_86(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -9373,14 +9407,14 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
           ),
         )),
         returnValueForMissingStub:
-            _i17.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_85(
+            _i18.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_86(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
             [event],
           ),
         )),
-      ) as _i17.Future<_i4.ToDeviceEvent>);
+      ) as _i18.Future<_i4.ToDeviceEvent>);
 
   @override
   _i4.Event decryptRoomEventSync(_i4.Event? event) => (super.noSuchMethod(
@@ -9388,14 +9422,14 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
           #decryptRoomEventSync,
           [event],
         ),
-        returnValue: _FakeEvent_86(
+        returnValue: _FakeEvent_87(
           this,
           Invocation.method(
             #decryptRoomEventSync,
             [event],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_86(
+        returnValueForMissingStub: _FakeEvent_87(
           this,
           Invocation.method(
             #decryptRoomEventSync,
@@ -9405,7 +9439,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       ) as _i4.Event);
 
   @override
-  _i17.Future<_i4.Event> decryptRoomEvent(
+  _i18.Future<_i4.Event> decryptRoomEvent(
     _i4.Event? event, {
     bool? store = false,
     _i4.EventUpdateType? updateType = _i4.EventUpdateType.timeline,
@@ -9419,7 +9453,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
             #updateType: updateType,
           },
         ),
-        returnValue: _i17.Future<_i4.Event>.value(_FakeEvent_86(
+        returnValue: _i18.Future<_i4.Event>.value(_FakeEvent_87(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -9430,7 +9464,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
             },
           ),
         )),
-        returnValueForMissingStub: _i17.Future<_i4.Event>.value(_FakeEvent_86(
+        returnValueForMissingStub: _i18.Future<_i4.Event>.value(_FakeEvent_87(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -9441,10 +9475,10 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
             },
           ),
         )),
-      ) as _i17.Future<_i4.Event>);
+      ) as _i18.Future<_i4.Event>);
 
   @override
-  _i17.Future<Map<String, dynamic>> encryptGroupMessagePayload(
+  _i18.Future<Map<String, dynamic>> encryptGroupMessagePayload(
     String? roomId,
     Map<String, dynamic>? payload, {
     String? type = 'm.room.message',
@@ -9459,13 +9493,13 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
           {#type: type},
         ),
         returnValue:
-            _i17.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
+            _i18.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
-      ) as _i17.Future<Map<String, dynamic>>);
+            _i18.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
+      ) as _i18.Future<Map<String, dynamic>>);
 
   @override
-  _i17.Future<
+  _i18.Future<
       Map<String, Map<String, Map<String, dynamic>>>> encryptToDeviceMessage(
     List<_i4.DeviceKeys>? deviceKeys,
     String? type,
@@ -9481,50 +9515,50 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
           ],
         ),
         returnValue:
-            _i17.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
+            _i18.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
                 <String, Map<String, Map<String, dynamic>>>{}),
         returnValueForMissingStub:
-            _i17.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
+            _i18.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
                 <String, Map<String, Map<String, dynamic>>>{}),
-      ) as _i17.Future<Map<String, Map<String, Map<String, dynamic>>>>);
+      ) as _i18.Future<Map<String, Map<String, Map<String, dynamic>>>>);
 
   @override
-  _i17.Future<void> autovalidateMasterOwnKey() => (super.noSuchMethod(
+  _i18.Future<void> autovalidateMasterOwnKey() => (super.noSuchMethod(
         Invocation.method(
           #autovalidateMasterOwnKey,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
-  _i17.Future<void> dispose() => (super.noSuchMethod(
+  _i18.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }
 
 /// A class which mocks [CrossSigning].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCrossSigning extends _i1.Mock implements _i21.CrossSigning {
+class MockCrossSigning extends _i1.Mock implements _i22.CrossSigning {
   @override
-  _i14.Encryption get encryption => (super.noSuchMethod(
+  _i15.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_12(
+        returnValue: _FakeEncryption_13(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_12(
+        returnValueForMissingStub: _FakeEncryption_13(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i14.Encryption);
+      ) as _i15.Encryption);
 
   @override
   _i4.Client get client => (super.noSuchMethod(
@@ -9547,21 +9581,21 @@ class MockCrossSigning extends _i1.Mock implements _i21.CrossSigning {
       ) as bool);
 
   @override
-  _i17.Future<bool> isCached() => (super.noSuchMethod(
+  _i18.Future<bool> isCached() => (super.noSuchMethod(
         Invocation.method(
           #isCached,
           [],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-        returnValueForMissingStub: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i18.Future<bool>.value(false),
+        returnValueForMissingStub: _i18.Future<bool>.value(false),
+      ) as _i18.Future<bool>);
 
   @override
-  _i17.Future<void> selfSign({
+  _i18.Future<void> selfSign({
     String? passphrase,
     String? recoveryKey,
     String? keyOrPassphrase,
-    _i14.OpenSSSS? openSsss,
+    _i15.OpenSSSS? openSsss,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9574,9 +9608,9 @@ class MockCrossSigning extends _i1.Mock implements _i21.CrossSigning {
             #openSsss: openSsss,
           },
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 
   @override
   bool signable(List<_i4.SignableKey>? keys) => (super.noSuchMethod(
@@ -9589,12 +9623,12 @@ class MockCrossSigning extends _i1.Mock implements _i21.CrossSigning {
       ) as bool);
 
   @override
-  _i17.Future<void> sign(List<_i4.SignableKey>? keys) => (super.noSuchMethod(
+  _i18.Future<void> sign(List<_i4.SignableKey>? keys) => (super.noSuchMethod(
         Invocation.method(
           #sign,
           [keys],
         ),
-        returnValue: _i17.Future<void>.value(),
-        returnValueForMissingStub: _i17.Future<void>.value(),
-      ) as _i17.Future<void>);
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
 }

--- a/test/widgets/registration_controller_test.mocks.dart
+++ b/test/widgets/registration_controller_test.mocks.dart
@@ -4,15 +4,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i23;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i24;
 
-import 'package:flutter/services.dart' as _i24;
-import 'package:flutter/widgets.dart' as _i25;
+import 'package:flutter/services.dart' as _i25;
+import 'package:flutter/widgets.dart' as _i26;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/models/server_auth_capabilities.dart' as _i18;
-import 'package:kohera/core/services/matrix_service.dart' as _i22;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/models/server_auth_capabilities.dart' as _i19;
+import 'package:kohera/core/services/matrix_service.dart' as _i23;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -29,12 +29,13 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i19;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i20;
+import 'package:mockito/src/dummies.dart' as _i21;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -859,9 +860,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -870,9 +871,20 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeServerAuthCapabilities_77 extends _i1.SmartFake
-    implements _i18.ServerAuthCapabilities {
-  _FakeServerAuthCapabilities_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeServerAuthCapabilities_78 extends _i1.SmartFake
+    implements _i19.ServerAuthCapabilities {
+  _FakeServerAuthCapabilities_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -899,12 +911,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i19.KeyVerificationMethod> get verificationMethods =>
+  Set<_i20.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i19.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
-      ) as Set<_i19.KeyVerificationMethod>);
+        returnValue: <_i20.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
+      ) as Set<_i20.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1024,11 +1036,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1065,11 +1077,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1099,11 +1111,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1112,11 +1124,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1402,34 +1414,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i20.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i19.KeyVerification>
+  _i3.CachedStreamController<_i20.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i19.KeyVerification>(
+                _FakeCachedStreamController_6<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i19.KeyVerification>);
+          ) as _i3.CachedStreamController<_i20.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1585,7 +1597,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1874,14 +1886,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2269,8 +2281,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValue: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2286,8 +2298,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2328,7 +2340,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2344,7 +2356,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2393,7 +2405,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2414,7 +2426,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2517,7 +2529,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2535,7 +2547,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3054,7 +3066,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3406,7 +3418,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3420,7 +3432,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3571,7 +3583,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4949,7 +4961,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4971,7 +4983,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5465,7 +5477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5477,7 +5489,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6485,7 +6497,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6496,7 +6508,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6744,7 +6756,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6756,7 +6768,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7016,7 +7028,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7029,7 +7041,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7096,7 +7108,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7109,7 +7121,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7157,7 +7169,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7169,7 +7181,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7417,7 +7429,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7428,7 +7440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7690,7 +7702,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7717,7 +7729,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7747,11 +7759,11 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7889,17 +7901,30 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8008,7 +8033,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8061,7 +8095,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i24.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8157,7 +8191,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8166,7 +8200,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8185,7 +8219,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i25.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8196,7 +8230,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i25.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8244,7 +8278,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i25.RouteInformation? routeInformation) =>
+          _i26.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8282,7 +8316,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i24.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8291,7 +8325,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i24.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8300,16 +8334,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i24.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
-      ) as _i5.Future<_i23.AppExitResponse>);
+            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
+      ) as _i5.Future<_i24.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8461,7 +8495,7 @@ class MockAuthService extends _i1.Mock implements _i15.AuthService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i18.ServerAuthCapabilities> getServerAuthCapabilities(
+  _i5.Future<_i19.ServerAuthCapabilities> getServerAuthCapabilities(
     String? homeserver, {
     required bool? isLoggedIn,
   }) =>
@@ -8471,8 +8505,8 @@ class MockAuthService extends _i1.Mock implements _i15.AuthService {
           [homeserver],
           {#isLoggedIn: isLoggedIn},
         ),
-        returnValue: _i5.Future<_i18.ServerAuthCapabilities>.value(
-            _FakeServerAuthCapabilities_77(
+        returnValue: _i5.Future<_i19.ServerAuthCapabilities>.value(
+            _FakeServerAuthCapabilities_78(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8481,8 +8515,8 @@ class MockAuthService extends _i1.Mock implements _i15.AuthService {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i18.ServerAuthCapabilities>.value(
-                _FakeServerAuthCapabilities_77(
+            _i5.Future<_i19.ServerAuthCapabilities>.value(
+                _FakeServerAuthCapabilities_78(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8490,7 +8524,7 @@ class MockAuthService extends _i1.Mock implements _i15.AuthService {
             {#isLoggedIn: isLoggedIn},
           ),
         )),
-      ) as _i5.Future<_i18.ServerAuthCapabilities>);
+      ) as _i5.Future<_i19.ServerAuthCapabilities>);
 
   @override
   bool isPermanentAuthFailure(Object? error) => (super.noSuchMethod(
@@ -8577,7 +8611,7 @@ class MockAuthService extends _i1.Mock implements _i15.AuthService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8586,7 +8620,7 @@ class MockAuthService extends _i1.Mock implements _i15.AuthService {
       );
 
   @override
-  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/widgets/room_context_menu_test.mocks.dart
+++ b/test/widgets/room_context_menu_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,14 +28,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i26;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i27;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i25;
+import 'package:matrix/src/utils/space_child.dart' as _i26;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -860,9 +861,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -871,8 +872,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,9 +883,19 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_78(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,8 +904,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,8 +914,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -930,12 +942,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1055,11 +1067,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1096,11 +1108,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1130,11 +1142,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1143,11 +1155,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1433,34 +1445,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1616,7 +1628,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1905,14 +1917,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2300,8 +2312,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2317,8 +2329,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2359,7 +2371,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2375,7 +2387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2424,7 +2436,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2445,7 +2457,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2548,7 +2560,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2566,7 +2578,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3085,7 +3097,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3437,7 +3449,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3451,7 +3463,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3602,7 +3614,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4980,7 +4992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5002,7 +5014,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5496,7 +5508,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5508,7 +5520,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6516,7 +6528,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6527,7 +6539,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6775,7 +6787,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6787,7 +6799,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7047,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7060,7 +7072,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7127,7 +7139,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7140,7 +7152,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7188,7 +7200,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7200,7 +7212,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7448,7 +7460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7459,7 +7471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7721,7 +7733,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7748,7 +7760,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7778,11 +7790,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7920,17 +7932,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8039,7 +8064,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8092,7 +8126,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8188,7 +8222,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8197,7 +8231,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8216,7 +8250,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8227,7 +8261,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8275,7 +8309,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8313,7 +8347,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8322,7 +8356,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8331,16 +8365,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8368,11 +8402,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8402,11 +8436,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -8459,11 +8493,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8499,11 +8533,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8519,11 +8553,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8532,11 +8566,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8579,11 +8613,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8626,11 +8660,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8849,18 +8883,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i25.SpaceParent>[],
-        returnValueForMissingStub: <_i25.SpaceParent>[],
-      ) as List<_i25.SpaceParent>);
+        returnValue: <_i26.SpaceParent>[],
+        returnValueForMissingStub: <_i26.SpaceParent>[],
+      ) as List<_i26.SpaceParent>);
 
   @override
-  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i25.SpaceChild>[],
-        returnValueForMissingStub: <_i25.SpaceChild>[],
-      ) as List<_i25.SpaceChild>);
+        returnValue: <_i26.SpaceChild>[],
+        returnValueForMissingStub: <_i26.SpaceChild>[],
+      ) as List<_i26.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9027,14 +9061,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9082,7 +9116,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9090,7 +9124,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9105,7 +9139,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9113,7 +9147,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9207,7 +9241,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9215,7 +9249,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9457,7 +9491,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9468,7 +9502,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9557,15 +9591,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i26.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i27.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i26.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i26.TimelineChunk?>.value(),
-      ) as _i5.Future<_i26.TimelineChunk?>);
+        returnValue: _i5.Future<_i27.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i27.TimelineChunk?>.value(),
+      ) as _i5.Future<_i27.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9606,7 +9640,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9623,7 +9657,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9687,14 +9721,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9710,14 +9744,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9773,7 +9807,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9781,7 +9815,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/room_details_panel_test.mocks.dart
+++ b/test/widgets/room_details_panel_test.mocks.dart
@@ -4,15 +4,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/models/join_mode.dart' as _i27;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/models/join_mode.dart' as _i28;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -29,14 +29,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i26;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i27;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i25;
+import 'package:matrix/src/utils/space_child.dart' as _i26;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -861,9 +862,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -872,8 +873,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -882,9 +884,19 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_78(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -893,8 +905,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -903,8 +915,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -913,8 +925,8 @@ class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeStateEvent_81 extends _i1.SmartFake implements _i2.StateEvent {
-  _FakeStateEvent_81(
+class _FakeStateEvent_82 extends _i1.SmartFake implements _i2.StateEvent {
+  _FakeStateEvent_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -941,12 +953,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1066,11 +1078,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1107,11 +1119,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1141,11 +1153,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1154,11 +1166,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1444,34 +1456,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1627,7 +1639,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1916,14 +1928,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2311,8 +2323,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2328,8 +2340,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2370,7 +2382,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2386,7 +2398,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2435,7 +2447,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2456,7 +2468,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2559,7 +2571,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2577,7 +2589,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3096,7 +3108,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3448,7 +3460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3462,7 +3474,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3613,7 +3625,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4991,7 +5003,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5013,7 +5025,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5507,7 +5519,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5519,7 +5531,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6527,7 +6539,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6538,7 +6550,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6786,7 +6798,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6798,7 +6810,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7058,7 +7070,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7071,7 +7083,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7138,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7151,7 +7163,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7199,7 +7211,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7211,7 +7223,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7459,7 +7471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7470,7 +7482,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7732,7 +7744,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7759,7 +7771,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7789,11 +7801,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7931,17 +7943,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8050,7 +8075,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8103,7 +8137,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8199,7 +8233,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8208,7 +8242,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8227,7 +8261,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8238,7 +8272,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8286,7 +8320,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8324,7 +8358,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8333,7 +8367,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8342,16 +8376,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8379,11 +8413,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8413,11 +8447,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -8470,11 +8504,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8510,11 +8544,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8530,11 +8564,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8543,11 +8577,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8590,11 +8624,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8637,11 +8671,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8860,18 +8894,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i25.SpaceParent>[],
-        returnValueForMissingStub: <_i25.SpaceParent>[],
-      ) as List<_i25.SpaceParent>);
+        returnValue: <_i26.SpaceParent>[],
+        returnValueForMissingStub: <_i26.SpaceParent>[],
+      ) as List<_i26.SpaceParent>);
 
   @override
-  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i25.SpaceChild>[],
-        returnValueForMissingStub: <_i25.SpaceChild>[],
-      ) as List<_i25.SpaceChild>);
+        returnValue: <_i26.SpaceChild>[],
+        returnValueForMissingStub: <_i26.SpaceChild>[],
+      ) as List<_i26.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9038,14 +9072,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9093,7 +9127,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9101,7 +9135,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9116,7 +9150,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9124,7 +9158,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9218,7 +9252,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9226,7 +9260,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9468,7 +9502,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9479,7 +9513,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9568,15 +9602,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i26.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i27.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i26.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i26.TimelineChunk?>.value(),
-      ) as _i5.Future<_i26.TimelineChunk?>);
+        returnValue: _i5.Future<_i27.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i27.TimelineChunk?>.value(),
+      ) as _i5.Future<_i27.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9617,7 +9651,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9634,7 +9668,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9698,14 +9732,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9721,14 +9755,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9784,7 +9818,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9792,7 +9826,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10103,14 +10137,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
 class MockSpaceAccessService extends _i1.Mock
     implements _i13.SpaceAccessService {
   @override
-  _i27.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
+  _i28.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
         Invocation.method(
           #getJoinMode,
           [room],
         ),
-        returnValue: _i27.JoinMode.invite,
-        returnValueForMissingStub: _i27.JoinMode.invite,
-      ) as _i27.JoinMode);
+        returnValue: _i28.JoinMode.invite,
+        returnValueForMissingStub: _i28.JoinMode.invite,
+      ) as _i28.JoinMode);
 
   @override
   List<String> allowedSpaceIds(_i2.Room? room) => (super.noSuchMethod(
@@ -10194,7 +10228,7 @@ class MockSpaceAccessService extends _i1.Mock
   @override
   _i5.Future<void> applyJoinMode({
     required String? roomId,
-    required _i27.JoinMode? mode,
+    required _i28.JoinMode? mode,
     List<String>? allowSpaceIds = const [],
   }) =>
       (super.noSuchMethod(
@@ -10213,7 +10247,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   Map<String, Object?> buildJoinRulesPayload(
-    _i27.JoinMode? mode,
+    _i28.JoinMode? mode,
     List<String>? allowSpaceIds, {
     List<Map<String, Object?>>? preserveEntries = const [],
   }) =>
@@ -10232,7 +10266,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   _i2.StateEvent buildJoinRulesStateEvent(
-    _i27.JoinMode? mode,
+    _i28.JoinMode? mode,
     List<String>? allowSpaceIds,
   ) =>
       (super.noSuchMethod(
@@ -10243,7 +10277,7 @@ class MockSpaceAccessService extends _i1.Mock
             allowSpaceIds,
           ],
         ),
-        returnValue: _FakeStateEvent_81(
+        returnValue: _FakeStateEvent_82(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -10253,7 +10287,7 @@ class MockSpaceAccessService extends _i1.Mock
             ],
           ),
         ),
-        returnValueForMissingStub: _FakeStateEvent_81(
+        returnValueForMissingStub: _FakeStateEvent_82(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -10278,7 +10312,7 @@ class MockSpaceAccessService extends _i1.Mock
             newVersion,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,
@@ -10289,7 +10323,7 @@ class MockSpaceAccessService extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,

--- a/test/widgets/room_list_empty_state_test.mocks.dart
+++ b/test/widgets/room_list_empty_state_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,14 +28,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i26;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i27;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i25;
+import 'package:matrix/src/utils/space_child.dart' as _i26;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -860,9 +861,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -871,8 +872,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,9 +883,19 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_78(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,8 +904,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,8 +914,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -930,12 +942,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1055,11 +1067,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1096,11 +1108,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1130,11 +1142,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1143,11 +1155,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1433,34 +1445,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1616,7 +1628,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1905,14 +1917,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2300,8 +2312,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2317,8 +2329,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2359,7 +2371,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2375,7 +2387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2424,7 +2436,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2445,7 +2457,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2548,7 +2560,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2566,7 +2578,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3085,7 +3097,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3437,7 +3449,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3451,7 +3463,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3602,7 +3614,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4980,7 +4992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5002,7 +5014,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5496,7 +5508,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5508,7 +5520,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6516,7 +6528,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6527,7 +6539,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6775,7 +6787,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6787,7 +6799,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7047,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7060,7 +7072,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7127,7 +7139,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7140,7 +7152,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7188,7 +7200,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7200,7 +7212,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7448,7 +7460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7459,7 +7471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7721,7 +7733,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7748,7 +7760,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7778,11 +7790,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7920,17 +7932,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8039,7 +8064,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8092,7 +8126,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8188,7 +8222,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8197,7 +8231,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8216,7 +8250,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8227,7 +8261,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8275,7 +8309,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8313,7 +8347,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8322,7 +8356,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8331,16 +8365,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8368,11 +8402,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8402,11 +8436,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -8459,11 +8493,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8499,11 +8533,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8519,11 +8553,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8532,11 +8566,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8579,11 +8613,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8626,11 +8660,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8849,18 +8883,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i25.SpaceParent>[],
-        returnValueForMissingStub: <_i25.SpaceParent>[],
-      ) as List<_i25.SpaceParent>);
+        returnValue: <_i26.SpaceParent>[],
+        returnValueForMissingStub: <_i26.SpaceParent>[],
+      ) as List<_i26.SpaceParent>);
 
   @override
-  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i25.SpaceChild>[],
-        returnValueForMissingStub: <_i25.SpaceChild>[],
-      ) as List<_i25.SpaceChild>);
+        returnValue: <_i26.SpaceChild>[],
+        returnValueForMissingStub: <_i26.SpaceChild>[],
+      ) as List<_i26.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9027,14 +9061,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9082,7 +9116,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9090,7 +9124,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9105,7 +9139,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9113,7 +9147,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9207,7 +9241,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9215,7 +9249,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9457,7 +9491,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9468,7 +9502,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9557,15 +9591,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i26.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i27.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i26.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i26.TimelineChunk?>.value(),
-      ) as _i5.Future<_i26.TimelineChunk?>);
+        returnValue: _i5.Future<_i27.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i27.TimelineChunk?>.value(),
+      ) as _i5.Future<_i27.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9606,7 +9640,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9623,7 +9657,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9687,14 +9721,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9710,14 +9744,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9773,7 +9807,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9781,7 +9815,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/room_list_unjoined_test.mocks.dart
+++ b/test/widgets/room_list_unjoined_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,14 +28,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i26;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i27;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i25;
+import 'package:matrix/src/utils/space_child.dart' as _i26;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -860,9 +861,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -871,8 +872,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,9 +883,19 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_78(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,8 +904,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,8 +914,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -930,12 +942,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1055,11 +1067,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1096,11 +1108,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1130,11 +1142,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1143,11 +1155,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1433,34 +1445,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1616,7 +1628,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1905,14 +1917,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2300,8 +2312,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2317,8 +2329,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2359,7 +2371,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2375,7 +2387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2424,7 +2436,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2445,7 +2457,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2548,7 +2560,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2566,7 +2578,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3085,7 +3097,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3437,7 +3449,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3451,7 +3463,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3602,7 +3614,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4980,7 +4992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5002,7 +5014,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5496,7 +5508,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5508,7 +5520,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6516,7 +6528,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6527,7 +6539,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6775,7 +6787,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6787,7 +6799,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7047,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7060,7 +7072,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7127,7 +7139,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7140,7 +7152,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7188,7 +7200,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7200,7 +7212,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7448,7 +7460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7459,7 +7471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7721,7 +7733,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7748,7 +7760,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7778,11 +7790,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7920,17 +7932,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8039,7 +8064,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8092,7 +8126,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8188,7 +8222,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8197,7 +8231,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8216,7 +8250,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8227,7 +8261,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8275,7 +8309,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8313,7 +8347,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8322,7 +8356,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8331,16 +8365,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8368,11 +8402,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8402,11 +8436,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -8459,11 +8493,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8499,11 +8533,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8519,11 +8553,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8532,11 +8566,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8579,11 +8613,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8626,11 +8660,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8849,18 +8883,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i25.SpaceParent>[],
-        returnValueForMissingStub: <_i25.SpaceParent>[],
-      ) as List<_i25.SpaceParent>);
+        returnValue: <_i26.SpaceParent>[],
+        returnValueForMissingStub: <_i26.SpaceParent>[],
+      ) as List<_i26.SpaceParent>);
 
   @override
-  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i25.SpaceChild>[],
-        returnValueForMissingStub: <_i25.SpaceChild>[],
-      ) as List<_i25.SpaceChild>);
+        returnValue: <_i26.SpaceChild>[],
+        returnValueForMissingStub: <_i26.SpaceChild>[],
+      ) as List<_i26.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9027,14 +9061,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9082,7 +9116,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9090,7 +9124,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9105,7 +9139,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9113,7 +9147,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9207,7 +9241,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9215,7 +9249,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9457,7 +9491,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9468,7 +9502,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9557,15 +9591,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i26.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i27.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i26.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i26.TimelineChunk?>.value(),
-      ) as _i5.Future<_i26.TimelineChunk?>);
+        returnValue: _i5.Future<_i27.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i27.TimelineChunk?>.value(),
+      ) as _i5.Future<_i27.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9606,7 +9640,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9623,7 +9657,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9687,14 +9721,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9710,14 +9744,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9773,7 +9807,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9781,7 +9815,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/room_members_section_test.dart
+++ b/test/widgets/room_members_section_test.dart
@@ -7,6 +7,7 @@ import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/presence_service.dart';
 import 'package:kohera/features/rooms/models/room_role.dart';
 import 'package:kohera/features/rooms/widgets/room_members_section.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/annotations.dart';
@@ -21,10 +22,17 @@ import 'package:provider/provider.dart';
 ])
 import 'room_members_section_test.mocks.dart';
 
+class _NullAvatarResolver implements AvatarResolver {
+  const _NullAvatarResolver();
+  @override
+  Future<AvatarThumbnail?> resolve(String? mxcUrl, {required double size}) async => null;
+}
+
 MockUser _makeUser(String id, String displayName, {Room? room}) {
   final user = MockUser();
   when(user.id).thenReturn(id);
   when(user.displayName).thenReturn(displayName);
+  when(user.calcDisplayname()).thenReturn(displayName);
   when(user.room).thenReturn(room ?? MockRoom());
   when(user.membership).thenReturn(Membership.join);
   return user;
@@ -44,6 +52,7 @@ void main() {
     when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
     when(mockClient.onPresenceChanged)
         .thenReturn(CachedStreamController<CachedPresence>());
+    when(mockMatrixService.avatarResolver).thenReturn(const _NullAvatarResolver());
     when(mockMatrixService.presence)
         .thenReturn(PresenceService(client: mockClient));
     when(mockRoom.id).thenReturn('!room:example.com');

--- a/test/widgets/room_members_section_test.mocks.dart
+++ b/test/widgets/room_members_section_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,14 +28,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i26;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i27;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i25;
+import 'package:matrix/src/utils/space_child.dart' as _i26;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -860,9 +861,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -871,8 +872,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,9 +883,19 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_78(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,8 +904,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,8 +914,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -912,8 +924,8 @@ class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_81 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_81(
+class _FakeRoom_82 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -940,12 +952,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1065,11 +1077,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1106,11 +1118,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1140,11 +1152,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1153,11 +1165,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1443,34 +1455,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1626,7 +1638,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1915,14 +1927,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2310,8 +2322,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2327,8 +2339,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2369,7 +2381,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2385,7 +2397,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2434,7 +2446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2455,7 +2467,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2558,7 +2570,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2576,7 +2588,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3095,7 +3107,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3447,7 +3459,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3461,7 +3473,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3612,7 +3624,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4990,7 +5002,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5012,7 +5024,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5506,7 +5518,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5518,7 +5530,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6526,7 +6538,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6537,7 +6549,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6785,7 +6797,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6797,7 +6809,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7057,7 +7069,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7070,7 +7082,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7137,7 +7149,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7150,7 +7162,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7198,7 +7210,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7210,7 +7222,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7458,7 +7470,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7469,7 +7481,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7731,7 +7743,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7758,7 +7770,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7788,11 +7800,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7930,17 +7942,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8049,7 +8074,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8102,7 +8136,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8198,7 +8232,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8207,7 +8241,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8226,7 +8260,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8237,7 +8271,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8285,7 +8319,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8323,7 +8357,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8332,7 +8366,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8341,16 +8375,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8378,11 +8412,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8412,11 +8446,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -8469,11 +8503,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8509,11 +8543,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8529,11 +8563,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8542,11 +8576,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8589,11 +8623,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8636,11 +8670,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8859,18 +8893,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i25.SpaceParent>[],
-        returnValueForMissingStub: <_i25.SpaceParent>[],
-      ) as List<_i25.SpaceParent>);
+        returnValue: <_i26.SpaceParent>[],
+        returnValueForMissingStub: <_i26.SpaceParent>[],
+      ) as List<_i26.SpaceParent>);
 
   @override
-  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i25.SpaceChild>[],
-        returnValueForMissingStub: <_i25.SpaceChild>[],
-      ) as List<_i25.SpaceChild>);
+        returnValue: <_i26.SpaceChild>[],
+        returnValueForMissingStub: <_i26.SpaceChild>[],
+      ) as List<_i26.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9037,14 +9071,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9092,7 +9126,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9100,7 +9134,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9115,7 +9149,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9123,7 +9157,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9217,7 +9251,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9225,7 +9259,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9467,7 +9501,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9478,7 +9512,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9567,15 +9601,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i26.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i27.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i26.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i26.TimelineChunk?>.value(),
-      ) as _i5.Future<_i26.TimelineChunk?>);
+        returnValue: _i5.Future<_i27.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i27.TimelineChunk?>.value(),
+      ) as _i5.Future<_i27.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9616,7 +9650,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9633,7 +9667,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9697,14 +9731,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9720,14 +9754,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9783,7 +9817,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9791,7 +9825,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10103,11 +10137,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -10116,11 +10150,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -10186,11 +10220,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -10215,11 +10249,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10237,11 +10271,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10288,7 +10322,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -10300,7 +10334,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -10370,7 +10404,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -10383,7 +10417,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/room_section_header_test.mocks.dart
+++ b/test/widgets/room_section_header_test.mocks.dart
@@ -4,16 +4,16 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i23;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i24;
 
-import 'package:flutter/material.dart' as _i28;
-import 'package:flutter/services.dart' as _i24;
-import 'package:flutter/widgets.dart' as _i25;
+import 'package:flutter/material.dart' as _i29;
+import 'package:flutter/services.dart' as _i25;
+import 'package:flutter/widgets.dart' as _i26;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i22;
-import 'package:kohera/core/services/preferences_service.dart' as _i26;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i23;
+import 'package:kohera/core/services/preferences_service.dart' as _i27;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -26,20 +26,21 @@ import 'package:kohera/core/services/sub_services/space_access_service.dart'
     as _i13;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
-import 'package:kohera/core/theme/custom_theme.dart' as _i18;
-import 'package:kohera/core/utils/openmoji.dart' as _i27;
+import 'package:kohera/core/theme/custom_theme.dart' as _i19;
+import 'package:kohera/core/utils/openmoji.dart' as _i28;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i19;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i30;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i31;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i29;
+import 'package:matrix/src/utils/space_child.dart' as _i30;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i20;
+import 'package:mockito/src/dummies.dart' as _i21;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -864,9 +865,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -875,8 +876,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeCustomTheme_77 extends _i1.SmartFake implements _i18.CustomTheme {
-  _FakeCustomTheme_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -885,8 +887,8 @@ class _FakeCustomTheme_77 extends _i1.SmartFake implements _i18.CustomTheme {
         );
 }
 
-class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_78(
+class _FakeCustomTheme_78 extends _i1.SmartFake implements _i19.CustomTheme {
+  _FakeCustomTheme_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -895,9 +897,19 @@ class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_79 extends _i1.SmartFake
+class _FakeRoomSummary_79 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_79(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_80 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_79(
+  _FakeLatestReceiptState_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -906,8 +918,8 @@ class _FakeLatestReceiptState_79 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_80(
+class _FakeTimeline_81 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -916,8 +928,8 @@ class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_81(
+class _FakeUser_82 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -944,12 +956,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i19.KeyVerificationMethod> get verificationMethods =>
+  Set<_i20.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i19.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
-      ) as Set<_i19.KeyVerificationMethod>);
+        returnValue: <_i20.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
+      ) as Set<_i20.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1069,11 +1081,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1110,11 +1122,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1144,11 +1156,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1157,11 +1169,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1447,34 +1459,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i20.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i19.KeyVerification>
+  _i3.CachedStreamController<_i20.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i19.KeyVerification>(
+                _FakeCachedStreamController_6<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i19.KeyVerification>);
+          ) as _i3.CachedStreamController<_i20.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1630,7 +1642,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1919,14 +1931,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2314,8 +2326,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValue: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2331,8 +2343,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2373,7 +2385,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2389,7 +2401,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2438,7 +2450,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2459,7 +2471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2562,7 +2574,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2580,7 +2592,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3099,7 +3111,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3451,7 +3463,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3465,7 +3477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3616,7 +3628,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4994,7 +5006,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5016,7 +5028,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5510,7 +5522,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5522,7 +5534,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6530,7 +6542,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6541,7 +6553,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6789,7 +6801,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6801,7 +6813,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7061,7 +7073,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7074,7 +7086,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7141,7 +7153,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7154,7 +7166,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7202,7 +7214,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7214,7 +7226,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7462,7 +7474,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7473,7 +7485,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7735,7 +7747,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7762,7 +7774,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7792,11 +7804,11 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7934,17 +7946,30 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8053,7 +8078,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8106,7 +8140,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i24.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8202,7 +8236,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8211,7 +8245,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8230,7 +8264,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i25.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8241,7 +8275,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i25.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8289,7 +8323,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i25.RouteInformation? routeInformation) =>
+          _i26.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8327,7 +8361,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i24.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8336,7 +8370,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i24.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8345,16 +8379,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i24.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
-      ) as _i5.Future<_i23.AppExitResponse>);
+            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
+      ) as _i5.Future<_i24.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8379,67 +8413,67 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockPreferencesService extends _i1.Mock
-    implements _i26.PreferencesService {
+    implements _i27.PreferencesService {
   @override
-  _i26.MessageDensity get messageDensity => (super.noSuchMethod(
+  _i27.MessageDensity get messageDensity => (super.noSuchMethod(
         Invocation.getter(#messageDensity),
-        returnValue: _i26.MessageDensity.compact,
-        returnValueForMissingStub: _i26.MessageDensity.compact,
-      ) as _i26.MessageDensity);
+        returnValue: _i27.MessageDensity.compact,
+        returnValueForMissingStub: _i27.MessageDensity.compact,
+      ) as _i27.MessageDensity);
 
   @override
-  _i26.MobileTab get lastMobileTab => (super.noSuchMethod(
+  _i27.MobileTab get lastMobileTab => (super.noSuchMethod(
         Invocation.getter(#lastMobileTab),
-        returnValue: _i26.MobileTab.inbox,
-        returnValueForMissingStub: _i26.MobileTab.inbox,
-      ) as _i26.MobileTab);
+        returnValue: _i27.MobileTab.inbox,
+        returnValueForMissingStub: _i27.MobileTab.inbox,
+      ) as _i27.MobileTab);
 
   @override
-  _i27.SkinTone get skinTone => (super.noSuchMethod(
+  _i28.SkinTone get skinTone => (super.noSuchMethod(
         Invocation.getter(#skinTone),
-        returnValue: _i27.SkinTone.none,
-        returnValueForMissingStub: _i27.SkinTone.none,
-      ) as _i27.SkinTone);
+        returnValue: _i28.SkinTone.none,
+        returnValueForMissingStub: _i28.SkinTone.none,
+      ) as _i28.SkinTone);
 
   @override
-  _i28.ThemeMode get themeMode => (super.noSuchMethod(
+  _i29.ThemeMode get themeMode => (super.noSuchMethod(
         Invocation.getter(#themeMode),
-        returnValue: _i28.ThemeMode.system,
-        returnValueForMissingStub: _i28.ThemeMode.system,
-      ) as _i28.ThemeMode);
+        returnValue: _i29.ThemeMode.system,
+        returnValueForMissingStub: _i29.ThemeMode.system,
+      ) as _i29.ThemeMode);
 
   @override
   String get themeModeLabel => (super.noSuchMethod(
         Invocation.getter(#themeModeLabel),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#themeModeLabel),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#themeModeLabel),
         ),
       ) as String);
 
   @override
-  _i18.CustomTheme get customTheme => (super.noSuchMethod(
+  _i19.CustomTheme get customTheme => (super.noSuchMethod(
         Invocation.getter(#customTheme),
-        returnValue: _FakeCustomTheme_77(
+        returnValue: _FakeCustomTheme_78(
           this,
           Invocation.getter(#customTheme),
         ),
-        returnValueForMissingStub: _FakeCustomTheme_77(
+        returnValueForMissingStub: _FakeCustomTheme_78(
           this,
           Invocation.getter(#customTheme),
         ),
-      ) as _i18.CustomTheme);
+      ) as _i19.CustomTheme);
 
   @override
-  _i28.ThemeMode get customThemeMode => (super.noSuchMethod(
+  _i29.ThemeMode get customThemeMode => (super.noSuchMethod(
         Invocation.getter(#customThemeMode),
-        returnValue: _i28.ThemeMode.system,
-        returnValueForMissingStub: _i28.ThemeMode.system,
-      ) as _i28.ThemeMode);
+        returnValue: _i29.ThemeMode.system,
+        returnValueForMissingStub: _i29.ThemeMode.system,
+      ) as _i29.ThemeMode);
 
   @override
   Set<String> get collapsedSpaceSections => (super.noSuchMethod(
@@ -8470,20 +8504,20 @@ class MockPreferencesService extends _i1.Mock
       ) as double);
 
   @override
-  _i26.NotificationLevel get notificationLevel => (super.noSuchMethod(
+  _i27.NotificationLevel get notificationLevel => (super.noSuchMethod(
         Invocation.getter(#notificationLevel),
-        returnValue: _i26.NotificationLevel.all,
-        returnValueForMissingStub: _i26.NotificationLevel.all,
-      ) as _i26.NotificationLevel);
+        returnValue: _i27.NotificationLevel.all,
+        returnValueForMissingStub: _i27.NotificationLevel.all,
+      ) as _i27.NotificationLevel);
 
   @override
   String get notificationLevelLabel => (super.noSuchMethod(
         Invocation.getter(#notificationLevelLabel),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#notificationLevelLabel),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#notificationLevelLabel),
         ),
@@ -8637,11 +8671,11 @@ class MockPreferencesService extends _i1.Mock
       ) as bool);
 
   @override
-  _i26.AudioQuality get audioQuality => (super.noSuchMethod(
+  _i27.AudioQuality get audioQuality => (super.noSuchMethod(
         Invocation.getter(#audioQuality),
-        returnValue: _i26.AudioQuality.speech,
-        returnValueForMissingStub: _i26.AudioQuality.speech,
-      ) as _i26.AudioQuality);
+        returnValue: _i27.AudioQuality.speech,
+        returnValueForMissingStub: _i27.AudioQuality.speech,
+      ) as _i27.AudioQuality);
 
   @override
   bool get highPassFilter => (super.noSuchMethod(
@@ -8692,7 +8726,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setMessageDensity(_i26.MessageDensity? density) =>
+  _i5.Future<void> setMessageDensity(_i27.MessageDensity? density) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMessageDensity,
@@ -8703,7 +8737,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setLastMobileTab(_i26.MobileTab? tab) => (super.noSuchMethod(
+  _i5.Future<void> setLastMobileTab(_i27.MobileTab? tab) => (super.noSuchMethod(
         Invocation.method(
           #setLastMobileTab,
           [tab],
@@ -8713,7 +8747,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setSkinTone(_i27.SkinTone? tone) => (super.noSuchMethod(
+  _i5.Future<void> setSkinTone(_i28.SkinTone? tone) => (super.noSuchMethod(
         Invocation.method(
           #setSkinTone,
           [tone],
@@ -8723,7 +8757,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setThemeMode(_i28.ThemeMode? mode) => (super.noSuchMethod(
+  _i5.Future<void> setThemeMode(_i29.ThemeMode? mode) => (super.noSuchMethod(
         Invocation.method(
           #setThemeMode,
           [mode],
@@ -8743,7 +8777,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setCustomTheme(_i18.CustomTheme? theme) =>
+  _i5.Future<void> setCustomTheme(_i19.CustomTheme? theme) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCustomTheme,
@@ -8754,7 +8788,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setCustomThemeMode(_i28.ThemeMode? mode) =>
+  _i5.Future<void> setCustomThemeMode(_i29.ThemeMode? mode) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCustomThemeMode,
@@ -8806,7 +8840,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setNotificationLevel(_i26.NotificationLevel? level) =>
+  _i5.Future<void> setNotificationLevel(_i27.NotificationLevel? level) =>
       (super.noSuchMethod(
         Invocation.method(
           #setNotificationLevel,
@@ -9085,7 +9119,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setAudioQuality(_i26.AudioQuality? quality) =>
+  _i5.Future<void> setAudioQuality(_i27.AudioQuality? quality) =>
       (super.noSuchMethod(
         Invocation.method(
           #setAudioQuality,
@@ -9146,7 +9180,7 @@ class MockPreferencesService extends _i1.Mock
       ) as bool);
 
   @override
-  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -9155,7 +9189,7 @@ class MockPreferencesService extends _i1.Mock
       );
 
   @override
-  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -9189,11 +9223,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -9223,11 +9257,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_78(
+        returnValue: _FakeRoomSummary_79(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_78(
+        returnValueForMissingStub: _FakeRoomSummary_79(
           this,
           Invocation.getter(#summary),
         ),
@@ -9280,11 +9314,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -9320,11 +9354,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -9340,11 +9374,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -9353,11 +9387,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -9400,11 +9434,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -9447,11 +9481,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_79(
+        returnValue: _FakeLatestReceiptState_80(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_79(
+        returnValueForMissingStub: _FakeLatestReceiptState_80(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -9670,18 +9704,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i29.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i30.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i29.SpaceParent>[],
-        returnValueForMissingStub: <_i29.SpaceParent>[],
-      ) as List<_i29.SpaceParent>);
+        returnValue: <_i30.SpaceParent>[],
+        returnValueForMissingStub: <_i30.SpaceParent>[],
+      ) as List<_i30.SpaceParent>);
 
   @override
-  List<_i29.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i30.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i29.SpaceChild>[],
-        returnValueForMissingStub: <_i29.SpaceChild>[],
-      ) as List<_i29.SpaceChild>);
+        returnValue: <_i30.SpaceChild>[],
+        returnValueForMissingStub: <_i30.SpaceChild>[],
+      ) as List<_i30.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9848,14 +9882,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9903,7 +9937,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9911,7 +9945,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9926,7 +9960,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9934,7 +9968,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -10028,7 +10062,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -10036,7 +10070,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -10278,7 +10312,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10289,7 +10323,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10378,15 +10412,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i30.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i31.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i30.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i30.TimelineChunk?>.value(),
-      ) as _i5.Future<_i30.TimelineChunk?>);
+        returnValue: _i5.Future<_i31.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i31.TimelineChunk?>.value(),
+      ) as _i5.Future<_i31.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -10427,7 +10461,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_81(
           this,
           Invocation.method(
             #getTimeline,
@@ -10444,7 +10478,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_81(
           this,
           Invocation.method(
             #getTimeline,
@@ -10508,14 +10542,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_81(
+        returnValue: _FakeUser_82(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_81(
+        returnValueForMissingStub: _FakeUser_82(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -10531,14 +10565,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_81(
+        returnValue: _FakeUser_82(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_81(
+        returnValueForMissingStub: _FakeUser_82(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -10594,7 +10628,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10602,7 +10636,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/room_tile_test.mocks.dart
+++ b/test/widgets/room_tile_test.mocks.dart
@@ -3,17 +3,17 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i16;
-import 'dart:typed_data' as _i26;
-import 'dart:ui' as _i20;
+import 'dart:async' as _i17;
+import 'dart:typed_data' as _i27;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
-import 'package:http/http.dart' as _i15;
-import 'package:kohera/core/services/call_service.dart' as _i27;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/preferences_service.dart' as _i33;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i13;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
+import 'package:http/http.dart' as _i16;
+import 'package:kohera/core/services/call_service.dart' as _i28;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/preferences_service.dart' as _i34;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -25,24 +25,25 @@ import 'package:kohera/core/services/sub_services/space_access_service.dart'
     as _i9;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
-import 'package:kohera/features/calling/models/call_participant.dart' as _i30;
-import 'package:kohera/features/calling/models/call_state.dart' as _i32;
-import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i31;
-import 'package:kohera/features/calling/services/livekit_service.dart' as _i28;
-import 'package:kohera/features/calling/services/ringtone_service.dart' as _i34;
+import 'package:kohera/features/calling/models/call_participant.dart' as _i31;
+import 'package:kohera/features/calling/models/call_state.dart' as _i33;
+import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i32;
+import 'package:kohera/features/calling/services/livekit_service.dart' as _i29;
+import 'package:kohera/features/calling/services/ringtone_service.dart' as _i35;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:livekit_client/livekit_client.dart' as _i29;
-import 'package:matrix/encryption.dart' as _i25;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i13;
+import 'package:livekit_client/livekit_client.dart' as _i30;
+import 'package:matrix/encryption.dart' as _i26;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i17;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i14;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i18;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i15;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -176,9 +177,9 @@ class _FakeOutboxService_10 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_11 extends _i1.SmartFake
-    implements _i13.StickerPackService {
-  _FakeStickerPackService_11(
+class _FakeAvatarResolver_11 extends _i1.SmartFake
+    implements _i13.AvatarResolver {
+  _FakeAvatarResolver_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -187,8 +188,9 @@ class _FakeStickerPackService_11 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_12 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_12(
+class _FakeStickerPackService_12 extends _i1.SmartFake
+    implements _i14.StickerPackService {
+  _FakeStickerPackService_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -197,9 +199,8 @@ class _FakeRoomSummary_12 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_13<T> extends _i1.SmartFake
-    implements _i14.CachedStreamController<T> {
-  _FakeCachedStreamController_13(
+class _FakeRoomSummary_13 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -208,8 +209,9 @@ class _FakeCachedStreamController_13<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_14 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_14(
+class _FakeCachedStreamController_14<T> extends _i1.SmartFake
+    implements _i15.CachedStreamController<T> {
+  _FakeCachedStreamController_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -218,9 +220,19 @@ class _FakeDateTime_14 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_15 extends _i1.SmartFake
+class _FakeDateTime_15 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_15(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_16 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_15(
+  _FakeLatestReceiptState_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -229,8 +241,8 @@ class _FakeLatestReceiptState_15 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_16 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_16(
+class _FakeSyncUpdate_17 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -239,8 +251,8 @@ class _FakeSyncUpdate_16 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_17 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_17(
+class _FakeTimeline_18 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -249,8 +261,8 @@ class _FakeTimeline_17 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_18 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_18(
+class _FakeUser_19 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -259,8 +271,8 @@ class _FakeUser_18 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_19 extends _i1.SmartFake implements Uri {
-  _FakeUri_19(
+class _FakeUri_20 extends _i1.SmartFake implements Uri {
+  _FakeUri_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -269,8 +281,8 @@ class _FakeUri_19 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_20 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_20(
+class _FakeDatabaseApi_21 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -279,8 +291,8 @@ class _FakeDatabaseApi_20 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_21 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_21(
+class _FakeFilter_22 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -289,9 +301,9 @@ class _FakeFilter_21 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_22 extends _i1.SmartFake
+class _FakeNativeImplementations_23 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_22(
+  _FakeNativeImplementations_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -300,8 +312,8 @@ class _FakeNativeImplementations_22 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_23 extends _i1.SmartFake implements Duration {
-  _FakeDuration_23(
+class _FakeDuration_24 extends _i1.SmartFake implements Duration {
+  _FakeDuration_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -310,9 +322,9 @@ class _FakeDuration_23 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_24 extends _i1.SmartFake
+class _FakePushruleEvaluator_25 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_24(
+  _FakePushruleEvaluator_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -321,8 +333,8 @@ class _FakePushruleEvaluator_24 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_25 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_25(
+class _FakeProfile_26 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -331,8 +343,8 @@ class _FakeProfile_25 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_26 extends _i1.SmartFake implements _i15.Client {
-  _FakeClient_26(
+class _FakeClient_27 extends _i1.SmartFake implements _i16.Client {
+  _FakeClient_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -341,9 +353,9 @@ class _FakeClient_26 extends _i1.SmartFake implements _i15.Client {
         );
 }
 
-class _FakeDiscoveryInformation_27 extends _i1.SmartFake
+class _FakeDiscoveryInformation_28 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_27(
+  _FakeDiscoveryInformation_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -352,9 +364,9 @@ class _FakeDiscoveryInformation_27 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_28 extends _i1.SmartFake
+class _FakeGetVersionsResponse_29 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_28(
+  _FakeGetVersionsResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -363,9 +375,9 @@ class _FakeGetVersionsResponse_28 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_29 extends _i1.SmartFake
+class _FakeRegisterResponse_30 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_29(
+  _FakeRegisterResponse_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -374,8 +386,8 @@ class _FakeRegisterResponse_29 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_30 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_30(
+class _FakeLoginResponse_31 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -384,9 +396,9 @@ class _FakeLoginResponse_30 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_31 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_32 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_31(
+  _FakeGetAuthMetadataResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -395,8 +407,8 @@ class _FakeGetAuthMetadataResponse_31 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_32<T1> extends _i1.SmartFake implements _i16.Future<T1> {
-  _FakeFuture_32(
+class _FakeFuture_33<T1> extends _i1.SmartFake implements _i17.Future<T1> {
+  _FakeFuture_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -405,9 +417,9 @@ class _FakeFuture_32<T1> extends _i1.SmartFake implements _i16.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_33 extends _i1.SmartFake
+class _FakeCachedProfileInformation_34 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_33(
+  _FakeCachedProfileInformation_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -416,8 +428,8 @@ class _FakeCachedProfileInformation_33 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_34 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_34(
+class _FakeMediaConfig_35 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -426,8 +438,8 @@ class _FakeMediaConfig_34 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_35 extends _i1.SmartFake implements _i17.FileResponse {
-  _FakeFileResponse_35(
+class _FakeFileResponse_36 extends _i1.SmartFake implements _i18.FileResponse {
+  _FakeFileResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -436,8 +448,8 @@ class _FakeFileResponse_35 extends _i1.SmartFake implements _i17.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_36 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_36(
+class _FakePreviewForUrl_37 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -446,9 +458,9 @@ class _FakePreviewForUrl_36 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_37 extends _i1.SmartFake
+class _FakeCachedPresence_38 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_37(
+  _FakeCachedPresence_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -457,9 +469,9 @@ class _FakeCachedPresence_37 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_38 extends _i1.SmartFake
+class _FakeTurnServerCredentials_39 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_38(
+  _FakeTurnServerCredentials_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -468,9 +480,9 @@ class _FakeTurnServerCredentials_38 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_39 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_40 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_39(
+  _FakeRoomKeysUpdateResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -479,8 +491,8 @@ class _FakeRoomKeysUpdateResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_40 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_40(
+class _FakeKeyBackupData_41 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -489,9 +501,9 @@ class _FakeKeyBackupData_40 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_41 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_42 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_41(
+  _FakeGetWellknownSupportResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -500,9 +512,9 @@ class _FakeGetWellknownSupportResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_42 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_43 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_42(
+  _FakeGenerateLoginTokenResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -511,9 +523,9 @@ class _FakeGenerateLoginTokenResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_43 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_44 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_43(
+  _FakeGetRoomSummaryResponse$3_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -522,9 +534,9 @@ class _FakeGetRoomSummaryResponse$3_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_44 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_45 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_44(
+  _FakeGetSpaceHierarchyResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -533,9 +545,9 @@ class _FakeGetSpaceHierarchyResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_45 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_46 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_45(
+  _FakeGetRelatingEventsResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -544,9 +556,9 @@ class _FakeGetRelatingEventsResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_46 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_47 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_46(
+  _FakeGetRelatingEventsWithRelTypeResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -555,9 +567,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -566,9 +578,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_48 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_49 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_48(
+  _FakeGetThreadRootsResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -577,9 +589,9 @@ class _FakeGetThreadRootsResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_49 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_50 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_49(
+  _FakeGetEventByTimestampResponse_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -588,9 +600,9 @@ class _FakeGetEventByTimestampResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_50 extends _i1.SmartFake
+class _FakeRequestTokenResponse_51 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_50(
+  _FakeRequestTokenResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -599,9 +611,9 @@ class _FakeRequestTokenResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_51 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_52 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_51(
+  _FakeTokenOwnerInfo_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -610,8 +622,8 @@ class _FakeTokenOwnerInfo_51 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_52 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_52(
+class _FakeWhoIsInfo_53 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -620,8 +632,8 @@ class _FakeWhoIsInfo_52 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_53 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_53(
+class _FakeCapabilities_54 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -630,8 +642,8 @@ class _FakeCapabilities_53 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_54 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_54(
+class _FakeDevice_55 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -640,9 +652,9 @@ class _FakeDevice_54 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_55 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_56 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_55(
+  _FakeGetRoomIdByAliasResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -651,9 +663,9 @@ class _FakeGetRoomIdByAliasResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_56 extends _i1.SmartFake
+class _FakeGetEventsResponse_57 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_56(
+  _FakeGetEventsResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -662,9 +674,9 @@ class _FakeGetEventsResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_57 extends _i1.SmartFake
+class _FakePeekEventsResponse_58 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_57(
+  _FakePeekEventsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -673,8 +685,8 @@ class _FakePeekEventsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_58 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_58(
+class _FakeMatrixEvent_59 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -683,9 +695,9 @@ class _FakeMatrixEvent_58 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_59 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_60 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_59(
+  _FakeGetKeysChangesResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -694,9 +706,9 @@ class _FakeGetKeysChangesResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_60 extends _i1.SmartFake
+class _FakeClaimKeysResponse_61 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_60(
+  _FakeClaimKeysResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -705,9 +717,9 @@ class _FakeClaimKeysResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_61 extends _i1.SmartFake
+class _FakeQueryKeysResponse_62 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_61(
+  _FakeQueryKeysResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -716,9 +728,9 @@ class _FakeQueryKeysResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_62 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_63 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_62(
+  _FakeGetNotificationsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -727,9 +739,9 @@ class _FakeGetNotificationsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_63 extends _i1.SmartFake
+class _FakeGetPresenceResponse_64 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_63(
+  _FakeGetPresenceResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -738,9 +750,9 @@ class _FakeGetPresenceResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_64 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_65 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_64(
+  _FakeGetPublicRoomsResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -749,9 +761,9 @@ class _FakeGetPublicRoomsResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_65 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_66 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_65(
+  _FakeQueryPublicRoomsResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -760,8 +772,8 @@ class _FakeQueryPublicRoomsResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_66 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_66(
+class _FakePushRuleSet_67 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -770,9 +782,9 @@ class _FakePushRuleSet_66 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_67 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_68 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_67(
+  _FakeGetPushRulesGlobalResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -781,8 +793,8 @@ class _FakeGetPushRulesGlobalResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_68 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_68(
+class _FakePushRule_69 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -791,9 +803,9 @@ class _FakePushRule_68 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_69 extends _i1.SmartFake
+class _FakeRefreshResponse_70 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_69(
+  _FakeRefreshResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -802,8 +814,8 @@ class _FakeRefreshResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_70 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_70(
+class _FakeRoomKeys_71 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -812,8 +824,8 @@ class _FakeRoomKeys_70 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_71 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_71(
+class _FakeRoomKeyBackup_72 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -822,9 +834,9 @@ class _FakeRoomKeyBackup_71 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_72 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_73 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_72(
+  _FakeGetRoomKeysVersionCurrentResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -833,9 +845,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_73 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_74 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_73(
+  _FakeGetRoomKeysVersionResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -844,8 +856,8 @@ class _FakeGetRoomKeysVersionResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_74 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_74(
+class _FakeEventContext_75 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -854,9 +866,9 @@ class _FakeEventContext_74 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_75 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_76 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_75(
+  _FakeGetRoomEventsResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -865,8 +877,8 @@ class _FakeGetRoomEventsResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_76 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_76(
+class _FakeSearchResults_77 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -875,9 +887,9 @@ class _FakeSearchResults_76 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_77 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_78 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_77(
+  _FakeGetProtocolMetadataResponse$2_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -886,9 +898,9 @@ class _FakeGetProtocolMetadataResponse$2_77 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_78 extends _i1.SmartFake
+class _FakeOpenIdCredentials_79 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_78(
+  _FakeOpenIdCredentials_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -897,9 +909,9 @@ class _FakeOpenIdCredentials_78 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_79 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_80 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_79(
+  _FakeSearchUserDirectoryResponse_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -908,9 +920,9 @@ class _FakeSearchUserDirectoryResponse_79 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_80 extends _i1.SmartFake
+class _FakeCreateContentResponse_81 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_80(
+  _FakeCreateContentResponse_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -919,8 +931,8 @@ class _FakeCreateContentResponse_80 extends _i1.SmartFake
         );
 }
 
-class _FakeRoom_81 extends _i1.SmartFake implements _i4.Room {
-  _FakeRoom_81(
+class _FakeRoom_82 extends _i1.SmartFake implements _i4.Room {
+  _FakeRoom_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -929,8 +941,8 @@ class _FakeRoom_81 extends _i1.SmartFake implements _i4.Room {
         );
 }
 
-class _FakeMatrixFile_82 extends _i1.SmartFake implements _i4.MatrixFile {
-  _FakeMatrixFile_82(
+class _FakeMatrixFile_83 extends _i1.SmartFake implements _i4.MatrixFile {
+  _FakeMatrixFile_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -939,8 +951,8 @@ class _FakeMatrixFile_82 extends _i1.SmartFake implements _i4.MatrixFile {
         );
 }
 
-class _FakeEvent_83 extends _i1.SmartFake implements _i4.Event {
-  _FakeEvent_83(
+class _FakeEvent_84 extends _i1.SmartFake implements _i4.Event {
+  _FakeEvent_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -949,8 +961,8 @@ class _FakeEvent_83 extends _i1.SmartFake implements _i4.Event {
         );
 }
 
-class _FakeResponse_84 extends _i1.SmartFake implements _i15.Response {
-  _FakeResponse_84(
+class _FakeResponse_85 extends _i1.SmartFake implements _i16.Response {
+  _FakeResponse_85(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -962,7 +974,7 @@ class _FakeResponse_84 extends _i1.SmartFake implements _i15.Response {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -992,11 +1004,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1134,17 +1146,30 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i12.OutboxService);
 
   @override
-  _i13.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i13.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_11(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i13.AvatarResolver);
+
+  @override
+  _i14.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_11(
+        returnValue: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_11(
+        returnValueForMissingStub: _FakeStickerPackService_12(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i13.StickerPackService);
+      ) as _i14.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1253,7 +1278,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set stickerPacks(_i13.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i13.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i14.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -1269,14 +1303,14 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  _i16.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i17.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1306,7 +1340,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1316,18 +1350,18 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i17.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<bool> login({
+  _i17.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1344,12 +1378,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> completeSsoLogin({
+  _i17.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1362,12 +1396,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> completeRegistration(
+  _i17.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1377,32 +1411,32 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> logout() => (super.noSuchMethod(
+  _i17.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i17.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1411,7 +1445,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1420,17 +1454,17 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i17.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1441,7 +1475,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1478,26 +1512,26 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i17.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+  _i17.Future<bool> didPushRouteInformation(
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1527,7 +1561,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1536,7 +1570,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1545,16 +1579,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i16.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i17.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i16.Future<_i20.AppExitResponse>);
+            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i17.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1582,11 +1616,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1616,11 +1650,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_12(
+        returnValue: _FakeRoomSummary_13(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_12(
+        returnValueForMissingStub: _FakeRoomSummary_13(
           this,
           Invocation.getter(#summary),
         ),
@@ -1650,11 +1684,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i16.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i17.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i16.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i16.Completer<dynamic>>[],
-      ) as List<_i16.Completer<dynamic>>);
+        returnValue: <_i17.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i17.Completer<dynamic>>[],
+      ) as List<_i17.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1673,51 +1707,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i14.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i15.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i14.CachedStreamController<String> get onSessionKeyReceived =>
+  _i15.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1733,11 +1767,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1746,11 +1780,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1793,11 +1827,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1806,11 +1840,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_14(
+        returnValue: _FakeDateTime_15(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_14(
+        returnValueForMissingStub: _FakeDateTime_15(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1840,11 +1874,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_15(
+        returnValue: _FakeLatestReceiptState_16(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_15(
+        returnValueForMissingStub: _FakeLatestReceiptState_16(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1865,18 +1899,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i16.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i17.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -2063,18 +2097,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -2187,14 +2221,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i16.Future<void> postLoad() => (super.noSuchMethod(
+  _i17.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2222,15 +2256,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i16.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i17.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i16.Future<List<_i4.User>>);
+            _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i17.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2241,14 +2275,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2258,18 +2292,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i16.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i17.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Event?> refreshLastEvent(
+  _i17.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2277,9 +2311,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2291,12 +2325,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i16.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i17.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2304,22 +2338,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i17.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2327,17 +2361,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> addTag(
+  _i17.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2347,27 +2381,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i17.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i17.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2375,53 +2409,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i17.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i17.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+  _i17.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
         Invocation.method(
           #setLowPriority,
           [lowPriority],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i17.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2429,14 +2463,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2448,7 +2482,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i16.Future<String?> sendTextEvent(
+  _i17.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2480,12 +2514,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendReaction(
+  _i17.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2499,12 +2533,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendLocation(
+  _i17.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2518,12 +2552,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> sendFileEvent(
+  _i17.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2551,25 +2585,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i17.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i16.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i17.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i16.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i17.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i16.Future<_i4.EncryptionHealthState>);
+      ) as _i17.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i16.Future<String?> sendEvent(
+  _i17.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2593,73 +2627,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i17.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leave() => (super.noSuchMethod(
+  _i17.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> forget() => (super.noSuchMethod(
+  _i17.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> setPower(
+  _i17.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2671,7 +2705,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2682,7 +2716,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2692,10 +2726,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> invite(
+  _i17.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2705,12 +2739,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<int> requestHistory({
+  _i17.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2727,32 +2761,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
-  _i16.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i17.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i17.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setReadMarker(
+  _i17.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2766,23 +2800,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
+  _i17.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i16.Future<_i24.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i16.Future<_i24.TimelineChunk?>.value(),
-      ) as _i16.Future<_i24.TimelineChunk?>);
+        returnValue: _i17.Future<_i25.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i17.Future<_i25.TimelineChunk?>.value(),
+      ) as _i17.Future<_i25.TimelineChunk?>);
 
   @override
-  _i16.Future<void> postReceipt(
+  _i17.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2792,12 +2826,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Timeline> getTimeline({
+  _i17.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2820,7 +2854,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i16.Future<_i4.Timeline>.value(_FakeTimeline_17(
+        returnValue: _i17.Future<_i4.Timeline>.value(_FakeTimeline_18(
           this,
           Invocation.method(
             #getTimeline,
@@ -2837,7 +2871,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Timeline>.value(_FakeTimeline_17(
+            _i17.Future<_i4.Timeline>.value(_FakeTimeline_18(
           this,
           Invocation.method(
             #getTimeline,
@@ -2853,7 +2887,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Timeline>);
+      ) as _i17.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2872,7 +2906,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i16.Future<List<_i4.User>> requestParticipants([
+  _i17.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2890,10 +2924,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i16.Future<List<_i4.User>>);
+            _i17.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i17.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2901,14 +2935,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_18(
+        returnValue: _FakeUser_19(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_18(
+        returnValueForMissingStub: _FakeUser_19(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2924,14 +2958,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_18(
+        returnValue: _FakeUser_19(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_18(
+        returnValueForMissingStub: _FakeUser_19(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2941,7 +2975,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i16.Future<_i4.User?> requestUser(
+  _i17.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2957,19 +2991,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i16.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.User?>.value(),
-      ) as _i16.Future<_i4.User?>);
+        returnValue: _i17.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.User?>.value(),
+      ) as _i17.Future<_i4.User?>);
 
   @override
-  _i16.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i17.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2982,12 +3016,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i16.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i17.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2995,14 +3029,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -3025,14 +3059,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i16.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i17.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -3071,18 +3105,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i16.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i17.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEvent(
+  _i17.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -3096,12 +3130,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> setTyping(
+  _i17.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -3111,12 +3145,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setJoinRules(
+  _i17.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -3130,59 +3164,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i17.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setHistoryVisibility(
+  _i17.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i17.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i17.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i16.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i17.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i16.Future<List<_i4.DeviceKeys>>);
+            _i17.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i17.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i16.Future<void> requestSessionKey(
+  _i17.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3194,12 +3228,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setSpaceChild(
+  _i17.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3215,44 +3249,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i17.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValue: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i16.Future<Uri>);
+      ) as _i17.Future<Uri>);
 
   @override
-  _i16.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<
+  _i17.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3279,21 +3313,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i16.Future<
+        returnValue: _i17.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i16.Future<
+        returnValueForMissingStub: _i17.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i16.Future<
+      ) as _i17.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3308,23 +3342,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_20(
+        returnValue: _FakeDatabaseApi_21(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_20(
+        returnValueForMissingStub: _FakeDatabaseApi_21(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i25.KeyVerificationMethod> get verificationMethods =>
+  Set<_i26.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i25.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i25.KeyVerificationMethod>{},
-      ) as Set<_i25.KeyVerificationMethod>);
+        returnValue: <_i26.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i26.KeyVerificationMethod>{},
+      ) as Set<_i26.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3385,11 +3419,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_21(
+        returnValue: _FakeFilter_22(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_21(
+        returnValueForMissingStub: _FakeFilter_22(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3398,11 +3432,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_22(
+        returnValue: _FakeNativeImplementations_23(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_22(
+        returnValueForMissingStub: _FakeNativeImplementations_23(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3418,11 +3452,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_23(
+        returnValue: _FakeDuration_24(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_23(
+        returnValueForMissingStub: _FakeDuration_24(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3431,11 +3465,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_23(
+        returnValue: _FakeDuration_24(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_23(
+        returnValueForMissingStub: _FakeDuration_24(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3444,11 +3478,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3485,11 +3519,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3519,11 +3553,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3532,11 +3566,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3559,11 +3593,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_24(
+        returnValue: _FakePushruleEvaluator_25(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_24(
+        returnValueForMissingStub: _FakePushruleEvaluator_25(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3584,332 +3618,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i16.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i17.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i14.CachedStreamController<String> get onUserProfileUpdate =>
+  _i15.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i16.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i17.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i16.Future<List<_i4.Room>>);
+            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i17.Future<List<_i4.Room>>);
 
   @override
-  _i14.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i15.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.EventUpdate>(
+            _FakeCachedStreamController_14<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.EventUpdate>);
+      ) as _i15.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i15.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i15.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onNotification =>
+  _i15.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i15.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_13<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i14.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i15.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i14.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i15.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_13<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_13<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i14.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i15.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i14.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i15.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_13<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_14<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.LoginState>(
+            _FakeCachedStreamController_14<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i14.CachedStreamController<_i4.LoginState>);
+      ) as _i15.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i14.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i15.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_13<bool>(
+        returnValue: _FakeCachedStreamController_14<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i14.CachedStreamController<bool>);
+      ) as _i15.CachedStreamController<bool>);
 
   @override
-  _i14.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i15.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_13<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_14<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i14.CachedStreamController<_i4.SdkError>);
+      ) as _i15.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i14.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i15.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_13<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.SyncUpdate>(
+            _FakeCachedStreamController_14<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i14.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i15.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i15.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_13<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i14.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i15.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i14.CachedStreamController<_i4.Presence> get onPresence =>
+  _i15.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_13<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_14<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i14.CachedStreamController<_i4.Presence>);
+      ) as _i15.CachedStreamController<_i4.Presence>);
 
   @override
-  _i14.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i15.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_13<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_14<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.CachedPresence>(
+            _FakeCachedStreamController_14<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i14.CachedStreamController<_i4.CachedPresence>);
+      ) as _i15.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i14.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i15.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_13<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_14<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.BasicEvent>(
+            _FakeCachedStreamController_14<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i14.CachedStreamController<_i4.BasicEvent>);
+      ) as _i15.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i14.CachedStreamController<_i25.RoomKeyRequest> get onRoomKeyRequest =>
+  _i15.CachedStreamController<_i26.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_13<_i25.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_14<_i26.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i25.RoomKeyRequest>(
+            _FakeCachedStreamController_14<_i26.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i14.CachedStreamController<_i25.RoomKeyRequest>);
+      ) as _i15.CachedStreamController<_i26.RoomKeyRequest>);
 
   @override
-  _i14.CachedStreamController<_i25.KeyVerification>
+  _i15.CachedStreamController<_i26.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_13<_i25.KeyVerification>(
+            returnValue: _FakeCachedStreamController_14<_i26.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_13<_i25.KeyVerification>(
+                _FakeCachedStreamController_14<_i26.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i14.CachedStreamController<_i25.KeyVerification>);
+          ) as _i15.CachedStreamController<_i26.KeyVerification>);
 
   @override
-  _i14.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i15.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_13<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i14.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i15.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i14.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i15.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_13<_i4.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i14.CachedStreamController<_i4.Event>);
+      ) as _i15.CachedStreamController<_i4.Event>);
 
   @override
-  _i14.CachedStreamController<String> get onCancelSendEvent =>
+  _i15.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i14.CachedStreamController<String>);
+      ) as _i15.CachedStreamController<String>);
 
   @override
-  _i14.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i15.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_13<
+            returnValue: _FakeCachedStreamController_14<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_13<
+            returnValueForMissingStub: _FakeCachedStreamController_14<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i14.CachedStreamController<
+          ) as _i15.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3929,11 +3963,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_14(
+        returnValue: _FakeDateTime_15(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_14(
+        returnValueForMissingStub: _FakeDateTime_15(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -4006,7 +4040,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i25.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i26.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -4061,7 +4095,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i16.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i17.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -4072,7 +4106,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i16.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i17.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -4183,7 +4217,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4192,7 +4226,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4201,7 +4235,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i16.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i17.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4228,20 +4262,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i15.Client get httpClient => (super.noSuchMethod(
+  _i16.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_26(
+        returnValue: _FakeClient_27(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_26(
+        returnValueForMissingStub: _FakeClient_27(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i15.Client);
+      ) as _i16.Client);
 
   @override
-  set httpClient(_i15.Client? value) => super.noSuchMethod(
+  set httpClient(_i16.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4268,7 +4302,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<void> refreshAccessToken(
+  _i17.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4276,9 +4310,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4296,14 +4330,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4340,33 +4374,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i16.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i17.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i16.Future<_i4.DiscoveryInformation>);
+      ) as _i17.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i16.Future<
+  _i17.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4388,7 +4422,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i16.Future<
+        returnValue: _i17.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4396,7 +4430,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_28(
+          _FakeGetVersionsResponse_29(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4411,7 +4445,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i16.Future<
+        returnValueForMissingStub: _i17.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4419,7 +4453,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_28(
+          _FakeGetVersionsResponse_29(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4434,7 +4468,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i16.Future<
+      ) as _i17.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4443,7 +4477,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i16.Future<_i4.DiscoveryInformation> getWellknown({
+  _i17.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4456,8 +4490,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValue: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getWellknown,
@@ -4468,8 +4502,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_27(
+        returnValueForMissingStub: _i17.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_28(
           this,
           Invocation.method(
             #getWellknown,
@@ -4480,10 +4514,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.DiscoveryInformation>);
+      ) as _i17.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i16.Future<_i4.RegisterResponse> register({
+  _i17.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4511,7 +4545,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_29(
+            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_30(
           this,
           Invocation.method(
             #register,
@@ -4530,7 +4564,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_29(
+            _i17.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_30(
           this,
           Invocation.method(
             #register,
@@ -4548,10 +4582,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RegisterResponse>);
+      ) as _i17.Future<_i4.RegisterResponse>);
 
   @override
-  _i16.Future<_i4.LoginResponse> login(
+  _i17.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4581,7 +4615,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_30(
+        returnValue: _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_31(
           this,
           Invocation.method(
             #login,
@@ -4601,7 +4635,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_30(
+            _i17.Future<_i4.LoginResponse>.value(_FakeLoginResponse_31(
           this,
           Invocation.method(
             #login,
@@ -4620,10 +4654,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.LoginResponse>);
+      ) as _i17.Future<_i4.LoginResponse>);
 
   @override
-  _i16.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i17.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4636,8 +4670,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_31(
+        returnValue: _i17.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_32(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4649,8 +4683,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_31(
+            _i17.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_32(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4661,74 +4695,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i17.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i16.Future<void> logout() => (super.noSuchMethod(
+  _i17.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> logoutAll() => (super.noSuchMethod(
+  _i17.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<T> uiaRequestBackground<T>(
-          _i16.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i17.Future<T> uiaRequestBackground<T>(
+          _i17.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i16.Future<T>.value(v),
+              (T v) => _i17.Future<T>.value(v),
             ) ??
-            _FakeFuture_32<T>(
+            _FakeFuture_33<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i16.Future<T>.value(v),
+              (T v) => _i17.Future<T>.value(v),
             ) ??
-            _FakeFuture_32<T>(
+            _FakeFuture_33<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i16.Future<T>);
+      ) as _i17.Future<T>);
 
   @override
-  _i16.Future<String> startDirectChat(
+  _i17.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4750,7 +4784,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4766,7 +4800,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4781,10 +4815,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<String> createGroupChat({
+  _i17.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4815,7 +4849,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4836,7 +4870,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4856,10 +4890,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i17.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4875,7 +4909,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4888,7 +4922,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4900,21 +4934,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i17.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<String> createSpace({
+  _i17.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4939,7 +4973,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4957,7 +4991,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4974,10 +5008,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i17.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4985,7 +5019,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4994,7 +5028,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -5002,10 +5036,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i16.Future<_i4.Profile> fetchOwnProfile({
+  _i17.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -5018,7 +5052,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -5030,7 +5064,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -5041,10 +5075,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
-  _i16.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i17.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -5058,8 +5092,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i16.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_33(
+        returnValue: _i17.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_34(
           this,
           Invocation.method(
             #getUserProfile,
@@ -5071,8 +5105,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_33(
+            _i17.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_34(
           this,
           Invocation.method(
             #getUserProfile,
@@ -5083,10 +5117,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.CachedProfileInformation>);
+      ) as _i17.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i16.Future<_i4.Profile> getProfileFromUserId(
+  _i17.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -5104,7 +5138,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+        returnValue: _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5118,7 +5152,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Profile>.value(_FakeProfile_25(
+            _i17.Future<_i4.Profile>.value(_FakeProfile_26(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5131,7 +5165,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.Profile>);
+      ) as _i17.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -5153,31 +5187,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i16.Future<List<_i4.Room>>);
+            _i17.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i17.Future<List<_i4.Room>>);
 
   @override
-  _i16.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i17.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i16.Future<List<_i4.ArchivedRoom>>);
+            _i17.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i17.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i16.Future<_i4.GetVersionsResponse> getVersions({
+  _i17.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5190,8 +5224,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_28(
+        returnValue: _i17.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_29(
           this,
           Invocation.method(
             #getVersions,
@@ -5202,8 +5236,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_28(
+        returnValueForMissingStub: _i17.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_29(
           this,
           Invocation.method(
             #getVersions,
@@ -5214,20 +5248,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetVersionsResponse>);
+      ) as _i17.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i16.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i17.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.MediaConfig> getConfig({
+  _i17.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5240,7 +5274,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfig,
@@ -5252,7 +5286,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfig,
@@ -5263,10 +5297,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.MediaConfig>);
+      ) as _i17.Future<_i4.MediaConfig>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContent(
+  _i17.Future<_i18.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5286,7 +5320,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContent,
@@ -5302,7 +5336,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContent,
@@ -5317,10 +5351,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentOverrideName(
+  _i17.Future<_i18.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5342,7 +5376,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5359,7 +5393,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5375,10 +5409,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentThumbnail(
+  _i17.Future<_i18.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5406,7 +5440,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5426,7 +5460,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5445,10 +5479,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i17.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5458,7 +5492,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5467,7 +5501,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5475,11 +5509,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i16.Future<_i4.PreviewForUrl>);
+      ) as _i17.Future<_i4.PreviewForUrl>);
 
   @override
-  _i16.Future<Uri> uploadContent(
-    _i26.Uint8List? file, {
+  _i17.Future<Uri> uploadContent(
+    _i27.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5492,7 +5526,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValue: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #uploadContent,
@@ -5503,7 +5537,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_19(
+        returnValueForMissingStub: _i17.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #uploadContent,
@@ -5514,10 +5548,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<Uri>);
+      ) as _i17.Future<Uri>);
 
   @override
-  _i16.Future<void> setTyping(
+  _i17.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5533,42 +5567,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> exportDump() => (super.noSuchMethod(
+  _i17.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i17.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i17.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Event?> getEventByPushNotification(
+  _i17.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5584,12 +5618,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
-  _i16.Future<void> init({
+  _i17.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5624,9 +5658,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5638,40 +5672,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i16.Future<void> clear() => (super.noSuchMethod(
+  _i17.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i17.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ensureNotSoftLoggedOut(
+  _i17.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> handleSync(
+  _i17.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5681,9 +5715,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5696,29 +5730,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i16.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i17.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i17.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDevice(
+  _i17.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5732,12 +5766,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDevicesOfUserIds(
+  _i17.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5753,12 +5787,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDeviceEncrypted(
+  _i17.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5778,12 +5812,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> sendToDeviceEncryptedChunked(
+  _i17.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5797,23 +5831,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i17.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> joinRoom(
+  _i17.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5831,7 +5865,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5845,7 +5879,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5858,10 +5892,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> changePassword(
+  _i17.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5877,22 +5911,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> clearCache() => (super.noSuchMethod(
+  _i17.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ignoreUser(
+  _i17.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5902,22 +5936,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i17.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i17.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5928,7 +5962,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_37(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_38(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5937,7 +5971,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_37(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_38(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5945,32 +5979,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i16.Future<_i4.CachedPresence>);
+      ) as _i17.Future<_i4.CachedPresence>);
 
   @override
-  _i16.Future<void> abortSync() => (super.noSuchMethod(
+  _i17.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i17.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEventWithMetadata(
+  _i17.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5990,14 +6024,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i15.BaseResponse? response,
-    _i26.Uint8List? body,
+    _i16.BaseResponse? response,
+    _i27.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6029,7 +6063,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i16.Future<Map<String, Object?>> request(
+  _i17.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -6050,13 +6084,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> postPusher(
+  _i17.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -6066,57 +6100,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i17.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i17.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i17.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i16.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_38(
+        returnValue: _i17.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_39(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_38(
+        returnValueForMissingStub: _i17.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_39(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.TurnServerCredentials>);
+      ) as _i17.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6130,8 +6164,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6143,8 +6177,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6155,10 +6189,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6174,8 +6208,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6188,8 +6222,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6201,10 +6235,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i17.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6218,7 +6252,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6230,7 +6264,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6241,17 +6275,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.KeyBackupData>);
+      ) as _i17.Future<_i4.KeyBackupData>);
 
   @override
-  _i16.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i17.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i16.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_41(
+        returnValue: _i17.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_42(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6259,18 +6293,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_41(
+            _i17.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_42(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i17.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i16.Future<int> pingAppservice(
+  _i17.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6280,12 +6314,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i16.Future<int>.value(0),
-        returnValueForMissingStub: _i16.Future<int>.value(0),
-      ) as _i16.Future<int>);
+        returnValue: _i17.Future<int>.value(0),
+        returnValueForMissingStub: _i17.Future<int>.value(0),
+      ) as _i17.Future<int>);
 
   @override
-  _i16.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i17.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6293,8 +6327,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_42(
+        returnValue: _i17.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_43(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6303,8 +6337,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_42(
+            _i17.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_43(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6312,15 +6346,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i16.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i17.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i16.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i17.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+        returnValue: _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6328,17 +6362,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_34(
+            _i17.Future<_i4.MediaConfig>.value(_FakeMediaConfig_35(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.MediaConfig>);
+      ) as _i17.Future<_i4.MediaConfig>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentAuthed(
+  _i17.Future<_i18.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6352,7 +6386,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6364,7 +6398,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6375,10 +6409,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentOverrideNameAuthed(
+  _i17.Future<_i18.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6394,7 +6428,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6407,7 +6441,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6419,10 +6453,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i17.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6432,7 +6466,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+        returnValue: _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6441,7 +6475,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_36(
+            _i17.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_37(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6449,10 +6483,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i16.Future<_i4.PreviewForUrl>);
+      ) as _i17.Future<_i4.PreviewForUrl>);
 
   @override
-  _i16.Future<_i17.FileResponse> getContentThumbnailAuthed(
+  _i17.Future<_i18.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6476,7 +6510,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+        returnValue: _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6494,7 +6528,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_35(
+            _i17.Future<_i18.FileResponse>.value(_FakeFileResponse_36(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6511,21 +6545,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i17.FileResponse>);
+      ) as _i17.Future<_i18.FileResponse>);
 
   @override
-  _i16.Future<bool> registrationTokenValidity(String? token) =>
+  _i17.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i17.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6535,8 +6569,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_43(
+        returnValue: _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_44(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6545,8 +6579,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_43(
+            _i17.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_44(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6554,10 +6588,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i17.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i16.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i17.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6575,8 +6609,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_44(
+        returnValue: _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_45(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6590,8 +6624,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_44(
+            _i17.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_45(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6604,10 +6638,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i17.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i17.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6631,8 +6665,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i16.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_45(
+        returnValue: _i17.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_46(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6650,8 +6684,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_45(
+            _i17.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_46(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6668,10 +6702,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i17.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6699,8 +6733,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_46(
+                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_47(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6719,8 +6753,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_46(
+                _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_47(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6738,10 +6772,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i17.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i16.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i17.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6770,9 +6804,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i16.Future<
+            returnValue: _i17.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6791,9 +6825,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i16.Future<
+            returnValueForMissingStub: _i17.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_47(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_48(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6812,11 +6846,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i16
+          ) as _i17
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i16.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i17.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6832,8 +6866,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i16.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_48(
+        returnValue: _i17.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_49(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6846,8 +6880,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_48(
+            _i17.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_49(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6859,10 +6893,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetThreadRootsResponse>);
+      ) as _i17.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i16.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i17.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6876,8 +6910,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i16.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_49(
+        returnValue: _i17.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_50(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6889,8 +6923,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_49(
+            _i17.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_50(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6901,33 +6935,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i17.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i17.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i16.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i17.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i17.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i16.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i17.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i16.Future<Uri?>.value(),
-        returnValueForMissingStub: _i16.Future<Uri?>.value(),
-      ) as _i16.Future<Uri?>);
+        returnValue: _i17.Future<Uri?>.value(),
+        returnValueForMissingStub: _i17.Future<Uri?>.value(),
+      ) as _i17.Future<Uri?>);
 
   @override
-  _i16.Future<void> add3PID(
+  _i17.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6941,12 +6975,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> bind3PID(
+  _i17.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6962,12 +6996,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i17.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6981,14 +7015,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7010,8 +7044,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -7027,8 +7061,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -7044,10 +7078,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7071,8 +7105,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -7089,8 +7123,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -7107,10 +7141,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i17.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -7124,14 +7158,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i17.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -7146,14 +7180,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i17.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i16.Future<_i4.IdServerUnbindResult>);
+      ) as _i17.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7175,8 +7209,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7192,8 +7226,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7209,10 +7243,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7236,8 +7270,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7254,8 +7288,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7272,16 +7306,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i17.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_51(
+            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_52(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7289,22 +7323,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_51(
+            _i17.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_52(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.TokenOwnerInfo>);
+      ) as _i17.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i16.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i17.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_52(
+        returnValue: _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_53(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7312,22 +7346,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_52(
+            _i17.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_53(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i16.Future<_i4.WhoIsInfo>);
+      ) as _i17.Future<_i4.WhoIsInfo>);
 
   @override
-  _i16.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i17.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_53(
+        returnValue: _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_54(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7335,17 +7369,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_53(
+            _i17.Future<_i4.Capabilities>.value(_FakeCapabilities_54(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.Capabilities>);
+      ) as _i17.Future<_i4.Capabilities>);
 
   @override
-  _i16.Future<String> createRoom({
+  _i17.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7378,7 +7412,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7400,7 +7434,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7421,10 +7455,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> deleteDevices(
+  _i17.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7434,22 +7468,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.Device>?>.value(),
-      ) as _i16.Future<List<_i4.Device>?>);
+        returnValue: _i17.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.Device>?>.value(),
+      ) as _i17.Future<List<_i4.Device>?>);
 
   @override
-  _i16.Future<void> deleteDevice(
+  _i17.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7459,34 +7493,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i17.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i16.Future<_i4.Device>.value(_FakeDevice_54(
+        returnValue: _i17.Future<_i4.Device>.value(_FakeDevice_55(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.Device>.value(_FakeDevice_54(
+        returnValueForMissingStub: _i17.Future<_i4.Device>.value(_FakeDevice_55(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i16.Future<_i4.Device>);
+      ) as _i17.Future<_i4.Device>);
 
   @override
-  _i16.Future<void> updateDevice(
+  _i17.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7496,12 +7530,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i17.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7516,24 +7550,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i17.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i16.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Visibility?>.value(),
-      ) as _i16.Future<_i4.Visibility?>);
+        returnValue: _i17.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Visibility?>.value(),
+      ) as _i17.Future<_i4.Visibility?>);
 
   @override
-  _i16.Future<void> setRoomVisibilityOnDirectory(
+  _i17.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7543,30 +7577,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i17.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i17.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_55(
+        returnValue: _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_56(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7574,18 +7608,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_55(
+            _i17.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_56(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i17.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i16.Future<void> setRoomAlias(
+  _i17.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7597,12 +7631,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetEventsResponse> getEvents({
+  _i17.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7616,7 +7650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_56(
+            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_57(
           this,
           Invocation.method(
             #getEvents,
@@ -7628,7 +7662,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_56(
+            _i17.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_57(
           this,
           Invocation.method(
             #getEvents,
@@ -7639,10 +7673,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetEventsResponse>);
+      ) as _i17.Future<_i4.GetEventsResponse>);
 
   @override
-  _i16.Future<_i4.PeekEventsResponse> peekEvents({
+  _i17.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7657,8 +7691,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i16.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_57(
+        returnValue: _i17.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_58(
           this,
           Invocation.method(
             #peekEvents,
@@ -7670,8 +7704,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_57(
+        returnValueForMissingStub: _i17.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_58(
           this,
           Invocation.method(
             #peekEvents,
@@ -7683,16 +7717,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.PeekEventsResponse>);
+      ) as _i17.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i16.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i17.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7700,27 +7734,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i16.Future<_i4.MatrixEvent>);
+      ) as _i17.Future<_i4.MatrixEvent>);
 
   @override
-  _i16.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i17.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 
   @override
-  _i16.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i17.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7732,8 +7766,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i16.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_59(
+        returnValue: _i17.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_60(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7744,8 +7778,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_59(
+            _i17.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_60(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7755,10 +7789,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.GetKeysChangesResponse>);
+      ) as _i17.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i16.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i17.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7769,7 +7803,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_60(
+            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_61(
           this,
           Invocation.method(
             #claimKeys,
@@ -7778,7 +7812,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_60(
+            _i17.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_61(
           this,
           Invocation.method(
             #claimKeys,
@@ -7786,10 +7820,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i16.Future<_i4.ClaimKeysResponse>);
+      ) as _i17.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i16.Future<void> uploadCrossSigningKeys({
+  _i17.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7806,12 +7840,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.QueryKeysResponse> queryKeys(
+  _i17.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7822,7 +7856,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_61(
+            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_62(
           this,
           Invocation.method(
             #queryKeys,
@@ -7831,7 +7865,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_61(
+            _i17.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_62(
           this,
           Invocation.method(
             #queryKeys,
@@ -7839,10 +7873,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i16.Future<_i4.QueryKeysResponse>);
+      ) as _i17.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7850,14 +7884,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i16.Future<
+            returnValue: _i17.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i16.Future<
+            returnValueForMissingStub: _i17.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i17.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i16.Future<Map<String, int>> uploadKeys({
+  _i17.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7872,13 +7906,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i16.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i17.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i16.Future<Map<String, int>>);
+            _i17.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i17.Future<Map<String, int>>);
 
   @override
-  _i16.Future<String> knockRoom(
+  _i17.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7892,7 +7926,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7904,7 +7938,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7915,20 +7949,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i17.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i16.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i17.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i17.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i16.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i17.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7943,8 +7977,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i16.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_62(
+        returnValue: _i17.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_63(
           this,
           Invocation.method(
             #getNotifications,
@@ -7957,8 +7991,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_62(
+            _i17.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_63(
           this,
           Invocation.method(
             #getNotifications,
@@ -7970,35 +8004,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetNotificationsResponse>);
+      ) as _i17.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i16.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i17.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i16.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_63(
+        returnValue: _i17.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_64(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_63(
+        returnValueForMissingStub: _i17.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_64(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i16.Future<_i4.GetPresenceResponse>);
+      ) as _i17.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i16.Future<void> setPresence(
+  _i17.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -8012,12 +8046,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, Object?>> deleteProfileField(
+  _i17.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -8030,13 +8064,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getProfileField(
+  _i17.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -8049,13 +8083,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<Map<String, Object?>> setProfileField(
+  _i17.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -8070,13 +8104,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i17.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -8091,8 +8125,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i16.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_64(
+        returnValue: _i17.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_65(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -8105,8 +8139,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_64(
+            _i17.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_65(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -8118,10 +8152,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i17.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i16.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i17.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -8142,8 +8176,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i16.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_65(
+        returnValue: _i17.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_66(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8159,8 +8193,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_65(
+            _i17.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_66(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8175,25 +8209,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i17.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i16.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i17.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i16.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.Pusher>?>.value(),
-      ) as _i16.Future<List<_i4.Pusher>?>);
+        returnValue: _i17.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.Pusher>?>.value(),
+      ) as _i17.Future<List<_i4.Pusher>?>);
 
   @override
-  _i16.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i17.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_66(
+        returnValue: _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_67(
           this,
           Invocation.method(
             #getPushRules,
@@ -8201,24 +8235,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_66(
+            _i17.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_67(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.PushRuleSet>);
+      ) as _i17.Future<_i4.PushRuleSet>);
 
   @override
-  _i16.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i17.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_67(
+        returnValue: _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_68(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8226,18 +8260,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_67(
+            _i17.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_68(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i17.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i16.Future<void> deletePushRule(
+  _i17.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8249,12 +8283,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.PushRule> getPushRule(
+  _i17.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8266,7 +8300,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<_i4.PushRule>.value(_FakePushRule_68(
+        returnValue: _i17.Future<_i4.PushRule>.value(_FakePushRule_69(
           this,
           Invocation.method(
             #getPushRule,
@@ -8277,7 +8311,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.PushRule>.value(_FakePushRule_68(
+            _i17.Future<_i4.PushRule>.value(_FakePushRule_69(
           this,
           Invocation.method(
             #getPushRule,
@@ -8287,10 +8321,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.PushRule>);
+      ) as _i17.Future<_i4.PushRule>);
 
   @override
-  _i16.Future<void> setPushRule(
+  _i17.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8314,12 +8348,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<Object?>> getPushRuleActions(
+  _i17.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8331,13 +8365,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i17.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i16.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i16.Future<List<Object?>>);
+            _i17.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i17.Future<List<Object?>>);
 
   @override
-  _i16.Future<void> setPushRuleActions(
+  _i17.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8351,12 +8385,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<bool> isPushRuleEnabled(
+  _i17.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8368,12 +8402,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> setPushRuleEnabled(
+  _i17.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8387,19 +8421,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i17.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_69(
+            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_70(
           this,
           Invocation.method(
             #refresh,
@@ -8407,28 +8441,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_69(
+            _i17.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_70(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i16.Future<_i4.RefreshResponse>);
+      ) as _i17.Future<_i4.RefreshResponse>);
 
   @override
-  _i16.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i17.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i16.Future<bool?>.value(),
-        returnValueForMissingStub: _i16.Future<bool?>.value(),
-      ) as _i16.Future<bool?>);
+        returnValue: _i17.Future<bool?>.value(),
+        returnValueForMissingStub: _i17.Future<bool?>.value(),
+      ) as _i17.Future<bool?>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8450,8 +8484,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8467,8 +8501,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8484,10 +8518,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i17.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8511,8 +8545,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValue: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8529,8 +8563,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_50(
+        returnValueForMissingStub: _i17.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_51(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8547,17 +8581,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.RequestTokenResponse>);
+      ) as _i17.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8565,23 +8599,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i17.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_70(
+        returnValue: _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_71(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8589,17 +8623,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_70(
+            _i17.Future<_i4.RoomKeys>.value(_FakeRoomKeys_71(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeys>);
+      ) as _i17.Future<_i4.RoomKeys>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8611,8 +8645,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8623,8 +8657,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8634,10 +8668,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8649,8 +8683,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8661,8 +8695,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8672,10 +8706,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8687,7 +8721,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_71(
+        returnValue: _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_72(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8698,7 +8732,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_71(
+            _i17.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_72(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8708,10 +8742,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeyBackup>);
+      ) as _i17.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8725,8 +8759,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8738,8 +8772,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8750,10 +8784,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8767,8 +8801,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8780,8 +8814,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8792,10 +8826,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i17.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8809,7 +8843,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+        returnValue: _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8821,7 +8855,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_40(
+            _i17.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_41(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8832,10 +8866,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.KeyBackupData>);
+      ) as _i17.Future<_i4.KeyBackupData>);
 
   @override
-  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i17.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8851,8 +8885,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_39(
+        returnValue: _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8865,8 +8899,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_39(
+            _i17.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_40(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8878,18 +8912,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i17.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_72(
+                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_73(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8897,18 +8931,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_72(
+                _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_73(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i17.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i16.Future<String> postRoomKeysVersion(
+  _i17.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8920,7 +8954,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8931,7 +8965,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8941,29 +8975,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i17.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i17.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_73(
+        returnValue: _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_74(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8971,18 +9005,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_73(
+            _i17.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_74(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i17.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i17.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8997,24 +9031,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i17.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i16.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
-      ) as _i16.Future<List<String>>);
+        returnValue: _i17.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i17.Future<List<String>>.value(<String>[]),
+      ) as _i17.Future<List<String>>);
 
   @override
-  _i16.Future<void> ban(
+  _i17.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9028,12 +9062,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.EventContext> getEventContext(
+  _i17.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -9051,7 +9085,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<_i4.EventContext>.value(_FakeEventContext_74(
+        returnValue: _i17.Future<_i4.EventContext>.value(_FakeEventContext_75(
           this,
           Invocation.method(
             #getEventContext,
@@ -9066,7 +9100,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.EventContext>.value(_FakeEventContext_74(
+            _i17.Future<_i4.EventContext>.value(_FakeEventContext_75(
           this,
           Invocation.method(
             #getEventContext,
@@ -9080,10 +9114,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.EventContext>);
+      ) as _i17.Future<_i4.EventContext>);
 
   @override
-  _i16.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i17.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -9095,7 +9129,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+        returnValue: _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -9106,7 +9140,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_58(
+            _i17.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_59(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -9116,20 +9150,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.MatrixEvent>);
+      ) as _i17.Future<_i4.MatrixEvent>);
 
   @override
-  _i16.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> inviteBy3PID(
+  _i17.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -9141,12 +9175,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> inviteUser(
+  _i17.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9160,12 +9194,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> joinRoomById(
+  _i17.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -9179,7 +9213,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9191,7 +9225,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9202,23 +9236,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i17.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i16.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i17.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i16.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i16.Future<Map<String, _i4.RoomMember>?>);
+            _i17.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i17.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i16.Future<void> kick(
+  _i17.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9232,12 +9266,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leaveRoom(
+  _i17.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9247,12 +9281,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i17.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9268,12 +9302,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i16.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i16.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i16.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i17.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i17.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i17.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i16.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i17.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9295,8 +9329,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i16.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_75(
+        returnValue: _i17.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_76(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9312,8 +9346,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_75(
+        returnValueForMissingStub: _i17.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_76(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9329,10 +9363,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.GetRoomEventsResponse>);
+      ) as _i17.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i16.Future<void> setReadMarker(
+  _i17.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9348,12 +9382,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> postReceipt(
+  _i17.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9369,12 +9403,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> redactEvent(
+  _i17.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9390,12 +9424,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<void> reportRoom(
+  _i17.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9407,12 +9441,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> reportEvent(
+  _i17.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9430,12 +9464,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> sendMessage(
+  _i17.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9451,7 +9485,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9464,7 +9498,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9476,23 +9510,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i17.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i16.Future<List<_i4.MatrixEvent>>);
+            _i17.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i17.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i17.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9509,13 +9543,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<String> setRoomStateWithKey(
+  _i17.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9531,7 +9565,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9544,7 +9578,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9556,10 +9590,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<void> unban(
+  _i17.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9573,12 +9607,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> upgradeRoom(
+  _i17.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9592,7 +9626,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9604,7 +9638,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9615,10 +9649,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.SearchResults> search(
+  _i17.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9628,7 +9662,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_76(
+        returnValue: _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_77(
           this,
           Invocation.method(
             #search,
@@ -9637,7 +9671,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_76(
+            _i17.Future<_i4.SearchResults>.value(_FakeSearchResults_77(
           this,
           Invocation.method(
             #search,
@@ -9645,10 +9679,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i16.Future<_i4.SearchResults>);
+      ) as _i17.Future<_i4.SearchResults>);
 
   @override
-  _i16.Future<_i4.SyncUpdate> sync({
+  _i17.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9669,7 +9703,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+        returnValue: _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #sync,
@@ -9685,7 +9719,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_16(
+            _i17.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_17(
           this,
           Invocation.method(
             #sync,
@@ -9700,22 +9734,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i16.Future<_i4.SyncUpdate>);
+      ) as _i17.Future<_i4.SyncUpdate>);
 
   @override
-  _i16.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i17.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i16.Future<List<_i4.Location>>);
+            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i17.Future<List<_i4.Location>>);
 
   @override
-  _i16.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i17.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9725,21 +9759,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i16.Future<List<_i4.Location>>);
+            _i17.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i17.Future<List<_i4.Location>>);
 
   @override
-  _i16.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i17.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_77(
+        returnValue: _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_78(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9747,45 +9781,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_77(
+            _i17.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_78(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i16.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i17.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i16.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i17.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i17.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i17.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9796,13 +9830,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
+            _i17.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i17.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i16.Future<Map<String, Object?>> getAccountData(
+  _i17.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9815,13 +9849,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> setAccountData(
+  _i17.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9835,12 +9869,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> defineFilter(
+  _i17.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9852,7 +9886,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9863,7 +9897,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9873,10 +9907,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.Filter> getFilter(
+  _i17.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9888,7 +9922,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i16.Future<_i4.Filter>.value(_FakeFilter_21(
+        returnValue: _i17.Future<_i4.Filter>.value(_FakeFilter_22(
           this,
           Invocation.method(
             #getFilter,
@@ -9898,7 +9932,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.Filter>.value(_FakeFilter_21(
+        returnValueForMissingStub: _i17.Future<_i4.Filter>.value(_FakeFilter_22(
           this,
           Invocation.method(
             #getFilter,
@@ -9908,10 +9942,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.Filter>);
+      ) as _i17.Future<_i4.Filter>);
 
   @override
-  _i16.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i17.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9924,7 +9958,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_78(
+            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_79(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9935,7 +9969,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_78(
+            _i17.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_79(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9945,10 +9979,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i16.Future<_i4.OpenIdCredentials>);
+      ) as _i17.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i16.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i17.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9963,13 +9997,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<void> setAccountDataPerRoom(
+  _i17.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9985,12 +10019,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i17.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -10002,12 +10036,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i16.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i16.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i16.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i17.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i17.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i17.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i16.Future<void> deleteRoomTag(
+  _i17.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -10021,12 +10055,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setRoomTag(
+  _i17.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -10042,12 +10076,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i17.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -10057,8 +10091,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i16.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_79(
+        returnValue: _i17.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_80(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -10067,8 +10101,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_79(
+            _i17.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_80(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -10076,10 +10110,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i16.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i17.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> reportUser(
+  _i17.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -10092,40 +10126,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 
   @override
-  _i16.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i17.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i16.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_80(
+        returnValue: _i17.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_81(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i16.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_80(
+        returnValueForMissingStub: _i17.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_81(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.CreateContentResponse>);
+      ) as _i17.Future<_i4.CreateContentResponse>);
 
   @override
-  _i16.Future<Map<String, Object?>> uploadContentToMXC(
+  _i17.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i26.Uint8List? body, {
+    _i27.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10143,10 +10177,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i16.Future<Map<String, Object?>>);
+            _i17.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i17.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Event].
@@ -10156,11 +10190,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   _i4.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_18(
+        returnValue: _FakeUser_19(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_18(
+        returnValueForMissingStub: _FakeUser_19(
           this,
           Invocation.getter(#sender),
         ),
@@ -10169,11 +10203,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   _i4.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_18(
+        returnValue: _FakeUser_19(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_18(
+        returnValueForMissingStub: _FakeUser_19(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10182,11 +10216,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   _i4.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -10209,11 +10243,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   _i4.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_18(
+        returnValue: _FakeUser_19(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_18(
+        returnValueForMissingStub: _FakeUser_19(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10222,11 +10256,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10235,11 +10269,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10248,11 +10282,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10261,11 +10295,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10274,11 +10308,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10343,11 +10377,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10356,11 +10390,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10413,11 +10447,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10426,11 +10460,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   DateTime get originServerTs => (super.noSuchMethod(
         Invocation.getter(#originServerTs),
-        returnValue: _FakeDateTime_14(
+        returnValue: _FakeDateTime_15(
           this,
           Invocation.getter(#originServerTs),
         ),
-        returnValueForMissingStub: _FakeDateTime_14(
+        returnValueForMissingStub: _FakeDateTime_15(
           this,
           Invocation.getter(#originServerTs),
         ),
@@ -10502,11 +10536,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10524,11 +10558,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10560,14 +10594,14 @@ class MockEvent extends _i1.Mock implements _i4.Event {
       );
 
   @override
-  _i16.Future<_i4.User?> fetchSenderUser() => (super.noSuchMethod(
+  _i17.Future<_i4.User?> fetchSenderUser() => (super.noSuchMethod(
         Invocation.method(
           #fetchSenderUser,
           [],
         ),
-        returnValue: _i16.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.User?>.value(),
-      ) as _i16.Future<_i4.User?>);
+        returnValue: _i17.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.User?>.value(),
+      ) as _i17.Future<_i4.User?>);
 
   @override
   Map<String, dynamic> toJson() => (super.noSuchMethod(
@@ -10589,38 +10623,38 @@ class MockEvent extends _i1.Mock implements _i4.Event {
       );
 
   @override
-  _i16.Future<bool> remove() => (super.noSuchMethod(
+  _i17.Future<bool> remove() => (super.noSuchMethod(
         Invocation.method(
           #remove,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<void> cancelSend() => (super.noSuchMethod(
+  _i17.Future<void> cancelSend() => (super.noSuchMethod(
         Invocation.method(
           #cancelSend,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String?> sendAgain({String? txid}) => (super.noSuchMethod(
+  _i17.Future<String?> sendAgain({String? txid}) => (super.noSuchMethod(
         Invocation.method(
           #sendAgain,
           [],
           {#txid: txid},
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<String?> redactEvent({
+  _i17.Future<String?> redactEvent({
     String? reason,
     String? txid,
   }) =>
@@ -10633,30 +10667,30 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #txid: txid,
           },
         ),
-        returnValue: _i16.Future<String?>.value(),
-        returnValueForMissingStub: _i16.Future<String?>.value(),
-      ) as _i16.Future<String?>);
+        returnValue: _i17.Future<String?>.value(),
+        returnValueForMissingStub: _i17.Future<String?>.value(),
+      ) as _i17.Future<String?>);
 
   @override
-  _i16.Future<_i4.Event?> getReplyEvent(_i4.Timeline? timeline) =>
+  _i17.Future<_i4.Event?> getReplyEvent(_i4.Timeline? timeline) =>
       (super.noSuchMethod(
         Invocation.method(
           #getReplyEvent,
           [timeline],
         ),
-        returnValue: _i16.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
-      ) as _i16.Future<_i4.Event?>);
+        returnValue: _i17.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i17.Future<_i4.Event?>.value(),
+      ) as _i17.Future<_i4.Event?>);
 
   @override
-  _i16.Future<void> requestKey() => (super.noSuchMethod(
+  _i17.Future<void> requestKey() => (super.noSuchMethod(
         Invocation.method(
           #requestKey,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   Uri? attachmentOrThumbnailMxcUrl({bool? getThumbnail = false}) =>
@@ -10670,7 +10704,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
       ) as Uri?);
 
   @override
-  _i16.Future<Uri?> getAttachmentUri({
+  _i17.Future<Uri?> getAttachmentUri({
     bool? getThumbnail = false,
     bool? useThumbnailMxcUrl = false,
     double? width = 800.0,
@@ -10693,9 +10727,9 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #animated: animated,
           },
         ),
-        returnValue: _i16.Future<Uri?>.value(),
-        returnValueForMissingStub: _i16.Future<Uri?>.value(),
-      ) as _i16.Future<Uri?>);
+        returnValue: _i17.Future<Uri?>.value(),
+        returnValueForMissingStub: _i17.Future<Uri?>.value(),
+      ) as _i17.Future<Uri?>);
 
   @override
   Uri? getAttachmentUrl({
@@ -10725,21 +10759,21 @@ class MockEvent extends _i1.Mock implements _i4.Event {
       ) as Uri?);
 
   @override
-  _i16.Future<bool> isAttachmentInLocalStore({bool? getThumbnail = false}) =>
+  _i17.Future<bool> isAttachmentInLocalStore({bool? getThumbnail = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #isAttachmentInLocalStore,
           [],
           {#getThumbnail: getThumbnail},
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<_i4.MatrixFile> downloadAndDecryptAttachment({
+  _i17.Future<_i4.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i16.Future<_i26.Uint8List> Function(Uri)? downloadCallback,
+    _i17.Future<_i27.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10754,7 +10788,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i16.Future<_i4.MatrixFile>.value(_FakeMatrixFile_82(
+        returnValue: _i17.Future<_i4.MatrixFile>.value(_FakeMatrixFile_83(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10768,7 +10802,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.MatrixFile>.value(_FakeMatrixFile_82(
+            _i17.Future<_i4.MatrixFile>.value(_FakeMatrixFile_83(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10781,10 +10815,10 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         )),
-      ) as _i16.Future<_i4.MatrixFile>);
+      ) as _i17.Future<_i4.MatrixFile>);
 
   @override
-  _i16.Future<String> calcLocalizedBody(
+  _i17.Future<String> calcLocalizedBody(
     _i4.MatrixLocalizations? i18n, {
     bool? withSenderNamePrefix = false,
     bool? hideReply = false,
@@ -10804,7 +10838,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10819,7 +10853,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10833,7 +10867,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
   String getLocalizedBody(
@@ -10856,7 +10890,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10870,7 +10904,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10907,7 +10941,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10921,7 +10955,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10955,7 +10989,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10968,7 +11002,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11044,14 +11078,14 @@ class MockEvent extends _i1.Mock implements _i4.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_83(
+        returnValue: _FakeEvent_84(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_83(
+        returnValueForMissingStub: _FakeEvent_84(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11068,11 +11102,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   _i4.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -11081,11 +11115,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11106,19 +11140,19 @@ class MockUser extends _i1.Mock implements _i4.User {
       ) as _i4.Membership);
 
   @override
-  _i16.Future<_i4.CachedPresence> get currentPresence => (super.noSuchMethod(
+  _i17.Future<_i4.CachedPresence> get currentPresence => (super.noSuchMethod(
         Invocation.getter(#currentPresence),
         returnValue:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_37(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_38(
           this,
           Invocation.getter(#currentPresence),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_37(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_38(
           this,
           Invocation.getter(#currentPresence),
         )),
-      ) as _i16.Future<_i4.CachedPresence>);
+      ) as _i17.Future<_i4.CachedPresence>);
 
   @override
   bool get canBan => (super.noSuchMethod(
@@ -11151,11 +11185,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11180,11 +11214,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11202,11 +11236,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11253,7 +11287,7 @@ class MockUser extends _i1.Mock implements _i4.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11265,7 +11299,7 @@ class MockUser extends _i1.Mock implements _i4.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11280,47 +11314,47 @@ class MockUser extends _i1.Mock implements _i4.User {
       ) as String);
 
   @override
-  _i16.Future<void> kick() => (super.noSuchMethod(
+  _i17.Future<void> kick() => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> ban() => (super.noSuchMethod(
+  _i17.Future<void> ban() => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> unban() => (super.noSuchMethod(
+  _i17.Future<void> unban() => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setPower(int? power) => (super.noSuchMethod(
+  _i17.Future<void> setPower(int? power) => (super.noSuchMethod(
         Invocation.method(
           #setPower,
           [power],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<String> startDirectChat({
+  _i17.Future<String> startDirectChat({
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
     bool? waitForSync = true,
@@ -11335,7 +11369,7 @@ class MockUser extends _i1.Mock implements _i4.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11348,7 +11382,7 @@ class MockUser extends _i1.Mock implements _i4.User {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<String>.value(_i19.dummyValue<String>(
+            _i17.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11360,16 +11394,16 @@ class MockUser extends _i1.Mock implements _i4.User {
             },
           ),
         )),
-      ) as _i16.Future<String>);
+      ) as _i17.Future<String>);
 
   @override
-  _i16.Future<_i4.CachedPresence> fetchCurrentPresence() => (super.noSuchMethod(
+  _i17.Future<_i4.CachedPresence> fetchCurrentPresence() => (super.noSuchMethod(
         Invocation.method(
           #fetchCurrentPresence,
           [],
         ),
         returnValue:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_37(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_38(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -11377,14 +11411,14 @@ class MockUser extends _i1.Mock implements _i4.User {
           ),
         )),
         returnValueForMissingStub:
-            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_37(
+            _i17.Future<_i4.CachedPresence>.value(_FakeCachedPresence_38(
           this,
           Invocation.method(
             #fetchCurrentPresence,
             [],
           ),
         )),
-      ) as _i16.Future<_i4.CachedPresence>);
+      ) as _i17.Future<_i4.CachedPresence>);
 
   @override
   Map<String, Object?> toJson() => (super.noSuchMethod(
@@ -11400,7 +11434,7 @@ class MockUser extends _i1.Mock implements _i4.User {
 /// A class which mocks [CallService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCallService extends _i1.Mock implements _i27.CallService {
+class MockCallService extends _i1.Mock implements _i28.CallService {
   @override
   _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -11422,36 +11456,36 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       ) as bool);
 
   @override
-  _i28.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
+  _i29.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
         Invocation.getter(#httpPostForTest),
         returnValue: (
-          _i15.Client httpClient,
+          _i16.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i16.Future<_i15.Response>.value(_FakeResponse_84(
+            _i17.Future<_i16.Response>.value(_FakeResponse_85(
           this,
           Invocation.getter(#httpPostForTest),
         )),
         returnValueForMissingStub: (
-          _i15.Client httpClient,
+          _i16.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i16.Future<_i15.Response>.value(_FakeResponse_84(
+            _i17.Future<_i16.Response>.value(_FakeResponse_85(
           this,
           Invocation.getter(#httpPostForTest),
         )),
-      ) as _i28.HttpPostFunction);
+      ) as _i29.HttpPostFunction);
 
   @override
-  List<_i29.RemoteParticipant> get participants => (super.noSuchMethod(
+  List<_i30.RemoteParticipant> get participants => (super.noSuchMethod(
         Invocation.getter(#participants),
-        returnValue: <_i29.RemoteParticipant>[],
-        returnValueForMissingStub: <_i29.RemoteParticipant>[],
-      ) as List<_i29.RemoteParticipant>);
+        returnValue: <_i30.RemoteParticipant>[],
+        returnValueForMissingStub: <_i30.RemoteParticipant>[],
+      ) as List<_i30.RemoteParticipant>);
 
   @override
   bool get isMicEnabled => (super.noSuchMethod(
@@ -11482,14 +11516,14 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       ) as bool);
 
   @override
-  List<_i29.Participant<_i29.TrackPublication<_i29.Track>>>
+  List<_i30.Participant<_i30.TrackPublication<_i30.Track>>>
       get activeSpeakers => (super.noSuchMethod(
             Invocation.getter(#activeSpeakers),
-            returnValue: <_i29
-                .Participant<_i29.TrackPublication<_i29.Track>>>[],
-            returnValueForMissingStub: <_i29
-                .Participant<_i29.TrackPublication<_i29.Track>>>[],
-          ) as List<_i29.Participant<_i29.TrackPublication<_i29.Track>>>);
+            returnValue: <_i30
+                .Participant<_i30.TrackPublication<_i30.Track>>>[],
+            returnValueForMissingStub: <_i30
+                .Participant<_i30.TrackPublication<_i30.Track>>>[],
+          ) as List<_i30.Participant<_i30.TrackPublication<_i30.Track>>>);
 
   @override
   bool get isCallingAvailable => (super.noSuchMethod(
@@ -11499,11 +11533,11 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       ) as bool);
 
   @override
-  List<_i30.CallParticipant> get allParticipants => (super.noSuchMethod(
+  List<_i31.CallParticipant> get allParticipants => (super.noSuchMethod(
         Invocation.getter(#allParticipants),
-        returnValue: <_i30.CallParticipant>[],
-        returnValueForMissingStub: <_i30.CallParticipant>[],
-      ) as List<_i30.CallParticipant>);
+        returnValue: <_i31.CallParticipant>[],
+        returnValueForMissingStub: <_i31.CallParticipant>[],
+      ) as List<_i31.CallParticipant>);
 
   @override
   bool get isSpeakerOn => (super.noSuchMethod(
@@ -11513,29 +11547,29 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       ) as bool);
 
   @override
-  _i16.Stream<_i31.IncomingCallInfo> get incomingCallStream =>
+  _i17.Stream<_i32.IncomingCallInfo> get incomingCallStream =>
       (super.noSuchMethod(
         Invocation.getter(#incomingCallStream),
-        returnValue: _i16.Stream<_i31.IncomingCallInfo>.empty(),
-        returnValueForMissingStub: _i16.Stream<_i31.IncomingCallInfo>.empty(),
-      ) as _i16.Stream<_i31.IncomingCallInfo>);
+        returnValue: _i17.Stream<_i32.IncomingCallInfo>.empty(),
+        returnValueForMissingStub: _i17.Stream<_i32.IncomingCallInfo>.empty(),
+      ) as _i17.Stream<_i32.IncomingCallInfo>);
 
   @override
-  _i16.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
+  _i17.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
         Invocation.getter(#nativeAcceptedCallStream),
-        returnValue: _i16.Stream<String>.empty(),
-        returnValueForMissingStub: _i16.Stream<String>.empty(),
-      ) as _i16.Stream<String>);
+        returnValue: _i17.Stream<String>.empty(),
+        returnValueForMissingStub: _i17.Stream<String>.empty(),
+      ) as _i17.Stream<String>);
 
   @override
-  _i32.KoheraCallState get callState => (super.noSuchMethod(
+  _i33.KoheraCallState get callState => (super.noSuchMethod(
         Invocation.getter(#callState),
-        returnValue: _i32.KoheraCallState.idle,
-        returnValueForMissingStub: _i32.KoheraCallState.idle,
-      ) as _i32.KoheraCallState);
+        returnValue: _i33.KoheraCallState.idle,
+        returnValueForMissingStub: _i33.KoheraCallState.idle,
+      ) as _i33.KoheraCallState);
 
   @override
-  set preferencesService(_i33.PreferencesService? prefs) => super.noSuchMethod(
+  set preferencesService(_i34.PreferencesService? prefs) => super.noSuchMethod(
         Invocation.setter(
           #preferencesService,
           prefs,
@@ -11544,7 +11578,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  set ringtoneService(_i34.RingtoneService? service) => super.noSuchMethod(
+  set ringtoneService(_i35.RingtoneService? service) => super.noSuchMethod(
         Invocation.setter(
           #ringtoneService,
           service,
@@ -11553,7 +11587,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  set roomFactoryForTest(_i28.LiveKitRoomFactory? factory) =>
+  set roomFactoryForTest(_i29.LiveKitRoomFactory? factory) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomFactoryForTest,
@@ -11563,7 +11597,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  set httpPostForTest(_i28.HttpPostFunction? fn) => super.noSuchMethod(
+  set httpPostForTest(_i29.HttpPostFunction? fn) => super.noSuchMethod(
         Invocation.setter(
           #httpPostForTest,
           fn,
@@ -11597,27 +11631,27 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  _i16.Future<void> toggleMicrophone() => (super.noSuchMethod(
+  _i17.Future<void> toggleMicrophone() => (super.noSuchMethod(
         Invocation.method(
           #toggleMicrophone,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> toggleCamera() => (super.noSuchMethod(
+  _i17.Future<void> toggleCamera() => (super.noSuchMethod(
         Invocation.method(
           #toggleCamera,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> toggleScreenShare({
+  _i17.Future<void> toggleScreenShare({
     String? sourceId,
     bool? captureScreenAudio = false,
   }) =>
@@ -11630,39 +11664,39 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
             #captureScreenAudio: captureScreenAudio,
           },
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> toggleScreenAudio() => (super.noSuchMethod(
+  _i17.Future<void> toggleScreenAudio() => (super.noSuchMethod(
         Invocation.method(
           #toggleScreenAudio,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
+  _i17.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
         Invocation.method(
           #setOutputVolume,
           [volume],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> toggleSpeaker() => (super.noSuchMethod(
+  _i17.Future<void> toggleSpeaker() => (super.noSuchMethod(
         Invocation.method(
           #toggleSpeaker,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void setVoipPushHandlesCallKit(bool? value) => super.noSuchMethod(
@@ -11692,7 +11726,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -11720,36 +11754,36 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  _i16.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
+  _i17.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #joinCall,
           [roomId],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> leaveCall() => (super.noSuchMethod(
+  _i17.Future<void> leaveCall() => (super.noSuchMethod(
         Invocation.method(
           #leaveCall,
           [],
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
-  _i16.Future<void> acceptCall({bool? withVideo = false}) =>
+  _i17.Future<void> acceptCall({bool? withVideo = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #acceptCall,
           [],
           {#withVideo: withVideo},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   void declineCall() => super.noSuchMethod(
@@ -11771,9 +11805,9 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  _i16.Future<void> initiateCall(
+  _i17.Future<void> initiateCall(
     String? roomId, {
-    _i31.CallType? type = _i31.CallType.voice,
+    _i32.CallType? type = _i32.CallType.voice,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11781,9 +11815,9 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
           [roomId],
           {#type: type},
         ),
-        returnValue: _i16.Future<void>.value(),
-        returnValueForMissingStub: _i16.Future<void>.value(),
-      ) as _i16.Future<void>);
+        returnValue: _i17.Future<void>.value(),
+        returnValueForMissingStub: _i17.Future<void>.value(),
+      ) as _i17.Future<void>);
 
   @override
   bool roomHasActiveCall(String? roomId) => (super.noSuchMethod(
@@ -11876,7 +11910,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -11885,7 +11919,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -11894,17 +11928,17 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  _i16.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i17.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -11915,7 +11949,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -11952,26 +11986,26 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  _i16.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i17.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
-  _i16.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+  _i17.Future<bool> didPushRouteInformation(
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i16.Future<bool>.value(false),
-        returnValueForMissingStub: _i16.Future<bool>.value(false),
-      ) as _i16.Future<bool>);
+        returnValue: _i17.Future<bool>.value(false),
+        returnValueForMissingStub: _i17.Future<bool>.value(false),
+      ) as _i17.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -12001,7 +12035,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -12010,7 +12044,7 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -12019,16 +12053,16 @@ class MockCallService extends _i1.Mock implements _i27.CallService {
       );
 
   @override
-  _i16.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i17.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i16.Future<_i20.AppExitResponse>);
+            _i17.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i17.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/space_action_dialog_test.mocks.dart
+++ b/test/widgets/space_action_dialog_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,14 +28,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i26;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i27;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i25;
+import 'package:matrix/src/utils/space_child.dart' as _i26;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -860,9 +861,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -871,8 +872,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,9 +883,19 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_78(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,8 +904,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,8 +914,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -930,12 +942,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1055,11 +1067,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1096,11 +1108,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1130,11 +1142,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1143,11 +1155,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1433,34 +1445,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1616,7 +1628,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1905,14 +1917,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2300,8 +2312,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2317,8 +2329,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2359,7 +2371,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2375,7 +2387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2424,7 +2436,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2445,7 +2457,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2548,7 +2560,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2566,7 +2578,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3085,7 +3097,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3437,7 +3449,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3451,7 +3463,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3602,7 +3614,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4980,7 +4992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5002,7 +5014,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5496,7 +5508,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5508,7 +5520,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6516,7 +6528,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6527,7 +6539,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6775,7 +6787,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6787,7 +6799,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7047,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7060,7 +7072,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7127,7 +7139,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7140,7 +7152,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7188,7 +7200,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7200,7 +7212,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7448,7 +7460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7459,7 +7471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7721,7 +7733,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7748,7 +7760,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7778,11 +7790,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7920,17 +7932,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8039,7 +8064,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8092,7 +8126,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8188,7 +8222,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8197,7 +8231,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8216,7 +8250,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8227,7 +8261,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8275,7 +8309,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8313,7 +8347,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8322,7 +8356,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8331,16 +8365,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8368,11 +8402,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8402,11 +8436,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -8459,11 +8493,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8499,11 +8533,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8519,11 +8553,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8532,11 +8566,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8579,11 +8613,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8626,11 +8660,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8849,18 +8883,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i25.SpaceParent>[],
-        returnValueForMissingStub: <_i25.SpaceParent>[],
-      ) as List<_i25.SpaceParent>);
+        returnValue: <_i26.SpaceParent>[],
+        returnValueForMissingStub: <_i26.SpaceParent>[],
+      ) as List<_i26.SpaceParent>);
 
   @override
-  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i25.SpaceChild>[],
-        returnValueForMissingStub: <_i25.SpaceChild>[],
-      ) as List<_i25.SpaceChild>);
+        returnValue: <_i26.SpaceChild>[],
+        returnValueForMissingStub: <_i26.SpaceChild>[],
+      ) as List<_i26.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9027,14 +9061,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9082,7 +9116,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9090,7 +9124,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9105,7 +9139,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9113,7 +9147,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9207,7 +9241,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9215,7 +9249,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9457,7 +9491,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9468,7 +9502,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9557,15 +9591,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i26.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i27.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i26.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i26.TimelineChunk?>.value(),
-      ) as _i5.Future<_i26.TimelineChunk?>);
+        returnValue: _i5.Future<_i27.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i27.TimelineChunk?>.value(),
+      ) as _i5.Future<_i27.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9606,7 +9640,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9623,7 +9657,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9687,14 +9721,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9710,14 +9744,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9773,7 +9807,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9781,7 +9815,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/space_context_menu_test.mocks.dart
+++ b/test/widgets/space_context_menu_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,14 +28,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i26;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i27;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i25;
+import 'package:matrix/src/utils/space_child.dart' as _i26;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -860,9 +861,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -871,8 +872,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,9 +883,19 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_78(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,8 +904,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,8 +914,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -912,8 +924,8 @@ class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_81 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_81(
+class _FakeRoom_82 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -922,8 +934,8 @@ class _FakeRoom_81 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeMatrixFile_82 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_82(
+class _FakeMatrixFile_83 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -932,8 +944,8 @@ class _FakeMatrixFile_82 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_83 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_83(
+class _FakeEvent_84 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -960,12 +972,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1085,11 +1097,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1126,11 +1138,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1160,11 +1172,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1173,11 +1185,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1463,34 +1475,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1646,7 +1658,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1935,14 +1947,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2330,8 +2342,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2347,8 +2359,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2389,7 +2401,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2405,7 +2417,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2454,7 +2466,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2475,7 +2487,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2578,7 +2590,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2596,7 +2608,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3115,7 +3127,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3467,7 +3479,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3481,7 +3493,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3632,7 +3644,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5010,7 +5022,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5032,7 +5044,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5526,7 +5538,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5538,7 +5550,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6546,7 +6558,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6557,7 +6569,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6805,7 +6817,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6817,7 +6829,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7077,7 +7089,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7090,7 +7102,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7157,7 +7169,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7170,7 +7182,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7218,7 +7230,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7230,7 +7242,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7478,7 +7490,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7489,7 +7501,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7751,7 +7763,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7778,7 +7790,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7808,11 +7820,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7950,17 +7962,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8069,7 +8094,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8122,7 +8156,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8218,7 +8252,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8227,7 +8261,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8246,7 +8280,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8257,7 +8291,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8305,7 +8339,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8343,7 +8377,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8352,7 +8386,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8361,16 +8395,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8398,11 +8432,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8432,11 +8466,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -8489,11 +8523,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8529,11 +8563,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8549,11 +8583,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8562,11 +8596,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8609,11 +8643,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8656,11 +8690,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8879,18 +8913,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i25.SpaceParent>[],
-        returnValueForMissingStub: <_i25.SpaceParent>[],
-      ) as List<_i25.SpaceParent>);
+        returnValue: <_i26.SpaceParent>[],
+        returnValueForMissingStub: <_i26.SpaceParent>[],
+      ) as List<_i26.SpaceParent>);
 
   @override
-  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i25.SpaceChild>[],
-        returnValueForMissingStub: <_i25.SpaceChild>[],
-      ) as List<_i25.SpaceChild>);
+        returnValue: <_i26.SpaceChild>[],
+        returnValueForMissingStub: <_i26.SpaceChild>[],
+      ) as List<_i26.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9057,14 +9091,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9112,7 +9146,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9120,7 +9154,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9135,7 +9169,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9143,7 +9177,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9237,7 +9271,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9245,7 +9279,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9487,7 +9521,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9498,7 +9532,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9587,15 +9621,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i26.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i27.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i26.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i26.TimelineChunk?>.value(),
-      ) as _i5.Future<_i26.TimelineChunk?>);
+        returnValue: _i5.Future<_i27.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i27.TimelineChunk?>.value(),
+      ) as _i5.Future<_i27.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9636,7 +9670,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9653,7 +9687,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9717,14 +9751,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9740,14 +9774,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9803,7 +9837,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9811,7 +9845,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10123,11 +10157,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.getter(#sender),
         ),
@@ -10136,11 +10170,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10149,11 +10183,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -10176,11 +10210,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10189,11 +10223,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10202,11 +10236,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10215,11 +10249,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10228,11 +10262,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10241,11 +10275,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10310,11 +10344,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10323,11 +10357,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10380,11 +10414,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10469,11 +10503,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10491,11 +10525,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10706,7 +10740,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i20.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i21.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10721,7 +10755,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_82(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_83(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10735,7 +10769,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_82(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_83(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10771,7 +10805,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10786,7 +10820,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10823,7 +10857,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10837,7 +10871,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10874,7 +10908,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10888,7 +10922,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10922,7 +10956,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10935,7 +10969,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11011,14 +11045,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_83(
+        returnValue: _FakeEvent_84(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_83(
+        returnValueForMissingStub: _FakeEvent_84(
           this,
           Invocation.method(
             #getDisplayEvent,

--- a/test/widgets/space_details_panel_test.mocks.dart
+++ b/test/widgets/space_details_panel_test.mocks.dart
@@ -4,15 +4,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/models/join_mode.dart' as _i27;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/models/join_mode.dart' as _i28;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -29,14 +29,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i26;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i27;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i25;
+import 'package:matrix/src/utils/space_child.dart' as _i26;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -861,9 +862,9 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -872,8 +873,9 @@ class _FakeStickerPackService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -882,9 +884,19 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_78(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -893,8 +905,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -903,8 +915,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -913,8 +925,8 @@ class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeStateEvent_81 extends _i1.SmartFake implements _i2.StateEvent {
-  _FakeStateEvent_81(
+class _FakeStateEvent_82 extends _i1.SmartFake implements _i2.StateEvent {
+  _FakeStateEvent_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -941,12 +953,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1066,11 +1078,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1107,11 +1119,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1141,11 +1153,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1154,11 +1166,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1444,34 +1456,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1627,7 +1639,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1916,14 +1928,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2311,8 +2323,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2328,8 +2340,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2370,7 +2382,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2386,7 +2398,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2435,7 +2447,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2456,7 +2468,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2559,7 +2571,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2577,7 +2589,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3096,7 +3108,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3448,7 +3460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3462,7 +3474,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3613,7 +3625,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4991,7 +5003,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5013,7 +5025,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5507,7 +5519,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5519,7 +5531,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6527,7 +6539,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6538,7 +6550,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6786,7 +6798,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6798,7 +6810,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7058,7 +7070,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7071,7 +7083,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7138,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7151,7 +7163,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7199,7 +7211,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7211,7 +7223,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7459,7 +7471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7470,7 +7482,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7732,7 +7744,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7759,7 +7771,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7789,11 +7801,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7931,17 +7943,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -8050,7 +8075,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8103,7 +8137,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8199,7 +8233,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8208,7 +8242,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8227,7 +8261,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8238,7 +8272,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8286,7 +8320,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8324,7 +8358,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8333,7 +8367,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8342,16 +8376,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8379,11 +8413,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8413,11 +8447,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -8470,11 +8504,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8510,11 +8544,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8530,11 +8564,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8543,11 +8577,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8590,11 +8624,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8637,11 +8671,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8860,18 +8894,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i25.SpaceParent>[],
-        returnValueForMissingStub: <_i25.SpaceParent>[],
-      ) as List<_i25.SpaceParent>);
+        returnValue: <_i26.SpaceParent>[],
+        returnValueForMissingStub: <_i26.SpaceParent>[],
+      ) as List<_i26.SpaceParent>);
 
   @override
-  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i25.SpaceChild>[],
-        returnValueForMissingStub: <_i25.SpaceChild>[],
-      ) as List<_i25.SpaceChild>);
+        returnValue: <_i26.SpaceChild>[],
+        returnValueForMissingStub: <_i26.SpaceChild>[],
+      ) as List<_i26.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9038,14 +9072,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9093,7 +9127,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9101,7 +9135,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9116,7 +9150,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9124,7 +9158,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9218,7 +9252,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9226,7 +9260,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9468,7 +9502,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9479,7 +9513,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9568,15 +9602,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i26.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i27.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i26.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i26.TimelineChunk?>.value(),
-      ) as _i5.Future<_i26.TimelineChunk?>);
+        returnValue: _i5.Future<_i27.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i27.TimelineChunk?>.value(),
+      ) as _i5.Future<_i27.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9617,7 +9651,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9634,7 +9668,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -9698,14 +9732,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9721,14 +9755,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9784,7 +9818,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9792,7 +9826,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10103,14 +10137,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
 class MockSpaceAccessService extends _i1.Mock
     implements _i13.SpaceAccessService {
   @override
-  _i27.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
+  _i28.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
         Invocation.method(
           #getJoinMode,
           [room],
         ),
-        returnValue: _i27.JoinMode.invite,
-        returnValueForMissingStub: _i27.JoinMode.invite,
-      ) as _i27.JoinMode);
+        returnValue: _i28.JoinMode.invite,
+        returnValueForMissingStub: _i28.JoinMode.invite,
+      ) as _i28.JoinMode);
 
   @override
   List<String> allowedSpaceIds(_i2.Room? room) => (super.noSuchMethod(
@@ -10194,7 +10228,7 @@ class MockSpaceAccessService extends _i1.Mock
   @override
   _i5.Future<void> applyJoinMode({
     required String? roomId,
-    required _i27.JoinMode? mode,
+    required _i28.JoinMode? mode,
     List<String>? allowSpaceIds = const [],
   }) =>
       (super.noSuchMethod(
@@ -10213,7 +10247,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   Map<String, Object?> buildJoinRulesPayload(
-    _i27.JoinMode? mode,
+    _i28.JoinMode? mode,
     List<String>? allowSpaceIds, {
     List<Map<String, Object?>>? preserveEntries = const [],
   }) =>
@@ -10232,7 +10266,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   _i2.StateEvent buildJoinRulesStateEvent(
-    _i27.JoinMode? mode,
+    _i28.JoinMode? mode,
     List<String>? allowSpaceIds,
   ) =>
       (super.noSuchMethod(
@@ -10243,7 +10277,7 @@ class MockSpaceAccessService extends _i1.Mock
             allowSpaceIds,
           ],
         ),
-        returnValue: _FakeStateEvent_81(
+        returnValue: _FakeStateEvent_82(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -10253,7 +10287,7 @@ class MockSpaceAccessService extends _i1.Mock
             ],
           ),
         ),
-        returnValueForMissingStub: _FakeStateEvent_81(
+        returnValueForMissingStub: _FakeStateEvent_82(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -10278,7 +10312,7 @@ class MockSpaceAccessService extends _i1.Mock
             newVersion,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,
@@ -10289,7 +10323,7 @@ class MockSpaceAccessService extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,

--- a/test/widgets/space_discovery_search_test.mocks.dart
+++ b/test/widgets/space_discovery_search_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,12 +28,13 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -858,9 +859,20 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -887,12 +899,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1012,11 +1024,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1053,11 +1065,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1087,11 +1099,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1100,11 +1112,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1390,34 +1402,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1573,7 +1585,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1862,14 +1874,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2257,8 +2269,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2274,8 +2286,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2316,7 +2328,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2332,7 +2344,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2381,7 +2393,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2402,7 +2414,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2505,7 +2517,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2523,7 +2535,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3042,7 +3054,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3394,7 +3406,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3408,7 +3420,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3559,7 +3571,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4937,7 +4949,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4959,7 +4971,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5453,7 +5465,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5465,7 +5477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6473,7 +6485,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6484,7 +6496,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6732,7 +6744,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6744,7 +6756,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7004,7 +7016,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7017,7 +7029,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7084,7 +7096,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7097,7 +7109,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7145,7 +7157,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7157,7 +7169,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7405,7 +7417,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7416,7 +7428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7678,7 +7690,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7705,7 +7717,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7735,11 +7747,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7877,17 +7889,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7996,7 +8021,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8049,7 +8083,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8145,7 +8179,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8154,7 +8188,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8173,7 +8207,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8184,7 +8218,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8232,7 +8266,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8270,7 +8304,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8279,7 +8313,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8288,16 +8322,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/space_discovery_server_test.mocks.dart
+++ b/test/widgets/space_discovery_server_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,12 +28,13 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -858,9 +859,20 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -887,12 +899,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1012,11 +1024,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1053,11 +1065,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1087,11 +1099,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1100,11 +1112,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1390,34 +1402,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1573,7 +1585,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1862,14 +1874,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2257,8 +2269,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2274,8 +2286,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2316,7 +2328,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2332,7 +2344,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2381,7 +2393,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2402,7 +2414,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2505,7 +2517,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2523,7 +2535,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3042,7 +3054,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3394,7 +3406,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3408,7 +3420,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3559,7 +3571,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4937,7 +4949,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4959,7 +4971,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5453,7 +5465,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5465,7 +5477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6473,7 +6485,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6484,7 +6496,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6732,7 +6744,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6744,7 +6756,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7004,7 +7016,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7017,7 +7029,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7084,7 +7096,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7097,7 +7109,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7145,7 +7157,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7157,7 +7169,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7405,7 +7417,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7416,7 +7428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7678,7 +7690,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7705,7 +7717,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7735,11 +7747,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7877,17 +7889,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7996,7 +8021,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8049,7 +8083,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8145,7 +8179,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8154,7 +8188,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8173,7 +8207,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8184,7 +8218,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8232,7 +8266,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8270,7 +8304,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8279,7 +8313,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8288,16 +8322,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/space_discovery_servers_edit_test.mocks.dart
+++ b/test/widgets/space_discovery_servers_edit_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,12 +28,13 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -858,9 +859,20 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -887,12 +899,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1012,11 +1024,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1053,11 +1065,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1087,11 +1099,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1100,11 +1112,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1390,34 +1402,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1573,7 +1585,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1862,14 +1874,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2257,8 +2269,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2274,8 +2286,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2316,7 +2328,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2332,7 +2344,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2381,7 +2393,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2402,7 +2414,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2505,7 +2517,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2523,7 +2535,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3042,7 +3054,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3394,7 +3406,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3408,7 +3420,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3559,7 +3571,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4937,7 +4949,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4959,7 +4971,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5453,7 +5465,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5465,7 +5477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6473,7 +6485,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6484,7 +6496,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6732,7 +6744,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6744,7 +6756,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7004,7 +7016,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7017,7 +7029,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7084,7 +7096,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7097,7 +7109,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7145,7 +7157,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7157,7 +7169,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7405,7 +7417,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7416,7 +7428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7678,7 +7690,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7705,7 +7717,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7735,11 +7747,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7877,17 +7889,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7996,7 +8021,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8049,7 +8083,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8145,7 +8179,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8154,7 +8188,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8173,7 +8207,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8184,7 +8218,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8232,7 +8266,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8270,7 +8304,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8279,7 +8313,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8288,16 +8322,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/user_avatar_test.dart
+++ b/test/widgets/user_avatar_test.dart
@@ -1,6 +1,7 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/sub_services/presence_service.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
 import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
@@ -12,25 +13,36 @@ import 'package:mockito/mockito.dart';
 ])
 import 'user_avatar_test.mocks.dart';
 
+/// A no-op [AvatarResolver] for tests — always returns null so the
+/// fallback initial is shown.
+class _NullAvatarResolver implements AvatarResolver {
+  const _NullAvatarResolver();
+  @override
+  Future<AvatarThumbnail?> resolve(String? mxcUrl, {required double size}) async => null;
+}
+
 void main() {
   late MockClient mockClient;
+  const avatarResolver = _NullAvatarResolver();
 
   setUp(() {
     mockClient = MockClient();
   });
 
   Widget buildTestWidget({
-    Uri? avatarUrl,
-    String? userId,
+    String? avatarUrl,
+    String userId = '',
+    String displayname = '',
     double size = 44,
   }) {
     return MaterialApp(
       theme: ThemeData(splashFactory: InkRipple.splashFactory),
       home: Scaffold(
         body: UserAvatar(
-          client: mockClient,
+          avatarResolver: avatarResolver,
           avatarUrl: avatarUrl,
           userId: userId,
+          displayname: displayname,
           size: size,
         ),
       ),
@@ -72,16 +84,16 @@ void main() {
       expect(sizedBox.height, 64);
     });
 
-    testWidgets('resolves thumbnail when avatarUrl is provided', (tester) async {
-      final mxcUri = Uri.parse('mxc://example.com/avatar123');
+    testWidgets('shows fallback initial when avatarUrl is provided', (tester) async {
+      const mxcUrl = 'mxc://example.com/avatar123';
 
       await tester.pumpWidget(buildTestWidget(
-        avatarUrl: mxcUri,
+        avatarUrl: mxcUrl,
         userId: '@charlie:example.com',
       ),);
       await tester.pump();
 
-      // While resolving, the fallback initial should show
+      // While resolving (or with null resolver), the fallback initial should show
       expect(find.text('C'), findsOneWidget);
     });
 
@@ -89,16 +101,18 @@ void main() {
       // This tests the color hashing — render two avatars and check they exist
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(splashFactory: InkRipple.splashFactory),
-        home: Scaffold(
+        home: const Scaffold(
           body: Column(
             children: [
               UserAvatar(
-                client: mockClient,
+                avatarResolver: avatarResolver,
                 userId: '@alice:example.com',
+                displayname: 'Alice',
               ),
               UserAvatar(
-                client: mockClient,
+                avatarResolver: avatarResolver,
                 userId: '@bob:example.com',
+                displayname: 'Bob',
               ),
             ],
           ),
@@ -139,8 +153,9 @@ void main() {
         theme: theme ?? ThemeData(splashFactory: InkRipple.splashFactory),
         home: Scaffold(
           body: UserAvatar(
-            client: mockClient,
+            avatarResolver: avatarResolver,
             userId: userId,
+            displayname: userId,
             presence: presenceService,
             size: size,
           ),

--- a/test/widgets/verification_request_listener_test.mocks.dart
+++ b/test/widgets/verification_request_listener_test.mocks.dart
@@ -4,14 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -28,12 +28,13 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:kohera/shared/services/avatar_resolver.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i19;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -858,9 +859,20 @@ class _FakeOutboxService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeStickerPackService_76 extends _i1.SmartFake
-    implements _i17.StickerPackService {
-  _FakeStickerPackService_76(
+class _FakeAvatarResolver_76 extends _i1.SmartFake
+    implements _i17.AvatarResolver {
+  _FakeAvatarResolver_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeStickerPackService_77 extends _i1.SmartFake
+    implements _i18.StickerPackService {
+  _FakeStickerPackService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -887,12 +899,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1012,11 +1024,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1053,11 +1065,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1087,11 +1099,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1100,11 +1112,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1390,34 +1402,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i18.KeyVerification>
+  _i3.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i18.KeyVerification>(
+                _FakeCachedStreamController_6<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i18.KeyVerification>);
+          ) as _i3.CachedStreamController<_i19.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1573,7 +1585,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1862,14 +1874,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2257,8 +2269,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2274,8 +2286,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2316,7 +2328,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2332,7 +2344,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2381,7 +2393,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2402,7 +2414,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2505,7 +2517,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2523,7 +2535,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3042,7 +3054,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3394,7 +3406,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3408,7 +3420,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3559,7 +3571,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4937,7 +4949,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4959,7 +4971,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5453,7 +5465,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5465,7 +5477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6473,7 +6485,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6484,7 +6496,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6732,7 +6744,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6744,7 +6756,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7004,7 +7016,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7017,7 +7029,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7084,7 +7096,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7097,7 +7109,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7145,7 +7157,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7157,7 +7169,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7405,7 +7417,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7416,7 +7428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7678,7 +7690,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7705,7 +7717,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7735,11 +7747,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7877,17 +7889,30 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i16.OutboxService);
 
   @override
-  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+  _i17.AvatarResolver get avatarResolver => (super.noSuchMethod(
+        Invocation.getter(#avatarResolver),
+        returnValue: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+        returnValueForMissingStub: _FakeAvatarResolver_76(
+          this,
+          Invocation.getter(#avatarResolver),
+        ),
+      ) as _i17.AvatarResolver);
+
+  @override
+  _i18.StickerPackService get stickerPacks => (super.noSuchMethod(
         Invocation.getter(#stickerPacks),
-        returnValue: _FakeStickerPackService_76(
+        returnValue: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-        returnValueForMissingStub: _FakeStickerPackService_76(
+        returnValueForMissingStub: _FakeStickerPackService_77(
           this,
           Invocation.getter(#stickerPacks),
         ),
-      ) as _i17.StickerPackService);
+      ) as _i18.StickerPackService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7996,7 +8021,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+  set avatarResolver(_i17.AvatarResolver? value) => super.noSuchMethod(
+        Invocation.setter(
+          #avatarResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set stickerPacks(_i18.StickerPackService? value) => super.noSuchMethod(
         Invocation.setter(
           #stickerPacks,
           value,
@@ -8049,7 +8083,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8145,7 +8179,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8154,7 +8188,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8173,7 +8207,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8184,7 +8218,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8232,7 +8266,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8270,7 +8304,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8279,7 +8313,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8288,16 +8322,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8437,7 +8471,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> runKeyRecovery({_i18.OpenSSSS? ssssKey}) =>
+  _i5.Future<void> runKeyRecovery({_i19.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
@@ -8491,7 +8525,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8500,7 +8534,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],


### PR DESCRIPTION
## Summary

Eliminate `matrix_sdk.User` and `matrix_sdk.Client` coupling from member and avatar widgets, following the pattern established by #693 (`KoheraNotificationItem`).

Part of epic #697.

## Changes

### New domain models
- **`KoheraUserSummary`** (`lib/shared/models/`) — Pure immutable model with `userId`, `displayname`, `avatarUrl`. Zero SDK imports. Foundation model for member/avatar widgets.
- **`KoheraUserSummaryMapper`** (`lib/shared/models/`) — `toKoheraUserSummary(User)` converter using `user.calcDisplayname()`. The single conversion boundary for `User` → `KoheraUserSummary`.
- **`KoheraReadReceipt`** (`lib/features/chat/models/`) — `KoheraUserSummary` + `DateTime`. Replaces SDK `Receipt` in read-receipt widgets.
- **`AvatarResolver`** (`lib/shared/services/`) — Abstract interface for mxc:// → HTTPS thumbnail resolution + auth headers. Decouples `UserAvatar` from `Client`.
- **`ClientAvatarResolver`** (`lib/core/services/`) — Concrete `AvatarResolver` wrapping `Client`. Wired into `MatrixService.avatarResolver` (same sub-service pattern as `PresenceService`).

### Widget refactors
- **`user_avatar.dart`** — New signature: `String? avatarUrl`, `String userId`, `String displayname`, `AvatarResolver?`. **Zero `package:matrix/matrix.dart` imports.**
- **`member_sheet_dialog.dart`** — `MemberSheetDialog` takes `KoheraUserSummary` (no `User` parameter) + pre-computed `powerLevel`, `isBanned`, `avatarResolver`. `showMemberSheet` is the conversion boundary.
- **`room_members_section.dart`** — Converts `List<User>` → `List<KoheraUserSummary>` at boundary via `toKoheraUserSummary`. Tracks banned users in a `Set<String>`.
- **`read_receipts.dart`** — `buildReceiptMap` returns `Map<String, List<KoheraReadReceipt>>`. `ReadReceiptsRow`/`showReadersSheet` take `AvatarResolver`, not `Client`.

### Collateral updates (15 UserAvatar call sites)
All `UserAvatar(...)` constructions updated to the new signature across: `mention_suggestion_overlay`, `search_result_tile`, `message_bubble`, `pinned_messages_popup`, `reaction_chips`, `room_tile`, `account_switcher`, `profile_avatar_card`, `space_rail`, `participant_tile`, `media_viewer_shell`.

## Acceptance criteria
- [x] `user_avatar.dart` has no `import 'package:matrix/matrix.dart'`
- [x] `member_sheet_dialog.dart` takes `KoheraUserSummary` and no `User` parameter
- [x] `room_members_section.dart` converts SDK `User` to `KoheraUserSummary` at boundary
- [x] `read_receipts.dart` no longer passes `Client` to avatar widgets
- [x] Avatar display, display name, and power level rendering preserved
- [x] `flutter analyze` passes with no new warnings
- [x] `flutter test` passes (2207 tests, all green)

## Design notes
- `KoheraUserSummary` deliberately omits `membership` and `powerLevel` — those will be added in `KoheraRoomMember` (slice #10 of epic #697).
- `MemberSheetDialog` keeps `Room` for moderation actions (kick/ban/unban/role-change/sync). Full Room decoupling deferred to #706.
- `AvatarResolver` follows the same sub-service pattern as `PresenceService` — injected into `MatrixService`, passed to widgets.

Refs #697