### PR TITLE
refactor(#706): wrap Room and User in KoheraRoomMemberList for member sections

### DIFF
--- a/lib/features/chat/widgets/chat_message_item.dart
+++ b/lib/features/chat/widgets/chat_message_item.dart
@@ -2,7 +2,10 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/utils/reply_fallback.dart';
 import 'package:kohera/features/chat/models/kohera_read_receipt.dart';
 import 'package:kohera/features/chat/services/media_content_resolver.dart';
@@ -26,8 +29,9 @@ import 'package:kohera/features/chat/widgets/reply_preview_host.dart';
 import 'package:kohera/features/chat/widgets/swipeable_message.dart';
 import 'package:kohera/features/chat/widgets/thread_indicator_chip.dart';
 import 'package:kohera/features/chat/widgets/video_bubble.dart';
+import 'package:kohera/features/rooms/models/kohera_room_member.dart';
+import 'package:kohera/features/rooms/services/power_level_service.dart';
 import 'package:kohera/features/rooms/widgets/member_sheet_dialog.dart';
-import 'package:kohera/shared/models/kohera_user_summary_mapper.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
@@ -271,11 +275,53 @@ class ChatMessageItem extends StatelessWidget {
 
   void _showSenderSheet(BuildContext context) {
     final sender = event.senderFromMemoryOrFallback;
-    unawaited(showMemberSheet(
+    final room = event.room;
+    final client = room.client;
+    final isMe = sender.id == client.userID;
+    final ownLevel = room.getPowerLevelByUserId(client.userID ?? '');
+    final member = KoheraRoomMember(
+      userId: sender.id,
+      displayname: sender.calcDisplayname(),
+      avatarUrl: sender.avatarUrl?.toString(),
+      membership: sender.membership.name,
+      powerLevel: room.getPowerLevelByUserId(sender.id),
+    );
+    unawaited(showMemberSheetDialog(
       context,
-      room: event.room,
-      user: toKoheraUserSummary(sender),
-      isBanned: sender.membership == Membership.ban,
+      member: member,
+      isMe: isMe,
+      ownLevel: ownLevel,
+      canChangeRole: !isMe && room.canChangePowerLevel && member.powerLevel < ownLevel,
+      canKick: !isMe && room.canKick && member.powerLevel < ownLevel && !member.isBanned,
+      canBan: !isMe && room.canBan && member.powerLevel < ownLevel && !member.isBanned,
+      avatarResolver: context.read<MatrixService>().avatarResolver,
+      presence: context.read<MatrixService>().presence,
+      onStartDm: isMe
+          ? null
+          : () async {
+              final dmRoomId = await client.startDirectChat(
+                member.userId,
+                enableEncryption: true,
+              );
+              if (client.getRoomById(dmRoomId) == null) {
+                await client
+                    .waitForRoomInSync(dmRoomId, join: true)
+                    .timeout(const Duration(seconds: 30));
+              }
+              if (!context.mounted) return;
+              context.read<SelectionService>().selectRoom(dmRoomId);
+              context.goNamed(
+                Routes.room,
+                pathParameters: {RouteParams.roomId: dmRoomId},
+              );
+            },
+      onRoleChange: (level) => PowerLevelService.update(
+        room,
+        PowerLevelPatch(users: {member.userId: level}),
+      ),
+      onKick: (reason) => client.kick(room.id, member.userId, reason: reason),
+      onBan: (reason) => client.ban(room.id, member.userId, reason: reason),
+      onUnban: () => client.unban(room.id, member.userId),
     ),);
   }
 

--- a/lib/features/chat/widgets/chat_message_item.dart
+++ b/lib/features/chat/widgets/chat_message_item.dart
@@ -2,10 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:go_router/go_router.dart';
-import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
-import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/utils/reply_fallback.dart';
 import 'package:kohera/features/chat/models/kohera_read_receipt.dart';
 import 'package:kohera/features/chat/services/media_content_resolver.dart';
@@ -30,8 +27,7 @@ import 'package:kohera/features/chat/widgets/swipeable_message.dart';
 import 'package:kohera/features/chat/widgets/thread_indicator_chip.dart';
 import 'package:kohera/features/chat/widgets/video_bubble.dart';
 import 'package:kohera/features/rooms/models/kohera_room_member.dart';
-import 'package:kohera/features/rooms/services/power_level_service.dart';
-import 'package:kohera/features/rooms/widgets/member_sheet_dialog.dart';
+import 'package:kohera/features/rooms/widgets/member_sheet_launcher.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
@@ -276,9 +272,6 @@ class ChatMessageItem extends StatelessWidget {
   void _showSenderSheet(BuildContext context) {
     final sender = event.senderFromMemoryOrFallback;
     final room = event.room;
-    final client = room.client;
-    final isMe = sender.id == client.userID;
-    final ownLevel = room.getPowerLevelByUserId(client.userID ?? '');
     final member = KoheraRoomMember(
       userId: sender.id,
       displayname: sender.calcDisplayname(),
@@ -286,43 +279,7 @@ class ChatMessageItem extends StatelessWidget {
       membership: sender.membership.name,
       powerLevel: room.getPowerLevelByUserId(sender.id),
     );
-    unawaited(showMemberSheetDialog(
-      context,
-      member: member,
-      isMe: isMe,
-      ownLevel: ownLevel,
-      canChangeRole: !isMe && room.canChangePowerLevel && member.powerLevel < ownLevel,
-      canKick: !isMe && room.canKick && member.powerLevel < ownLevel && !member.isBanned,
-      canBan: !isMe && room.canBan && member.powerLevel < ownLevel && !member.isBanned,
-      avatarResolver: context.read<MatrixService>().avatarResolver,
-      presence: context.read<MatrixService>().presence,
-      onStartDm: isMe
-          ? null
-          : () async {
-              final dmRoomId = await client.startDirectChat(
-                member.userId,
-                enableEncryption: true,
-              );
-              if (client.getRoomById(dmRoomId) == null) {
-                await client
-                    .waitForRoomInSync(dmRoomId, join: true)
-                    .timeout(const Duration(seconds: 30));
-              }
-              if (!context.mounted) return;
-              context.read<SelectionService>().selectRoom(dmRoomId);
-              context.goNamed(
-                Routes.room,
-                pathParameters: {RouteParams.roomId: dmRoomId},
-              );
-            },
-      onRoleChange: (level) => PowerLevelService.update(
-        room,
-        PowerLevelPatch(users: {member.userId: level}),
-      ),
-      onKick: (reason) => client.kick(room.id, member.userId, reason: reason),
-      onBan: (reason) => client.ban(room.id, member.userId, reason: reason),
-      onUnban: () => client.unban(room.id, member.userId),
-    ),);
+    unawaited(showRoomMemberSheet(context, room: room, member: member));
   }
 
   void _showMobileActions(

--- a/lib/features/rooms/models/kohera_room_member.dart
+++ b/lib/features/rooms/models/kohera_room_member.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/foundation.dart';
+
+// ── KoheraRoomMember ──────────────────────────────────────────
+
+/// A room member with pre-computed display fields and power level.
+///
+/// Composes the fields of [KoheraUserSummary] (userId, displayname,
+/// avatarUrl) and adds `membership` and `powerLevel`. Created by
+/// [RoomMemberListResolver] at the conversion boundary from
+/// `matrix_sdk.User` + `Room.getPowerLevelByUserId`.
+///
+/// This model replaces the simple `KoheraRoomMember` that was inline in
+/// `kohera_room_permissions.dart` — it adds `avatarUrl` and `membership`
+/// fields needed by the member list and member sheet dialog.
+@immutable
+class KoheraRoomMember {
+  const KoheraRoomMember({
+    required this.userId,
+    required this.displayname,
+    required this.membership,
+    required this.powerLevel,
+    this.avatarUrl,
+  });
+
+  /// The Matrix user ID (e.g. `@alice:example.com`).
+  final String userId;
+
+  /// The resolved display name (never null — falls back to userId).
+  final String displayname;
+
+  /// The `mxc://` avatar URI as a string, or `null` if no avatar.
+  final String? avatarUrl;
+
+  /// Membership state as a string: 'join', 'ban', 'leave', 'invite'.
+  final String membership;
+
+  /// The user's power level in this room.
+  final int powerLevel;
+
+  /// Convenience: whether this member is banned.
+  bool get isBanned => membership == 'ban';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is KoheraRoomMember && userId == other.userId;
+
+  @override
+  int get hashCode => userId.hashCode;
+
+  KoheraRoomMember copyWith({
+    String? userId,
+    String? displayname,
+    String? avatarUrl,
+    String? membership,
+    int? powerLevel,
+  }) =>
+      KoheraRoomMember(
+        userId: userId ?? this.userId,
+        displayname: displayname ?? this.displayname,
+        avatarUrl: avatarUrl ?? this.avatarUrl,
+        membership: membership ?? this.membership,
+        powerLevel: powerLevel ?? this.powerLevel,
+      );
+
+  @override
+  String toString() =>
+      'KoheraRoomMember(userId: $userId, displayname: $displayname, '
+      'avatarUrl: $avatarUrl, membership: $membership, '
+      'powerLevel: $powerLevel)';
+}
+
+// ── KoheraRoomMemberList ──────────────────────────────────────
+
+/// A pre-computed list of room members.
+///
+/// Created by [RoomMemberListResolver] at the conversion boundary.
+/// Widgets below the boundary consume this model — never `Room` directly.
+@immutable
+class KoheraRoomMemberList {
+  const KoheraRoomMemberList({
+    required this.members,
+    required this.participantListComplete,
+    required this.memberCount,
+  });
+
+  /// The member entries, sorted by power level (admins first, then mods,
+  /// then alphabetical).
+  final List<KoheraRoomMember> members;
+
+  /// Whether the participant list is complete (all members loaded from
+  /// the server).
+  final bool participantListComplete;
+
+  /// The joined member count from `room.summary.mJoinedMemberCount`.
+  final int memberCount;
+
+  bool get isEmpty => members.isEmpty;
+  bool get isNotEmpty => members.isNotEmpty;
+
+  @override
+  String toString() =>
+      'KoheraRoomMemberList(${members.length} members, '
+      'complete: $participantListComplete, count: $memberCount)';
+}

--- a/lib/features/rooms/models/kohera_room_permissions.dart
+++ b/lib/features/rooms/models/kohera_room_permissions.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:kohera/features/rooms/models/kohera_room_member.dart';
 
 // ── KoheraJoinRule ────────────────────────────────────────────
 
@@ -37,40 +38,6 @@ enum KoheraJoinRule {
         knock => 'knock',
         restricted => 'restricted',
       };
-}
-
-// ── KoheraRoomMember ──────────────────────────────────────────
-
-/// A room participant with their computed power level.
-///
-/// Pre-computed at the conversion boundary from
-/// `Room.getParticipants()` + `Room.getPowerLevelByUserId(userId)`.
-/// Will be upgraded to the full `KoheraRoomMember` from #706 when
-/// that lands.
-@immutable
-class KoheraRoomMember {
-  const KoheraRoomMember({
-    required this.userId,
-    required this.powerLevel,
-    this.displayName,
-  });
-
-  final String userId;
-  final String? displayName;
-  final int powerLevel;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is KoheraRoomMember && userId == other.userId;
-
-  @override
-  int get hashCode => userId.hashCode;
-
-  @override
-  String toString() =>
-      'KoheraRoomMember(userId: $userId, displayName: $displayName, '
-      'powerLevel: $powerLevel)';
 }
 
 // ── KoheraRoomPermissions ─────────────────────────────────────

--- a/lib/features/rooms/services/room_member_list_resolver.dart
+++ b/lib/features/rooms/services/room_member_list_resolver.dart
@@ -1,0 +1,40 @@
+import 'package:kohera/features/rooms/models/kohera_room_member.dart';
+import 'package:matrix/matrix.dart';
+
+// ── RoomMemberListResolver ───────────────────────────────────
+
+/// Converts a Matrix SDK `Room` into a Kohera-owned
+/// [KoheraRoomMemberList] at the conversion boundary.
+///
+/// Calls `room.requestParticipants()` (async, fetches from server) and
+/// maps each `User` to a [KoheraRoomMember] with pre-computed display
+/// name, avatar URL, membership, and power level.
+class RoomMemberListResolver {
+  const RoomMemberListResolver();
+
+  Future<KoheraRoomMemberList> resolve(Room room) async {
+    final users = await room.requestParticipants([Membership.join]);
+
+    final members = users.map((u) {
+      return KoheraRoomMember(
+        userId: u.id,
+        displayname: u.calcDisplayname(),
+        avatarUrl: u.avatarUrl?.toString(),
+        membership: u.membership.name,
+        powerLevel: room.getPowerLevelByUserId(u.id),
+      );
+    }).toList();
+
+    // Sort: admins first, then mods, then alphabetical by displayname.
+    members.sort((a, b) {
+      if (a.powerLevel != b.powerLevel) return b.powerLevel.compareTo(a.powerLevel);
+      return a.displayname.compareTo(b.displayname);
+    });
+
+    return KoheraRoomMemberList(
+      members: members,
+      participantListComplete: room.participantListComplete,
+      memberCount: room.summary.mJoinedMemberCount ?? 0,
+    );
+  }
+}

--- a/lib/features/rooms/services/room_permissions_resolver.dart
+++ b/lib/features/rooms/services/room_permissions_resolver.dart
@@ -1,3 +1,4 @@
+import 'package:kohera/features/rooms/models/kohera_room_member.dart';
 import 'package:kohera/features/rooms/models/kohera_room_permissions.dart';
 import 'package:matrix/matrix.dart';
 
@@ -21,7 +22,9 @@ class RoomPermissionsResolver {
     final participants = room.getParticipants().map((u) {
       return KoheraRoomMember(
         userId: u.id,
-        displayName: u.displayName,
+        displayname: u.calcDisplayname(),
+        avatarUrl: u.avatarUrl?.toString(),
+        membership: u.membership.name,
         powerLevel: room.getPowerLevelByUserId(u.id),
       );
     }).toList();

--- a/lib/features/rooms/widgets/member_sheet_dialog.dart
+++ b/lib/features/rooms/widgets/member_sheet_dialog.dart
@@ -31,7 +31,8 @@ Future<void> showMemberSheetDialog(
   Future<void> Function(int newLevel)? onRoleChange,
   Future<void> Function(String? reason)? onKick,
   Future<void> Function(String? reason)? onBan,
-  Future<void> Function()? onUnban,
+  Future<void> Function(String? reason)? onUnban,
+  String Function(Object error)? formatError,
 }) {
   return showDialog<void>(
     context: context,
@@ -49,6 +50,7 @@ Future<void> showMemberSheetDialog(
       onKick: onKick,
       onBan: onBan,
       onUnban: onUnban,
+      formatError: formatError,
     ),
   );
 }
@@ -70,6 +72,7 @@ class MemberSheetDialog extends StatefulWidget {
     this.onKick,
     this.onBan,
     this.onUnban,
+    this.formatError,
     super.key,
   });
 
@@ -85,7 +88,11 @@ class MemberSheetDialog extends StatefulWidget {
   final Future<void> Function(int newLevel)? onRoleChange;
   final Future<void> Function(String? reason)? onKick;
   final Future<void> Function(String? reason)? onBan;
-  final Future<void> Function()? onUnban;
+  final Future<void> Function(String? reason)? onUnban;
+
+  /// Formats caught errors for user-facing display.
+  /// When null, errors fall back to `e.toString()`.
+  final String Function(Object error)? formatError;
 
   @override
   State<MemberSheetDialog> createState() => _MemberSheetDialogState();
@@ -143,7 +150,7 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
     } catch (e) {
       if (mounted) {
         setState(() {
-          _roleError = e.toString();
+          _roleError = widget.formatError?.call(e) ?? e.toString();
           _roleLoading = false;
         });
       }
@@ -172,7 +179,7 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
       if (mounted) {
         setState(() {
           _actionLoading = false;
-          _actionError = e.toString();
+          _actionError = widget.formatError?.call(e) ?? e.toString();
         });
       }
     }
@@ -201,7 +208,7 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
       if (mounted) {
         setState(() {
           _actionLoading = false;
-          _actionError = e.toString();
+          _actionError = widget.formatError?.call(e) ?? e.toString();
         });
       }
     }
@@ -221,14 +228,14 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
       _actionError = null;
     });
     try {
-      await widget.onUnban?.call();
+      await widget.onUnban?.call(null);
       if (mounted) Navigator.pop(context);
     } catch (e) {
       debugPrint('[Kohera] Unban failed: $e');
       if (mounted) {
         setState(() {
           _actionLoading = false;
-          _actionError = e.toString();
+          _actionError = widget.formatError?.call(e) ?? e.toString();
         });
       }
     }

--- a/lib/features/rooms/widgets/member_sheet_dialog.dart
+++ b/lib/features/rooms/widgets/member_sheet_dialog.dart
@@ -2,82 +2,53 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:go_router/go_router.dart';
 import 'package:kohera/core/extensions/context_extension.dart';
-import 'package:kohera/core/routing/route_names.dart';
-import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/presence_service.dart';
-import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/utils/confirm_dialog.dart';
+import 'package:kohera/features/rooms/models/kohera_room_member.dart';
 import 'package:kohera/features/rooms/models/room_role.dart';
 import 'package:kohera/features/rooms/services/power_level_service.dart';
-import 'package:kohera/shared/models/kohera_user_summary.dart';
 import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
-import 'package:matrix/matrix.dart';
-import 'package:provider/provider.dart';
 
-/// Opens the member profile sheet for [user] in [room].
+/// Opens the member profile sheet for [member].
 ///
 /// Shows avatar, display name, Matrix ID, presence and role, plus a
 /// "Send message" action (others only) and moderation actions when the
-/// caller has permission. Reused by the room members list and chat avatars.
-Future<void> showMemberSheet(
+/// caller has permission. All SDK work is done by the caller — this
+/// function and [MemberSheetDialog] are SDK-free.
+Future<void> showMemberSheetDialog(
   BuildContext context, {
-  required Room room,
-  required KoheraUserSummary user,
-  bool isBanned = false,
+  required KoheraRoomMember member,
+  required bool isMe,
+  required int ownLevel,
+  required bool canChangeRole,
+  required bool canKick,
+  required bool canBan,
+  required AvatarResolver avatarResolver,
+  required PresenceService presence,
+  Future<void> Function()? onStartDm,
+  Future<void> Function(int newLevel)? onRoleChange,
+  Future<void> Function(String? reason)? onKick,
+  Future<void> Function(String? reason)? onBan,
+  Future<void> Function()? onUnban,
 }) {
-  final matrix = context.read<MatrixService>();
-  final isMe = user.userId == room.client.userID;
-  final ownLevel = room.getPowerLevelByUserId(room.client.userID!);
-  final powerLevel = room.getPowerLevelByUserId(user.userId);
-
-  Future<void> startDm() async {
-    if (!context.mounted) return;
-    final selection = context.read<SelectionService>();
-    final router = GoRouter.of(context);
-    final messenger = ScaffoldMessenger.of(context);
-    try {
-      final client = matrix.client;
-      final dmRoomId = await client.startDirectChat(
-        user.userId,
-        enableEncryption: true,
-      );
-      if (client.getRoomById(dmRoomId) == null) {
-        await client
-            .waitForRoomInSync(dmRoomId, join: true)
-            .timeout(const Duration(seconds: 30));
-      }
-      selection.selectRoom(dmRoomId);
-      router.goNamed(
-        Routes.room,
-        pathParameters: {RouteParams.roomId: dmRoomId},
-      );
-    } catch (e) {
-      debugPrint('[Kohera] Start DM failed: $e');
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(
-            'Failed to start chat: ${MatrixService.friendlyAuthError(e)}',
-          ),
-        ),
-      );
-    }
-  }
-
   return showDialog<void>(
     context: context,
     builder: (ctx) => MemberSheetDialog(
-      user: user,
-      room: room,
-      presence: matrix.presence,
-      ownLevel: ownLevel,
-      powerLevel: powerLevel,
-      isBanned: isBanned,
+      member: member,
       isMe: isMe,
-      avatarResolver: matrix.avatarResolver,
-      onStartDm: isMe ? null : startDm,
+      ownLevel: ownLevel,
+      canChangeRole: canChangeRole,
+      canKick: canKick,
+      canBan: canBan,
+      avatarResolver: avatarResolver,
+      presence: presence,
+      onStartDm: onStartDm,
+      onRoleChange: onRoleChange,
+      onKick: onKick,
+      onBan: onBan,
+      onUnban: onUnban,
     ),
   );
 }
@@ -86,27 +57,35 @@ Future<void> showMemberSheet(
 
 class MemberSheetDialog extends StatefulWidget {
   const MemberSheetDialog({
-    required this.user,
-    required this.room,
-    required this.presence,
-    required this.ownLevel,
-    required this.powerLevel,
-    required this.isBanned,
+    required this.member,
     required this.isMe,
+    required this.ownLevel,
+    required this.canChangeRole,
+    required this.canKick,
+    required this.canBan,
     required this.avatarResolver,
+    required this.presence,
     this.onStartDm,
+    this.onRoleChange,
+    this.onKick,
+    this.onBan,
+    this.onUnban,
     super.key,
   });
 
-  final KoheraUserSummary user;
-  final Room room;
-  final PresenceService presence;
-  final int ownLevel;
-  final int powerLevel;
-  final bool isBanned;
+  final KoheraRoomMember member;
   final bool isMe;
+  final int ownLevel;
+  final bool canChangeRole;
+  final bool canKick;
+  final bool canBan;
   final AvatarResolver avatarResolver;
+  final PresenceService presence;
   final Future<void> Function()? onStartDm;
+  final Future<void> Function(int newLevel)? onRoleChange;
+  final Future<void> Function(String? reason)? onKick;
+  final Future<void> Function(String? reason)? onBan;
+  final Future<void> Function()? onUnban;
 
   @override
   State<MemberSheetDialog> createState() => _MemberSheetDialogState();
@@ -117,30 +96,12 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
   String? _roleError;
   bool _actionLoading = false;
   String? _actionError;
-  StreamSubscription<SyncUpdate>? _syncSub;
-  Timer? _syncDebounce;
+  late int _currentPowerLevel;
 
   @override
   void initState() {
     super.initState();
-    _syncSub = widget.room.client.onSync.stream.listen(_onSync);
-  }
-
-  @override
-  void dispose() {
-    _syncDebounce?.cancel();
-    unawaited(_syncSub?.cancel());
-    super.dispose();
-  }
-
-  void _onSync(SyncUpdate update) {
-    final stateEvents =
-        update.rooms?.join?[widget.room.id]?.state ?? [];
-    if (!stateEvents.any((e) => e.type == EventTypes.RoomPowerLevels)) return;
-    _syncDebounce?.cancel();
-    _syncDebounce = Timer(const Duration(milliseconds: 300), () {
-      if (mounted) setState(() {});
-    });
+    _currentPowerLevel = widget.member.powerLevel;
   }
 
   Future<void> _changeRole(RoomRole newRole, int currentPowerLevel) async {
@@ -149,7 +110,7 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
 
     // Require explicit confirmation before demoting another admin.
     if (currentPowerLevel >= 100) {
-      final displayName = widget.user.displayname;
+      final displayName = widget.member.displayname;
       final confirmed = await confirmDialog(
         context,
         title: 'Demote admin?',
@@ -165,19 +126,32 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
       _roleError = null;
     });
     try {
-      await PowerLevelService.update(
-        widget.room,
-        PowerLevelPatch(users: {widget.user.userId: newRole.toPowerLevel()}),
-      );
+      await widget.onRoleChange?.call(newRole.toPowerLevel());
+      if (mounted) {
+        setState(() {
+          _currentPowerLevel = newRole.toPowerLevel();
+          _roleLoading = false;
+        });
+      }
     } on PowerLevelException catch (e) {
-      if (mounted) setState(() => _roleError = e.message);
-    } finally {
-      if (mounted) setState(() => _roleLoading = false);
+      if (mounted) {
+        setState(() {
+          _roleError = e.message;
+          _roleLoading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _roleError = e.toString();
+          _roleLoading = false;
+        });
+      }
     }
   }
 
   Future<void> _kick() async {
-    final displayName = widget.user.displayname;
+    final displayName = widget.member.displayname;
     final cs = Theme.of(context).colorScheme;
     final reason = await _promptModerationReason(
       title: 'Kick member?',
@@ -191,29 +165,26 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
       _actionError = null;
     });
     try {
-      await widget.room.client.kick(
-        widget.room.id,
-        widget.user.userId,
-        reason: reason.isEmpty ? null : reason,
-      );
+      await widget.onKick?.call(reason.isEmpty ? null : reason);
       if (mounted) Navigator.pop(context);
     } catch (e) {
       debugPrint('[Kohera] Kick failed: $e');
       if (mounted) {
         setState(() {
           _actionLoading = false;
-          _actionError = MatrixService.friendlyAuthError(e);
+          _actionError = e.toString();
         });
       }
     }
   }
 
   Future<void> _ban() async {
-    final displayName = widget.user.displayname;
+    final displayName = widget.member.displayname;
     final cs = Theme.of(context).colorScheme;
     final reason = await _promptModerationReason(
       title: 'Ban member?',
-      message: "Ban $displayName from this room? They won't be able to rejoin.",
+      message:
+          "Ban $displayName from this room? They won't be able to rejoin.",
       confirmLabel: 'Ban',
       cs: cs,
     );
@@ -223,25 +194,21 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
       _actionError = null;
     });
     try {
-      await widget.room.client.ban(
-        widget.room.id,
-        widget.user.userId,
-        reason: reason.isEmpty ? null : reason,
-      );
+      await widget.onBan?.call(reason.isEmpty ? null : reason);
       if (mounted) Navigator.pop(context);
     } catch (e) {
       debugPrint('[Kohera] Ban failed: $e');
       if (mounted) {
         setState(() {
           _actionLoading = false;
-          _actionError = MatrixService.friendlyAuthError(e);
+          _actionError = e.toString();
         });
       }
     }
   }
 
   Future<void> _unban() async {
-    final displayName = widget.user.displayname;
+    final displayName = widget.member.displayname;
     final confirmed = await confirmDialog(
       context,
       title: 'Unban member?',
@@ -254,14 +221,14 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
       _actionError = null;
     });
     try {
-      await widget.room.client.unban(widget.room.id, widget.user.userId);
+      await widget.onUnban?.call();
       if (mounted) Navigator.pop(context);
     } catch (e) {
       debugPrint('[Kohera] Unban failed: $e');
       if (mounted) {
         setState(() {
           _actionLoading = false;
-          _actionError = MatrixService.friendlyAuthError(e);
+          _actionError = e.toString();
         });
       }
     }
@@ -308,21 +275,23 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
         ownLevel: widget.ownLevel,
         targetCurrentLevel: powerLevel,
       );
-      items.add(DropdownMenuItem(
-        value: role,
-        enabled: canAssign,
-        child: Text(
-          role.label,
-          style: canAssign
-              ? null
-              : TextStyle(
-                  color: Theme.of(context)
-                      .colorScheme
-                      .onSurface
-                      .withValues(alpha: 0.38),
-                ),
+      items.add(
+        DropdownMenuItem(
+          value: role,
+          enabled: canAssign,
+          child: Text(
+            role.label,
+            style: canAssign
+                ? null
+                : TextStyle(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.38),
+                  ),
+          ),
         ),
-      ),);
+      );
     }
 
     return items;
@@ -332,25 +301,15 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
-    final user = widget.user;
-    final room = widget.room;
-    final powerLevel = widget.powerLevel;
+    final member = widget.member;
+    final isBanned = member.isBanned;
+    final powerLevel = _currentPowerLevel;
     final currentRole = RoomRole.fromPowerLevel(powerLevel);
-    final displayName = user.displayname;
-    final isBanned = widget.isBanned;
+    final displayName = member.displayname;
 
-    final canChangeRole = !widget.isMe &&
-        room.canChangePowerLevel &&
-        powerLevel < widget.ownLevel;
-    final canKick = !widget.isMe &&
-        room.canKick &&
-        powerLevel < widget.ownLevel &&
-        !isBanned;
-    final canBan = !widget.isMe &&
-        room.canBan &&
-        powerLevel < widget.ownLevel &&
-        !isBanned;
-    final canUnban = !widget.isMe && room.canBan && isBanned;
+    final canKick = widget.canKick && !isBanned;
+    final canBan = widget.canBan && !isBanned;
+    final canUnban = widget.canBan && isBanned;
 
     return SimpleDialog(
       titlePadding: const EdgeInsets.fromLTRB(24, 24, 24, 12),
@@ -358,9 +317,9 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
         children: [
           UserAvatar(
             avatarResolver: widget.avatarResolver,
-            userId: user.userId,
-            avatarUrl: user.avatarUrl,
-            displayname: user.displayname,
+            userId: member.userId,
+            avatarUrl: member.avatarUrl,
+            displayname: member.displayname,
             presence: widget.presence,
             size: 64,
           ),
@@ -375,7 +334,7 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
             children: [
               Flexible(
                 child: SelectableText(
-                  user.userId,
+                  member.userId,
                   style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
                   textAlign: TextAlign.center,
                 ),
@@ -387,7 +346,9 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
                 tooltip: 'Copy MXID',
                 color: cs.onSurfaceVariant,
                 onPressed: () {
-                  unawaited(Clipboard.setData(ClipboardData(text: user.userId)));
+                  unawaited(
+                    Clipboard.setData(ClipboardData(text: member.userId)),
+                  );
                   context.showSnack('Copied to clipboard');
                 },
               ),
@@ -418,7 +379,7 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
                 : DropdownButton<RoomRole>(
                     isExpanded: true,
                     value: currentRole,
-                    onChanged: canChangeRole
+                    onChanged: widget.canChangeRole
                         ? (newRole) {
                             if (newRole != null) {
                               unawaited(_changeRole(newRole, powerLevel));
@@ -565,8 +526,7 @@ class _ModerationReasonDialogState extends State<_ModerationReasonDialog> {
               labelText: 'Reason (optional)',
               border: OutlineInputBorder(),
             ),
-            onSubmitted: (_) =>
-                Navigator.pop(context, _controller.text.trim()),
+            onSubmitted: (_) => Navigator.pop(context, _controller.text.trim()),
           ),
         ],
       ),
@@ -580,8 +540,7 @@ class _ModerationReasonDialogState extends State<_ModerationReasonDialog> {
             backgroundColor: widget.confirmColor,
             foregroundColor: widget.onConfirmColor,
           ),
-          onPressed: () =>
-              Navigator.pop(context, _controller.text.trim()),
+          onPressed: () => Navigator.pop(context, _controller.text.trim()),
           child: Text(widget.confirmLabel),
         ),
       ],

--- a/lib/features/rooms/widgets/member_sheet_launcher.dart
+++ b/lib/features/rooms/widgets/member_sheet_launcher.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kohera/core/routing/route_names.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/services/sub_services/selection_service.dart';
+import 'package:kohera/features/rooms/models/kohera_room_member.dart';
+import 'package:kohera/features/rooms/services/power_level_service.dart';
+import 'package:kohera/features/rooms/widgets/member_sheet_dialog.dart';
+import 'package:matrix/matrix.dart';
+import 'package:provider/provider.dart';
+
+// ── Member sheet launcher ─────────────────────────────────────
+
+/// Opens the member profile sheet for [member] in [room].
+///
+/// This is the SDK boundary helper — it computes permissions from the
+/// [Room], wires all SDK callbacks (start DM, role change, kick, ban,
+/// unban), and delegates to the SDK-free [showMemberSheetDialog].
+///
+/// Use this from any widget that has a `Room` + `KoheraRoomMember`
+/// and needs to show the member profile sheet.
+Future<void> showRoomMemberSheet(
+  BuildContext context, {
+  required Room room,
+  required KoheraRoomMember member,
+}) {
+  final client = room.client;
+  final isMe = member.userId == client.userID;
+  final ownLevel = room.getPowerLevelByUserId(client.userID ?? '');
+
+  return showMemberSheetDialog(
+    context,
+    member: member,
+    isMe: isMe,
+    ownLevel: ownLevel,
+    canChangeRole:
+        !isMe && room.canChangePowerLevel && member.powerLevel < ownLevel,
+    canKick: !isMe &&
+        room.canKick &&
+        member.powerLevel < ownLevel &&
+        !member.isBanned,
+    canBan: !isMe &&
+        room.canBan &&
+        member.powerLevel < ownLevel &&
+        !member.isBanned,
+    avatarResolver: context.read<MatrixService>().avatarResolver,
+    presence: context.read<MatrixService>().presence,
+    formatError: MatrixService.friendlyAuthError,
+    onStartDm: isMe
+        ? null
+        : () async {
+            final dmRoomId = await client.startDirectChat(
+              member.userId,
+              enableEncryption: true,
+            );
+            if (client.getRoomById(dmRoomId) == null) {
+              await client
+                  .waitForRoomInSync(dmRoomId, join: true)
+                  .timeout(const Duration(seconds: 30));
+            }
+            if (!context.mounted) return;
+            context.read<SelectionService>().selectRoom(dmRoomId);
+            context.goNamed(
+              Routes.room,
+              pathParameters: {RouteParams.roomId: dmRoomId},
+            );
+          },
+    onRoleChange: (level) => PowerLevelService.update(
+      room,
+      PowerLevelPatch(users: {member.userId: level}),
+    ),
+    onKick: (reason) => client.kick(room.id, member.userId, reason: reason),
+    onBan: (reason) => client.ban(room.id, member.userId, reason: reason),
+    onUnban: (_) => client.unban(room.id, member.userId),
+  );
+}

--- a/lib/features/rooms/widgets/room_details_panel.dart
+++ b/lib/features/rooms/widgets/room_details_panel.dart
@@ -1,16 +1,21 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:kohera/core/routing/nav_helper.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:kohera/features/e2ee/widgets/key_verification_dialog.dart';
+import 'package:kohera/features/rooms/models/kohera_room_member.dart';
+import 'package:kohera/features/rooms/services/power_level_service.dart';
+import 'package:kohera/features/rooms/services/room_member_list_resolver.dart';
 import 'package:kohera/features/rooms/services/room_permissions_resolver.dart';
 import 'package:kohera/features/rooms/widgets/admin_settings_section.dart';
 import 'package:kohera/features/rooms/widgets/invite_user_dialog.dart';
 import 'package:kohera/features/rooms/widgets/join_access_controller.dart';
+import 'package:kohera/features/rooms/widgets/member_sheet_dialog.dart';
 import 'package:kohera/features/rooms/widgets/room_members_section.dart';
 import 'package:kohera/features/rooms/widgets/shared_media_section.dart';
 import 'package:kohera/shared/widgets/avatar_edit_overlay.dart';
@@ -44,6 +49,10 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
   StreamSubscription<SyncUpdate>? _syncSub;
   Timer? _syncDebounce;
   bool _deviceKeysExpanded = false;
+  KoheraRoomMemberList? _memberList;
+  bool _loadingMembers = false;
+  int? _lastMemberCount;
+  int _memberLoadGen = 0;
 
   bool get _loading => _inFlight.isNotEmpty;
   bool _busy(String action) => _inFlight.contains(action);
@@ -54,6 +63,18 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
   void initState() {
     super.initState();
     _refreshDeviceKeys();
+  }
+
+  @override
+  void didUpdateWidget(RoomDetailsPanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final room = context.read<MatrixService>().client.getRoomById(widget.roomId);
+    final count = room?.summary.mJoinedMemberCount;
+    if (count != null && count != _lastMemberCount) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        unawaited(_loadMembers(room!));
+      });
+    }
   }
 
   @override
@@ -78,6 +99,79 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
   }
 
   // ── Actions ────────────────────────────────────────────────
+
+  Future<void> _loadMembers(Room room) async {
+    final gen = ++_memberLoadGen;
+    setState(() => _loadingMembers = true);
+    try {
+      final list = await const RoomMemberListResolver().resolve(room);
+      if (!mounted || gen != _memberLoadGen) return;
+      setState(() {
+        _memberList = list;
+        _loadingMembers = false;
+        _lastMemberCount = list.memberCount;
+      });
+    } catch (e) {
+      debugPrint('[Kohera] Failed to load members: $e');
+      if (mounted) {
+        setState(() {
+          _memberList = const KoheraRoomMemberList(
+            members: [],
+            participantListComplete: false,
+            memberCount: 0,
+          );
+          _loadingMembers = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _showMemberSheet(
+    BuildContext context,
+    Room room,
+    KoheraRoomMember member,
+  ) async {
+    final client = room.client;
+    final isMe = member.userId == client.userID;
+    final ownLevel = room.getPowerLevelByUserId(client.userID ?? '');
+    await showMemberSheetDialog(
+      context,
+      member: member,
+      isMe: isMe,
+      ownLevel: ownLevel,
+      canChangeRole: !isMe && room.canChangePowerLevel && member.powerLevel < ownLevel,
+      canKick: !isMe && room.canKick && member.powerLevel < ownLevel && !member.isBanned,
+      canBan: !isMe && room.canBan && member.powerLevel < ownLevel && !member.isBanned,
+      avatarResolver: context.read<MatrixService>().avatarResolver,
+      presence: context.read<MatrixService>().presence,
+      onStartDm: isMe
+          ? null
+          : () async {
+              final dmRoomId = await client.startDirectChat(
+                member.userId,
+                enableEncryption: true,
+              );
+              if (client.getRoomById(dmRoomId) == null) {
+                await client
+                    .waitForRoomInSync(dmRoomId, join: true)
+                    .timeout(const Duration(seconds: 30));
+              }
+              if (!context.mounted) return;
+              context.read<SelectionService>().selectRoom(dmRoomId);
+              context.goNamed(
+                Routes.room,
+                pathParameters: {RouteParams.roomId: dmRoomId},
+              );
+            },
+      onRoleChange: (level) => PowerLevelService.update(
+        room,
+        PowerLevelPatch(users: {member.userId: level}),
+      ),
+      onKick: (reason) => client.kick(room.id, member.userId, reason: reason),
+      onBan: (reason) => client.ban(room.id, member.userId, reason: reason),
+      onUnban: () => client.unban(room.id, member.userId),
+    );
+  }
 
   Future<void> _run(String action, Future<void> Function() task) async {
     setState(() { _inFlight.add(action); _error = null; });
@@ -183,6 +277,12 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
   }
 
   Widget _buildContent(Room room, MatrixService matrix, ColorScheme cs, TextTheme tt) {
+    if (_memberList == null && !_loadingMembers) {
+      _loadingMembers = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        unawaited(_loadMembers(room));
+      });
+    }
     return ListView(
       padding: const EdgeInsets.only(bottom: 32),
       children: [
@@ -198,7 +298,14 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
         const Divider(),
         JoinAccessController(room: room),
         const Divider(),
-        RoomMembersSection(room: room),
+        if (_memberList != null)
+          RoomMembersSection(
+            members: _memberList!,
+            onMemberTap: (member) =>
+                _showMemberSheet(context, room, member),
+            avatarResolver: matrix.avatarResolver,
+            presence: matrix.presence,
+          ),
         const Divider(),
         _buildEncryptionSection(room, cs, tt),
         const Divider(),

--- a/lib/features/rooms/widgets/room_details_panel.dart
+++ b/lib/features/rooms/widgets/room_details_panel.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:kohera/core/routing/nav_helper.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
@@ -9,13 +8,12 @@ import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:kohera/features/e2ee/widgets/key_verification_dialog.dart';
 import 'package:kohera/features/rooms/models/kohera_room_member.dart';
-import 'package:kohera/features/rooms/services/power_level_service.dart';
 import 'package:kohera/features/rooms/services/room_member_list_resolver.dart';
 import 'package:kohera/features/rooms/services/room_permissions_resolver.dart';
 import 'package:kohera/features/rooms/widgets/admin_settings_section.dart';
 import 'package:kohera/features/rooms/widgets/invite_user_dialog.dart';
 import 'package:kohera/features/rooms/widgets/join_access_controller.dart';
-import 'package:kohera/features/rooms/widgets/member_sheet_dialog.dart';
+import 'package:kohera/features/rooms/widgets/member_sheet_launcher.dart';
 import 'package:kohera/features/rooms/widgets/room_members_section.dart';
 import 'package:kohera/features/rooms/widgets/shared_media_section.dart';
 import 'package:kohera/shared/widgets/avatar_edit_overlay.dart';
@@ -63,6 +61,10 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
   void initState() {
     super.initState();
     _refreshDeviceKeys();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final room = context.read<MatrixService>().client.getRoomById(widget.roomId);
+      if (room != null) unawaited(_loadMembers(room));
+    });
   }
 
   @override
@@ -70,9 +72,9 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
     super.didUpdateWidget(oldWidget);
     final room = context.read<MatrixService>().client.getRoomById(widget.roomId);
     final count = room?.summary.mJoinedMemberCount;
-    if (count != null && count != _lastMemberCount) {
+    if (count != null && count != _lastMemberCount && !_loadingMembers) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        unawaited(_loadMembers(room!));
+        if (mounted && room != null) unawaited(_loadMembers(room));
       });
     }
   }
@@ -90,10 +92,19 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
       if (mounted) setState(() {});
     },),);
     unawaited(_syncSub?.cancel());
-    _syncSub = client.onSync.stream.listen((_) {
+    _syncSub = client.onSync.stream.listen((update) {
+      // Detect power-level changes to reload members.
+      final stateEvents = update.rooms?.join?[widget.roomId]?.state ?? [];
+      final hasPowerLevelChanges =
+          stateEvents.any((e) => e.type == EventTypes.RoomPowerLevels);
       _syncDebounce?.cancel();
       _syncDebounce = Timer(const Duration(seconds: 2), () {
-        if (mounted) setState(() {});
+        if (!mounted) return;
+        setState(() {});
+        if (hasPowerLevelChanges && _memberList != null) {
+          final room = client.getRoomById(widget.roomId);
+          if (room != null) unawaited(_loadMembers(room));
+        }
       });
     });
   }
@@ -102,7 +113,9 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
 
   Future<void> _loadMembers(Room room) async {
     final gen = ++_memberLoadGen;
-    setState(() => _loadingMembers = true);
+    setState(() {
+      _loadingMembers = true;
+    });
     try {
       final list = await const RoomMemberListResolver().resolve(room);
       if (!mounted || gen != _memberLoadGen) return;
@@ -115,11 +128,6 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
       debugPrint('[Kohera] Failed to load members: $e');
       if (mounted) {
         setState(() {
-          _memberList = const KoheraRoomMemberList(
-            members: [],
-            participantListComplete: false,
-            memberCount: 0,
-          );
           _loadingMembers = false;
         });
       }
@@ -130,47 +138,8 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
     BuildContext context,
     Room room,
     KoheraRoomMember member,
-  ) async {
-    final client = room.client;
-    final isMe = member.userId == client.userID;
-    final ownLevel = room.getPowerLevelByUserId(client.userID ?? '');
-    await showMemberSheetDialog(
-      context,
-      member: member,
-      isMe: isMe,
-      ownLevel: ownLevel,
-      canChangeRole: !isMe && room.canChangePowerLevel && member.powerLevel < ownLevel,
-      canKick: !isMe && room.canKick && member.powerLevel < ownLevel && !member.isBanned,
-      canBan: !isMe && room.canBan && member.powerLevel < ownLevel && !member.isBanned,
-      avatarResolver: context.read<MatrixService>().avatarResolver,
-      presence: context.read<MatrixService>().presence,
-      onStartDm: isMe
-          ? null
-          : () async {
-              final dmRoomId = await client.startDirectChat(
-                member.userId,
-                enableEncryption: true,
-              );
-              if (client.getRoomById(dmRoomId) == null) {
-                await client
-                    .waitForRoomInSync(dmRoomId, join: true)
-                    .timeout(const Duration(seconds: 30));
-              }
-              if (!context.mounted) return;
-              context.read<SelectionService>().selectRoom(dmRoomId);
-              context.goNamed(
-                Routes.room,
-                pathParameters: {RouteParams.roomId: dmRoomId},
-              );
-            },
-      onRoleChange: (level) => PowerLevelService.update(
-        room,
-        PowerLevelPatch(users: {member.userId: level}),
-      ),
-      onKick: (reason) => client.kick(room.id, member.userId, reason: reason),
-      onBan: (reason) => client.ban(room.id, member.userId, reason: reason),
-      onUnban: () => client.unban(room.id, member.userId),
-    );
+  ) {
+    return showRoomMemberSheet(context, room: room, member: member);
   }
 
   Future<void> _run(String action, Future<void> Function() task) async {
@@ -277,12 +246,7 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
   }
 
   Widget _buildContent(Room room, MatrixService matrix, ColorScheme cs, TextTheme tt) {
-    if (_memberList == null && !_loadingMembers) {
-      _loadingMembers = true;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        unawaited(_loadMembers(room));
-      });
-    }
+    // Initial member load is triggered in initState — no side effects in build.
     return ListView(
       padding: const EdgeInsets.only(bottom: 32),
       children: [

--- a/lib/features/rooms/widgets/room_members_section.dart
+++ b/lib/features/rooms/widgets/room_members_section.dart
@@ -79,15 +79,7 @@ class _RoomMembersSectionState extends State<RoomMembersSection> {
           ),
         ),
         if (widget.members.isEmpty)
-          const Padding(
-            padding: EdgeInsets.all(16),
-            child: Center(
-              child: Text(
-                'No members',
-                style: TextStyle(color: Colors.grey),
-              ),
-            ),
-          )
+          const SizedBox.shrink()
         else ...[
           if (widget.members.members.length > 5)
             Padding(

--- a/lib/features/rooms/widgets/room_members_section.dart
+++ b/lib/features/rooms/widgets/room_members_section.dart
@@ -1,62 +1,48 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
-import 'package:kohera/core/services/matrix_service.dart';
-import 'package:kohera/features/rooms/widgets/member_sheet_dialog.dart';
-import 'package:kohera/shared/models/kohera_user_summary.dart';
-import 'package:kohera/shared/models/kohera_user_summary_mapper.dart';
+import 'package:kohera/core/services/sub_services/presence_service.dart';
+import 'package:kohera/features/rooms/models/kohera_room_member.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
-import 'package:matrix/matrix.dart';
-import 'package:provider/provider.dart';
 
 /// Displays a scrollable list of room members with role badges.
-/// Loads members asynchronously and shows the first 5 with an expand option.
+/// Shows the first 5 with an expand option and a search filter.
+///
+/// This widget is SDK-free — all data comes from [KoheraRoomMemberList]
+/// and all interactions are handled by the [onMemberTap] callback.
 class RoomMembersSection extends StatefulWidget {
-  const RoomMembersSection({required this.room, super.key});
+  const RoomMembersSection({
+    required this.members,
+    required this.onMemberTap,
+    required this.avatarResolver,
+    required this.presence,
+    super.key,
+  });
 
-  final Room room;
+  final KoheraRoomMemberList members;
+  final void Function(KoheraRoomMember member) onMemberTap;
+  final AvatarResolver avatarResolver;
+  final PresenceService presence;
 
   @override
   State<RoomMembersSection> createState() => _RoomMembersSectionState();
 }
 
 class _RoomMembersSectionState extends State<RoomMembersSection> {
-  List<KoheraUserSummary> _members = [];
-  final Set<String> _bannedUserIds = {};
-  bool _loading = true;
   bool _expanded = false;
-  int? _lastMemberCount;
-  int _loadGeneration = 0;
   final TextEditingController _searchController = TextEditingController();
   String _query = '';
-  StreamSubscription<SyncUpdate>? _syncSub;
-  Timer? _syncDebounce;
 
   @override
   void initState() {
     super.initState();
-    unawaited(_loadMembers());
     _searchController.addListener(_onSearchChanged);
-    _syncSub = widget.room.client.onSync.stream.listen(_onSync);
   }
 
   @override
   void dispose() {
-    _syncDebounce?.cancel();
-    unawaited(_syncSub?.cancel());
     _searchController.removeListener(_onSearchChanged);
     _searchController.dispose();
     super.dispose();
-  }
-
-  void _onSync(SyncUpdate update) {
-    final stateEvents =
-        update.rooms?.join?[widget.room.id]?.state ?? [];
-    if (!stateEvents.any((e) => e.type == EventTypes.RoomPowerLevels)) return;
-    _syncDebounce?.cancel();
-    _syncDebounce = Timer(const Duration(milliseconds: 300), () {
-      if (mounted) unawaited(_loadMembers());
-    });
   }
 
   void _onSearchChanged() {
@@ -65,62 +51,13 @@ class _RoomMembersSectionState extends State<RoomMembersSection> {
     setState(() => _query = next);
   }
 
-  List<KoheraUserSummary> _filtered() {
-    if (_query.isEmpty) return _members;
-    return _members.where((u) {
-      final name = u.displayname.toLowerCase();
-      final id = u.userId.toLowerCase();
+  List<KoheraRoomMember> _filtered() {
+    if (_query.isEmpty) return widget.members.members;
+    return widget.members.members.where((m) {
+      final name = m.displayname.toLowerCase();
+      final id = m.userId.toLowerCase();
       return name.contains(_query) || id.contains(_query);
     }).toList();
-  }
-
-  @override
-  void didUpdateWidget(RoomMembersSection oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    final currentCount = widget.room.summary.mJoinedMemberCount;
-    if (currentCount != _lastMemberCount) {
-      unawaited(_loadMembers());
-    }
-  }
-
-  Future<void> _loadMembers() async {
-    final gen = ++_loadGeneration;
-    setState(() => _loading = true);
-    try {
-      final members = await widget.room.requestParticipants([Membership.join]);
-      if (!mounted || gen != _loadGeneration) return;
-      // Convert SDK User → KoheraUserSummary at the boundary.
-      // Track banned users separately since KoheraUserSummary has no
-      // membership field (deferred to KoheraRoomMember, slice #10).
-      final bannedIds = <String>{};
-      for (final u in members) {
-        if (u.membership == Membership.ban) bannedIds.add(u.id);
-      }
-      final summaries = members.map(toKoheraUserSummary).toList();
-      // Sort: admins first, then mods, then alphabetical.
-      summaries.sort((a, b) {
-        final pa = widget.room.getPowerLevelByUserId(a.userId);
-        final pb = widget.room.getPowerLevelByUserId(b.userId);
-        if (pa != pb) return pb.compareTo(pa);
-        return a.displayname.compareTo(b.displayname);
-      });
-      setState(() {
-        _members = summaries;
-        _bannedUserIds
-          ..clear()
-          ..addAll(bannedIds);
-        _loading = false;
-        _lastMemberCount = widget.room.summary.mJoinedMemberCount;
-      });
-    } catch (e) {
-      debugPrint('[Kohera] Failed to load members: $e');
-      if (mounted) {
-        setState(() {
-          _loading = false;
-          _lastMemberCount = widget.room.summary.mJoinedMemberCount;
-        });
-      }
-    }
   }
 
   @override
@@ -141,13 +78,18 @@ class _RoomMembersSectionState extends State<RoomMembersSection> {
             ),
           ),
         ),
-        if (_loading)
+        if (widget.members.isEmpty)
           const Padding(
             padding: EdgeInsets.all(16),
-            child: Center(child: CircularProgressIndicator()),
+            child: Center(
+              child: Text(
+                'No members',
+                style: TextStyle(color: Colors.grey),
+              ),
+            ),
           )
         else ...[
-          if (_members.length > 5)
+          if (widget.members.members.length > 5)
             Padding(
               padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
               child: TextField(
@@ -184,9 +126,10 @@ class _RoomMembersSectionState extends State<RoomMembersSection> {
               children: [
                 for (final member in visible)
                   _MemberTile(
-                    user: member,
-                    room: widget.room,
-                    isBanned: _bannedUserIds.contains(member.userId),
+                    member: member,
+                    avatarResolver: widget.avatarResolver,
+                    presence: widget.presence,
+                    onTap: () => widget.onMemberTap(member),
                   ),
                 if (!showAll && filtered.length > 5)
                   TextButton(
@@ -207,51 +150,47 @@ class _RoomMembersSectionState extends State<RoomMembersSection> {
 
 // ── Member tile ────────────────────────────────────────────────
 
-class _MemberTile extends StatefulWidget {
+class _MemberTile extends StatelessWidget {
   const _MemberTile({
-    required this.user,
-    required this.room,
-    this.isBanned = false,
+    required this.member,
+    required this.avatarResolver,
+    required this.presence,
+    required this.onTap,
   });
 
-  final KoheraUserSummary user;
-  final Room room;
-  final bool isBanned;
+  final KoheraRoomMember member;
+  final AvatarResolver avatarResolver;
+  final PresenceService presence;
+  final VoidCallback onTap;
 
-  @override
-  State<_MemberTile> createState() => _MemberTileState();
-}
-
-class _MemberTileState extends State<_MemberTile> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
-    final powerLevel = widget.room.getPowerLevelByUserId(widget.user.userId);
-    final displayName = widget.user.displayname;
+    final powerLevel = member.powerLevel;
 
     return ListTile(
       dense: true,
       leading: UserAvatar(
-        avatarResolver: context.read<MatrixService>().avatarResolver,
-        userId: widget.user.userId,
-        avatarUrl: widget.user.avatarUrl,
-        displayname: widget.user.displayname,
-        presence: context.read<MatrixService>().presence,
+        avatarResolver: avatarResolver,
+        userId: member.userId,
+        avatarUrl: member.avatarUrl,
+        displayname: member.displayname,
+        presence: presence,
         size: 32,
       ),
       title: Text(
-        displayName,
+        member.displayname,
         overflow: TextOverflow.ellipsis,
         style: tt.bodyMedium,
       ),
       subtitle: Text(
-        widget.user.userId,
+        member.userId,
         style: tt.bodySmall,
         overflow: TextOverflow.ellipsis,
       ),
       trailing: _roleBadge(powerLevel, cs),
-      onTap: _showMemberSheet,
+      onTap: onTap,
     );
   }
 
@@ -283,14 +222,5 @@ class _MemberTileState extends State<_MemberTile> {
       );
     }
     return null;
-  }
-
-  void _showMemberSheet() {
-    unawaited(showMemberSheet(
-      context,
-      room: widget.room,
-      user: widget.user,
-      isBanned: widget.isBanned,
-    ),);
   }
 }

--- a/lib/features/spaces/widgets/space_details_panel.dart
+++ b/lib/features/spaces/widgets/space_details_panel.dart
@@ -1,12 +1,19 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/services/sub_services/selection_service.dart';
+import 'package:kohera/features/rooms/models/kohera_room_member.dart';
+import 'package:kohera/features/rooms/services/power_level_service.dart';
+import 'package:kohera/features/rooms/services/room_member_list_resolver.dart';
 import 'package:kohera/features/rooms/services/room_permissions_resolver.dart';
 import 'package:kohera/features/rooms/widgets/admin_settings_section.dart';
 import 'package:kohera/features/rooms/widgets/invite_user_dialog.dart';
 import 'package:kohera/features/rooms/widgets/join_access_controller.dart';
+import 'package:kohera/features/rooms/widgets/member_sheet_dialog.dart';
 import 'package:kohera/features/rooms/widgets/room_members_section.dart';
 import 'package:kohera/features/spaces/widgets/notification_radio_group.dart';
 import 'package:kohera/features/spaces/widgets/space_action_dialog.dart';
@@ -38,11 +45,84 @@ class SpaceDetailsPanel extends StatefulWidget {
 class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
   final Set<String> _inFlight = {};
   String? _error;
+  KoheraRoomMemberList? _memberList;
+  bool _loadingMembers = false;
 
   bool get _loading => _inFlight.isNotEmpty;
   bool _busy(String action) => _inFlight.contains(action);
 
   // ── Actions ────────────────────────────────────────────────
+
+  Future<void> _loadMembers(Room space) async {
+    setState(() => _loadingMembers = true);
+    try {
+      final list = await const RoomMemberListResolver().resolve(space);
+      if (!mounted) return;
+      setState(() {
+        _memberList = list;
+        _loadingMembers = false;
+      });
+    } catch (e) {
+      debugPrint('[Kohera] Failed to load members: $e');
+      if (mounted) {
+        setState(() {
+          _memberList = const KoheraRoomMemberList(
+            members: [],
+            participantListComplete: false,
+            memberCount: 0,
+          );
+          _loadingMembers = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _showMemberSheet(
+    BuildContext context,
+    Room space,
+    KoheraRoomMember member,
+  ) async {
+    final client = space.client;
+    final isMe = member.userId == client.userID;
+    final ownLevel = space.getPowerLevelByUserId(client.userID ?? '');
+    await showMemberSheetDialog(
+      context,
+      member: member,
+      isMe: isMe,
+      ownLevel: ownLevel,
+      canChangeRole: !isMe && space.canChangePowerLevel && member.powerLevel < ownLevel,
+      canKick: !isMe && space.canKick && member.powerLevel < ownLevel && !member.isBanned,
+      canBan: !isMe && space.canBan && member.powerLevel < ownLevel && !member.isBanned,
+      avatarResolver: context.read<MatrixService>().avatarResolver,
+      presence: context.read<MatrixService>().presence,
+      onStartDm: isMe
+          ? null
+          : () async {
+              final dmRoomId = await client.startDirectChat(
+                member.userId,
+                enableEncryption: true,
+              );
+              if (client.getRoomById(dmRoomId) == null) {
+                await client
+                    .waitForRoomInSync(dmRoomId, join: true)
+                    .timeout(const Duration(seconds: 30));
+              }
+              if (!context.mounted) return;
+              context.read<SelectionService>().selectRoom(dmRoomId);
+              context.goNamed(
+                Routes.room,
+                pathParameters: {RouteParams.roomId: dmRoomId},
+              );
+            },
+      onRoleChange: (level) => PowerLevelService.update(
+        space,
+        PowerLevelPatch(users: {member.userId: level}),
+      ),
+      onKick: (reason) => client.kick(space.id, member.userId, reason: reason),
+      onBan: (reason) => client.ban(space.id, member.userId, reason: reason),
+      onUnban: () => client.unban(space.id, member.userId),
+    );
+  }
 
   Future<void> _run(String action, Future<void> Function() task) async {
     setState(() { _inFlight.add(action); _error = null; });
@@ -110,6 +190,12 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
   }
 
   Widget _buildContent(Room space, ColorScheme cs, TextTheme tt) {
+    if (_memberList == null && !_loadingMembers) {
+      _loadingMembers = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        unawaited(_loadMembers(space));
+      });
+    }
     return ListView(
       padding: const EdgeInsets.only(bottom: 32),
       children: [
@@ -128,7 +214,14 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
           candidatesBuilder: _parentSpaceCandidates,
         ),
         const Divider(),
-        RoomMembersSection(room: space),
+        if (_memberList != null)
+          RoomMembersSection(
+            members: _memberList!,
+            onMemberTap: (member) =>
+                _showMemberSheet(context, space, member),
+            avatarResolver: context.read<MatrixService>().avatarResolver,
+            presence: context.read<MatrixService>().presence,
+          ),
         const Divider(),
         _buildNotificationSection(space, cs, tt),
         if (space.canChangeStateEvent(EventTypes.RoomName) ||

--- a/lib/features/spaces/widgets/space_details_panel.dart
+++ b/lib/features/spaces/widgets/space_details_panel.dart
@@ -5,15 +5,13 @@ import 'package:go_router/go_router.dart';
 import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
-import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/rooms/models/kohera_room_member.dart';
-import 'package:kohera/features/rooms/services/power_level_service.dart';
 import 'package:kohera/features/rooms/services/room_member_list_resolver.dart';
 import 'package:kohera/features/rooms/services/room_permissions_resolver.dart';
 import 'package:kohera/features/rooms/widgets/admin_settings_section.dart';
 import 'package:kohera/features/rooms/widgets/invite_user_dialog.dart';
 import 'package:kohera/features/rooms/widgets/join_access_controller.dart';
-import 'package:kohera/features/rooms/widgets/member_sheet_dialog.dart';
+import 'package:kohera/features/rooms/widgets/member_sheet_launcher.dart';
 import 'package:kohera/features/rooms/widgets/room_members_section.dart';
 import 'package:kohera/features/spaces/widgets/notification_radio_group.dart';
 import 'package:kohera/features/spaces/widgets/space_action_dialog.dart';
@@ -47,32 +45,81 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
   String? _error;
   KoheraRoomMemberList? _memberList;
   bool _loadingMembers = false;
+  int? _lastMemberCount;
+  int _memberLoadGen = 0;
+  StreamSubscription<SyncUpdate>? _syncSub;
+  Timer? _syncDebounce;
 
   bool get _loading => _inFlight.isNotEmpty;
   bool _busy(String action) => _inFlight.contains(action);
 
+  // ── Lifecycle ───────────────────────────────────────────────
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final space = context.read<MatrixService>().client.getRoomById(widget.spaceId);
+      if (space != null) unawaited(_loadMembers(space));
+      _setupSyncListener();
+    });
+  }
+
+  @override
+  void didUpdateWidget(SpaceDetailsPanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final space = context.read<MatrixService>().client.getRoomById(widget.spaceId);
+    final count = space?.summary.mJoinedMemberCount;
+    if (count != null && count != _lastMemberCount && !_loadingMembers) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && space != null) unawaited(_loadMembers(space));
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _syncDebounce?.cancel();
+    unawaited(_syncSub?.cancel());
+    super.dispose();
+  }
+
+  void _setupSyncListener() {
+    final client = context.read<MatrixService>().client;
+    unawaited(_syncSub?.cancel());
+    _syncSub = client.onSync.stream.listen((update) {
+      final stateEvents = update.rooms?.join?[widget.spaceId]?.state ?? [];
+      final hasPowerLevelChanges =
+          stateEvents.any((e) => e.type == EventTypes.RoomPowerLevels);
+      _syncDebounce?.cancel();
+      _syncDebounce = Timer(const Duration(seconds: 2), () {
+        if (!mounted) return;
+        setState(() {});
+        if (hasPowerLevelChanges && _memberList != null) {
+          final space = client.getRoomById(widget.spaceId);
+          if (space != null) unawaited(_loadMembers(space));
+        }
+      });
+    });
+  }
+
   // ── Actions ────────────────────────────────────────────────
 
   Future<void> _loadMembers(Room space) async {
+    final gen = ++_memberLoadGen;
     setState(() => _loadingMembers = true);
     try {
       final list = await const RoomMemberListResolver().resolve(space);
-      if (!mounted) return;
+      if (!mounted || gen != _memberLoadGen) return;
       setState(() {
         _memberList = list;
         _loadingMembers = false;
+        _lastMemberCount = list.memberCount;
       });
     } catch (e) {
       debugPrint('[Kohera] Failed to load members: $e');
       if (mounted) {
-        setState(() {
-          _memberList = const KoheraRoomMemberList(
-            members: [],
-            participantListComplete: false,
-            memberCount: 0,
-          );
-          _loadingMembers = false;
-        });
+        setState(() => _loadingMembers = false);
       }
     }
   }
@@ -81,47 +128,8 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
     BuildContext context,
     Room space,
     KoheraRoomMember member,
-  ) async {
-    final client = space.client;
-    final isMe = member.userId == client.userID;
-    final ownLevel = space.getPowerLevelByUserId(client.userID ?? '');
-    await showMemberSheetDialog(
-      context,
-      member: member,
-      isMe: isMe,
-      ownLevel: ownLevel,
-      canChangeRole: !isMe && space.canChangePowerLevel && member.powerLevel < ownLevel,
-      canKick: !isMe && space.canKick && member.powerLevel < ownLevel && !member.isBanned,
-      canBan: !isMe && space.canBan && member.powerLevel < ownLevel && !member.isBanned,
-      avatarResolver: context.read<MatrixService>().avatarResolver,
-      presence: context.read<MatrixService>().presence,
-      onStartDm: isMe
-          ? null
-          : () async {
-              final dmRoomId = await client.startDirectChat(
-                member.userId,
-                enableEncryption: true,
-              );
-              if (client.getRoomById(dmRoomId) == null) {
-                await client
-                    .waitForRoomInSync(dmRoomId, join: true)
-                    .timeout(const Duration(seconds: 30));
-              }
-              if (!context.mounted) return;
-              context.read<SelectionService>().selectRoom(dmRoomId);
-              context.goNamed(
-                Routes.room,
-                pathParameters: {RouteParams.roomId: dmRoomId},
-              );
-            },
-      onRoleChange: (level) => PowerLevelService.update(
-        space,
-        PowerLevelPatch(users: {member.userId: level}),
-      ),
-      onKick: (reason) => client.kick(space.id, member.userId, reason: reason),
-      onBan: (reason) => client.ban(space.id, member.userId, reason: reason),
-      onUnban: () => client.unban(space.id, member.userId),
-    );
+  ) {
+    return showRoomMemberSheet(context, room: space, member: member);
   }
 
   Future<void> _run(String action, Future<void> Function() task) async {
@@ -190,12 +198,7 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
   }
 
   Widget _buildContent(Room space, ColorScheme cs, TextTheme tt) {
-    if (_memberList == null && !_loadingMembers) {
-      _loadingMembers = true;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        unawaited(_loadMembers(space));
-      });
-    }
+    // Initial member load is triggered in initState — no side effects in build.
     return ListView(
       padding: const EdgeInsets.only(bottom: 32),
       children: [

--- a/test/models/kohera_room_member_test.dart
+++ b/test/models/kohera_room_member_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/features/rooms/models/kohera_room_member.dart';
+
+void main() {
+  group('KoheraRoomMember', () {
+    test('constructs with all fields', () {
+      const member = KoheraRoomMember(
+        userId: '@alice:example.com',
+        displayname: 'Alice',
+        avatarUrl: 'mxc://example.com/avatar',
+        membership: 'join',
+        powerLevel: 100,
+      );
+
+      expect(member.userId, '@alice:example.com');
+      expect(member.displayname, 'Alice');
+      expect(member.avatarUrl, 'mxc://example.com/avatar');
+      expect(member.membership, 'join');
+      expect(member.powerLevel, 100);
+    });
+
+    test('isBanned is true when membership is ban', () {
+      const member = KoheraRoomMember(
+        userId: '@bob:example.com',
+        displayname: 'Bob',
+        membership: 'ban',
+        powerLevel: 0,
+      );
+      expect(member.isBanned, isTrue);
+    });
+
+    test('isBanned is false when membership is join', () {
+      const member = KoheraRoomMember(
+        userId: '@bob:example.com',
+        displayname: 'Bob',
+        membership: 'join',
+        powerLevel: 0,
+      );
+      expect(member.isBanned, isFalse);
+    });
+
+    test('equality is based on userId', () {
+      const a = KoheraRoomMember(
+        userId: '@alice:example.com',
+        displayname: 'Alice',
+        membership: 'join',
+        powerLevel: 100,
+      );
+      const b = KoheraRoomMember(
+        userId: '@alice:example.com',
+        displayname: 'Alice 2',
+        membership: 'ban',
+        powerLevel: 0,
+      );
+      const c = KoheraRoomMember(
+        userId: '@bob:example.com',
+        displayname: 'Bob',
+        membership: 'join',
+        powerLevel: 0,
+      );
+
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('copyWith preserves un-overridden fields', () {
+      const member = KoheraRoomMember(
+        userId: '@alice:example.com',
+        displayname: 'Alice',
+        avatarUrl: 'mxc://example.com/avatar',
+        membership: 'join',
+        powerLevel: 50,
+      );
+
+      final copy = member.copyWith(powerLevel: 100);
+      expect(copy.userId, '@alice:example.com');
+      expect(copy.displayname, 'Alice');
+      expect(copy.avatarUrl, 'mxc://example.com/avatar');
+      expect(copy.membership, 'join');
+      expect(copy.powerLevel, 100);
+    });
+
+    test('toString includes userId and powerLevel', () {
+      const member = KoheraRoomMember(
+        userId: '@alice:example.com',
+        displayname: 'Alice',
+        membership: 'join',
+        powerLevel: 50,
+      );
+      final str = member.toString();
+      expect(str, contains('@alice:example.com'));
+      expect(str, contains('50'));
+    });
+  });
+
+  group('KoheraRoomMemberList', () {
+    test('isEmpty is true for empty list', () {
+      const list = KoheraRoomMemberList(
+        members: [],
+        participantListComplete: false,
+        memberCount: 0,
+      );
+      expect(list.isEmpty, isTrue);
+      expect(list.isNotEmpty, isFalse);
+    });
+
+    test('isNotEmpty is true for non-empty list', () {
+      const list = KoheraRoomMemberList(
+        members: [
+          KoheraRoomMember(
+            userId: '@a:example.com',
+            displayname: 'A',
+            membership: 'join',
+            powerLevel: 0,
+          ),
+        ],
+        participantListComplete: true,
+        memberCount: 1,
+      );
+      expect(list.isEmpty, isFalse);
+      expect(list.isNotEmpty, isTrue);
+    });
+
+    test('toString includes member count', () {
+      const list = KoheraRoomMemberList(
+        members: [
+          KoheraRoomMember(
+            userId: '@a:example.com',
+            displayname: 'A',
+            membership: 'join',
+            powerLevel: 0,
+          ),
+          KoheraRoomMember(
+            userId: '@b:example.com',
+            displayname: 'B',
+            membership: 'join',
+            powerLevel: 50,
+          ),
+        ],
+        participantListComplete: true,
+        memberCount: 2,
+      );
+      expect(list.toString(), contains('2 members'));
+    });
+  });
+}

--- a/test/models/kohera_room_permissions_test.dart
+++ b/test/models/kohera_room_permissions_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/features/rooms/models/kohera_room_member.dart';
 import 'package:kohera/features/rooms/models/kohera_room_permissions.dart';
 
 void main() {
@@ -26,13 +27,24 @@ void main() {
 
   group('KoheraRoomMember', () {
     test('equality is based on userId', () {
-      const a = KoheraRoomMember(userId: '@alice:e.com', powerLevel: 100);
+      const a = KoheraRoomMember(
+        userId: '@alice:e.com',
+        displayname: 'Alice',
+        membership: 'join',
+        powerLevel: 100,
+      );
       const b = KoheraRoomMember(
         userId: '@alice:e.com',
-        displayName: 'Alice 2',
+        displayname: 'Alice 2',
+        membership: 'join',
         powerLevel: 50,
       );
-      const c = KoheraRoomMember(userId: '@bob:e.com', powerLevel: 0);
+      const c = KoheraRoomMember(
+        userId: '@bob:e.com',
+        displayname: 'Bob',
+        membership: 'join',
+        powerLevel: 0,
+      );
 
       expect(a, equals(b));
       expect(a, isNot(equals(c)));
@@ -42,7 +54,8 @@ void main() {
     test('toString includes userId', () {
       const m = KoheraRoomMember(
         userId: '@alice:e.com',
-        displayName: 'Alice',
+        displayname: 'Alice',
+        membership: 'join',
         powerLevel: 50,
       );
       expect(m.toString(), contains('@alice:e.com'));
@@ -103,7 +116,12 @@ void main() {
         isEncrypted: true,
         powerLevelsContent: {'invite': 50},
         participants: [
-          KoheraRoomMember(userId: '@a:e.com', powerLevel: 0),
+          KoheraRoomMember(
+            userId: '@a:e.com',
+            displayname: 'A',
+            membership: 'join',
+            powerLevel: 0,
+          ),
         ],
         myPowerLevel: 100,
       );

--- a/test/screens/room_permissions_screen_test.dart
+++ b/test/screens/room_permissions_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/features/rooms/models/kohera_room_member.dart';
 import 'package:kohera/features/rooms/models/kohera_room_permissions.dart';
 import 'package:kohera/features/rooms/screens/room_permissions_host.dart';
 import 'package:kohera/features/rooms/screens/room_permissions_screen.dart';
@@ -279,9 +280,24 @@ void main() {
         _wrapScreen(
           _perms(
             participants: [
-              const KoheraRoomMember(userId: '@admin:e.com', powerLevel: 100),
-              const KoheraRoomMember(userId: '@mod:e.com', powerLevel: 50),
-              const KoheraRoomMember(userId: '@user:e.com', powerLevel: 0),
+              const KoheraRoomMember(
+                userId: '@admin:e.com',
+                displayname: 'Admin',
+                membership: 'join',
+                powerLevel: 100,
+              ),
+              const KoheraRoomMember(
+                userId: '@mod:e.com',
+                displayname: 'Mod',
+                membership: 'join',
+                powerLevel: 50,
+              ),
+              const KoheraRoomMember(
+                userId: '@user:e.com',
+                displayname: 'User',
+                membership: 'join',
+                powerLevel: 0,
+              ),
             ],
           ),
           recorder,

--- a/test/widgets/chat/message_actions_test.dart
+++ b/test/widgets/chat/message_actions_test.dart
@@ -17,8 +17,8 @@ import 'package:kohera/features/chat/widgets/edit_preview_banner.dart';
 import 'package:kohera/features/chat/widgets/html_message_text.dart';
 import 'package:kohera/features/chat/widgets/message_bubble.dart';
 import 'package:kohera/features/chat/widgets/message_bubble_context_menu.dart';
+import 'package:kohera/features/rooms/models/kohera_room_member.dart';
 import 'package:kohera/features/rooms/widgets/member_sheet_dialog.dart';
-import 'package:kohera/shared/models/kohera_user_summary_mapper.dart';
 import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
 import 'package:matrix/matrix.dart';
@@ -43,7 +43,13 @@ class _FakeAvatarResolver implements AvatarResolver {
   Future<AvatarThumbnail?> resolve(
     String? mxcUrl, {
     required double size,
-  }) async => null;
+  }) async =>
+      null;
+}
+
+class _FakePresence implements PresenceService {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
 }
 
 // ── Helpers ───────────────────────────────────────────────────
@@ -67,8 +73,7 @@ MockEvent _makeEvent({
   when(event.messageType).thenReturn(MessageTypes.Text);
   when(event.originServerTs).thenReturn(DateTime(2025, 1, 1, 12));
   when(event.status).thenReturn(EventStatus.synced);
-  when(event.content)
-      .thenReturn(content ?? {'body': body, 'msgtype': 'm.text'});
+  when(event.content).thenReturn(content ?? {'body': body, 'msgtype': 'm.text'});
   when(event.room).thenReturn(_mockRoom);
   when(event.redacted).thenReturn(redacted);
   when(event.canRedact).thenReturn(canRedact);
@@ -78,8 +83,7 @@ MockEvent _makeEvent({
   when(event.formattedText).thenReturn('');
 
   final sender = MockUser();
-  when(sender.displayName)
-      .thenReturn(senderId.split(':').first.substring(1));
+  when(sender.displayName).thenReturn(senderId.split(':').first.substring(1));
   when(sender.avatarUrl).thenReturn(null);
   when(event.senderFromMemoryOrFallback).thenReturn(sender);
 
@@ -155,12 +159,25 @@ Widget _buildBubble({
                 ),
                 onTapSender: () {
                   final sender = event.senderFromMemoryOrFallback;
+                  final isSenderMe = sender.id == event.room.client.userID;
                   unawaited(
-                    showMemberSheet(
+                    showMemberSheetDialog(
                       context,
-                      room: event.room,
-                      user: toKoheraUserSummary(sender),
-                      isBanned: sender.membership == Membership.ban,
+                      member: KoheraRoomMember(
+                        userId: sender.id,
+                        displayname: sender.calcDisplayname(),
+                        avatarUrl: sender.avatarUrl?.toString(),
+                        membership: sender.membership.name,
+                        powerLevel: event.room.getPowerLevelByUserId(sender.id),
+                      ),
+                      isMe: isSenderMe,
+                      ownLevel: event.room.getPowerLevelByUserId(event.room.client.userID ?? ''),
+                      canChangeRole: false,
+                      canKick: false,
+                      canBan: false,
+                      avatarResolver: const _FakeAvatarResolver(),
+                      presence: _FakePresence(),
+                      onStartDm: isSenderMe ? null : () async {},
                     ),
                   );
                 },
@@ -210,12 +227,25 @@ Widget _buildBubbleWithProviders({
                 ),
                 onTapSender: () {
                   final sender = event.senderFromMemoryOrFallback;
+                  final isSenderMe = sender.id == event.room.client.userID;
                   unawaited(
-                    showMemberSheet(
+                    showMemberSheetDialog(
                       context,
-                      room: event.room,
-                      user: toKoheraUserSummary(sender),
-                      isBanned: sender.membership == Membership.ban,
+                      member: KoheraRoomMember(
+                        userId: sender.id,
+                        displayname: sender.calcDisplayname(),
+                        avatarUrl: sender.avatarUrl?.toString(),
+                        membership: sender.membership.name,
+                        powerLevel: event.room.getPowerLevelByUserId(sender.id),
+                      ),
+                      isMe: isSenderMe,
+                      ownLevel: event.room.getPowerLevelByUserId(event.room.client.userID ?? ''),
+                      canChangeRole: false,
+                      canKick: false,
+                      canBan: false,
+                      avatarResolver: const _FakeAvatarResolver(),
+                      presence: _FakePresence(),
+                      onStartDm: isSenderMe ? null : () async {},
                     ),
                   );
                 },
@@ -268,20 +298,22 @@ void main() {
 
   group('EditPreviewBanner', () {
     testWidgets('shows edit icon and message body', (tester) async {
-      await tester.pumpWidget(MaterialApp(
-        theme: ThemeData(splashFactory: InkRipple.splashFactory),
-        home: Scaffold(
-          body: EditPreviewBanner(
-            preview: const KoheraReplyPreview(
-              parentSenderName: 'me',
-              parentBody: 'Original message text',
-              parentMessageId: r'$evt1',
-              parentSenderId: '@me:example.com',
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(splashFactory: InkRipple.splashFactory),
+          home: Scaffold(
+            body: EditPreviewBanner(
+              preview: const KoheraReplyPreview(
+                parentSenderName: 'me',
+                parentBody: 'Original message text',
+                parentMessageId: r'$evt1',
+                parentSenderId: '@me:example.com',
+              ),
+              onCancel: () {},
             ),
-            onCancel: () {},
           ),
         ),
-      ),);
+      );
 
       expect(find.byIcon(Icons.edit_rounded), findsOneWidget);
       expect(find.text('Editing'), findsOneWidget);
@@ -291,40 +323,44 @@ void main() {
     testWidgets('cancel button calls onCancel', (tester) async {
       var cancelled = false;
 
-      await tester.pumpWidget(MaterialApp(
-        theme: ThemeData(splashFactory: InkRipple.splashFactory),
-        home: Scaffold(
-          body: EditPreviewBanner(
-            preview: const KoheraReplyPreview(
-              parentSenderName: 'me',
-              parentBody: 'Some message',
-              parentMessageId: r'$evt1',
-              parentSenderId: '@me:example.com',
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(splashFactory: InkRipple.splashFactory),
+          home: Scaffold(
+            body: EditPreviewBanner(
+              preview: const KoheraReplyPreview(
+                parentSenderName: 'me',
+                parentBody: 'Some message',
+                parentMessageId: r'$evt1',
+                parentSenderId: '@me:example.com',
+              ),
+              onCancel: () => cancelled = true,
             ),
-            onCancel: () => cancelled = true,
           ),
         ),
-      ),);
+      );
 
       await tester.tap(find.byIcon(Icons.close_rounded));
       expect(cancelled, isTrue);
     });
 
     testWidgets('displays the preview body directly', (tester) async {
-      await tester.pumpWidget(MaterialApp(
-        theme: ThemeData(splashFactory: InkRipple.splashFactory),
-        home: Scaffold(
-          body: EditPreviewBanner(
-            preview: const KoheraReplyPreview(
-              parentSenderName: 'me',
-              parentBody: 'Actual text',
-              parentMessageId: r'$evt1',
-              parentSenderId: '@me:example.com',
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(splashFactory: InkRipple.splashFactory),
+          home: Scaffold(
+            body: EditPreviewBanner(
+              preview: const KoheraReplyPreview(
+                parentSenderName: 'me',
+                parentBody: 'Actual text',
+                parentMessageId: r'$evt1',
+                parentSenderId: '@me:example.com',
+              ),
+              onCancel: () {},
             ),
-            onCancel: () {},
           ),
         ),
-      ),);
+      );
 
       expect(find.text('Actual text'), findsOneWidget);
     });
@@ -333,8 +369,7 @@ void main() {
   // ── Redacted message rendering ─────────────────────────────
 
   group('Redacted message rendering', () {
-    testWidgets('shows "You deleted this message" for own redacted message',
-        (tester) async {
+    testWidgets('shows "You deleted this message" for own redacted message', (tester) async {
       final event = _makeEvent(
         eventId: r'$evt1',
         senderId: '@me:example.com',
@@ -349,8 +384,7 @@ void main() {
       expect(find.text('You deleted this message'), findsOneWidget);
     });
 
-    testWidgets('shows "This message was deleted" for other user self-redact',
-        (tester) async {
+    testWidgets('shows "This message was deleted" for other user self-redact', (tester) async {
       final event = _makeEvent(
         eventId: r'$evt1',
         senderId: '@alice:example.com',
@@ -369,8 +403,7 @@ void main() {
       expect(find.text('This message was deleted'), findsOneWidget);
     });
 
-    testWidgets('shows "Deleted by moderator" for moderator redaction',
-        (tester) async {
+    testWidgets('shows "Deleted by moderator" for moderator redaction', (tester) async {
       final event = _makeEvent(
         eventId: r'$evt1',
         senderId: '@alice:example.com',
@@ -385,8 +418,7 @@ void main() {
 
       final modUser = MockUser();
       when(modUser.displayName).thenReturn('Moderator');
-      when(mockRoom.unsafeGetUserFromMemoryOrFallback('@mod:example.com'))
-          .thenReturn(modUser);
+      when(mockRoom.unsafeGetUserFromMemoryOrFallback('@mod:example.com')).thenReturn(modUser);
 
       await tester.pumpWidget(_buildBubble(event: event, isMe: false));
       await tester.pumpAndSettle();
@@ -398,21 +430,21 @@ void main() {
   // ── Edited message rendering ───────────────────────────────
 
   group('Edited message rendering', () {
-    testWidgets('shows (edited) indicator when message has edits',
-        (tester) async {
+    testWidgets('shows (edited) indicator when message has edits', (tester) async {
       final event = _makeEvent(
         eventId: r'$evt1',
         senderId: '@me:example.com',
         body: 'Updated text',
       );
-      when(event.hasAggregatedEvents(mockTimeline, RelationshipTypes.edit))
-          .thenReturn(true);
+      when(event.hasAggregatedEvents(mockTimeline, RelationshipTypes.edit)).thenReturn(true);
 
-      await tester.pumpWidget(_buildBubble(
-        event: event,
-        isMe: true,
-        timeline: mockTimeline,
-      ),);
+      await tester.pumpWidget(
+        _buildBubble(
+          event: event,
+          isMe: true,
+          timeline: mockTimeline,
+        ),
+      );
       await tester.pumpAndSettle();
 
       expect(find.text('(edited)'), findsOneWidget);
@@ -429,17 +461,21 @@ void main() {
         senderId: '@me:example.com',
         body: 'Edited text',
       );
-      when(originalEvent.getDisplayEvent(mockTimeline))
-          .thenReturn(editedEvent);
-      when(originalEvent.hasAggregatedEvents(
-              mockTimeline, RelationshipTypes.edit,),)
-          .thenReturn(true);
+      when(originalEvent.getDisplayEvent(mockTimeline)).thenReturn(editedEvent);
+      when(
+        originalEvent.hasAggregatedEvents(
+          mockTimeline,
+          RelationshipTypes.edit,
+        ),
+      ).thenReturn(true);
 
-      await tester.pumpWidget(_buildBubble(
-        event: originalEvent,
-        isMe: true,
-        timeline: mockTimeline,
-      ),);
+      await tester.pumpWidget(
+        _buildBubble(
+          event: originalEvent,
+          isMe: true,
+          timeline: mockTimeline,
+        ),
+      );
       await tester.pumpAndSettle();
 
       expect(find.text('Edited text'), findsOneWidget);
@@ -457,13 +493,15 @@ void main() {
         body: 'My message',
       );
 
-      await tester.pumpWidget(_buildBubble(
-        event: event,
-        isMe: true,
-        onReply: () {},
-        onEdit: () {},
-        onDelete: () {},
-      ),);
+      await tester.pumpWidget(
+        _buildBubble(
+          event: event,
+          isMe: true,
+          onReply: () {},
+          onEdit: () {},
+          onDelete: () {},
+        ),
+      );
       await tester.pumpAndSettle();
 
       // Right-click to show context menu.
@@ -480,20 +518,21 @@ void main() {
       expect(find.text('Delete'), findsOneWidget);
     });
 
-    testWidgets('shows "Remove" label for other users messages',
-        (tester) async {
+    testWidgets('shows "Remove" label for other users messages', (tester) async {
       final event = _makeEvent(
         eventId: r'$evt1',
         senderId: '@alice:example.com',
         body: 'Their message',
       );
 
-      await tester.pumpWidget(_buildBubble(
-        event: event,
-        isMe: false,
-        onReply: () {},
-        onDelete: () {},
-      ),);
+      await tester.pumpWidget(
+        _buildBubble(
+          event: event,
+          isMe: false,
+          onReply: () {},
+          onDelete: () {},
+        ),
+      );
       await tester.pumpAndSettle();
 
       // Right-click.
@@ -538,15 +577,16 @@ void main() {
         senderId: '@me:example.com',
         body: 'Edited text',
       );
-      when(originalEvent.getDisplayEvent(mockTimeline))
-          .thenReturn(editedEvent);
+      when(originalEvent.getDisplayEvent(mockTimeline)).thenReturn(editedEvent);
 
-      await tester.pumpWidget(_buildBubble(
-        event: originalEvent,
-        isMe: true,
-        timeline: mockTimeline,
-        onReply: () {},
-      ),);
+      await tester.pumpWidget(
+        _buildBubble(
+          event: originalEvent,
+          isMe: true,
+          timeline: mockTimeline,
+          onReply: () {},
+        ),
+      );
       await tester.pumpAndSettle();
 
       // Right-click.
@@ -568,8 +608,7 @@ void main() {
   // ── Edit flow in ChatScreen ────────────────────────────────
 
   group('ChatScreen edit flow', () {
-    testWidgets('edit preview banner appears after triggering edit',
-        (tester) async {
+    testWidgets('edit preview banner appears after triggering edit', (tester) async {
       // Use desktop width to access right-click context menu.
       tester.view.physicalSize = const Size(800, 600);
       tester.view.devicePixelRatio = 1.0;
@@ -587,13 +626,15 @@ void main() {
       when(mockRoom.getTimeline(eventContextId: anyNamed('eventContextId'), onUpdate: anyNamed('onUpdate')))
           .thenAnswer((_) async => mockTimeline);
 
-      await tester.pumpWidget(_buildChatWidget(
-        mockClient: mockClient,
-        mockMatrix: mockMatrix,
-        prefsService: prefsService,
-        selectionService: selectionService,
-        width: 800,
-      ),);
+      await tester.pumpWidget(
+        _buildChatWidget(
+          mockClient: mockClient,
+          mockMatrix: mockMatrix,
+          prefsService: prefsService,
+          selectionService: selectionService,
+          width: 800,
+        ),
+      );
       await tester.pumpAndSettle();
 
       // Right-click the message.
@@ -635,13 +676,15 @@ void main() {
       when(mockRoom.getTimeline(eventContextId: anyNamed('eventContextId'), onUpdate: anyNamed('onUpdate')))
           .thenAnswer((_) async => mockTimeline);
 
-      await tester.pumpWidget(_buildChatWidget(
-        mockClient: mockClient,
-        mockMatrix: mockMatrix,
-        prefsService: prefsService,
-        selectionService: selectionService,
-        width: 800,
-      ),);
+      await tester.pumpWidget(
+        _buildChatWidget(
+          mockClient: mockClient,
+          mockMatrix: mockMatrix,
+          prefsService: prefsService,
+          selectionService: selectionService,
+          width: 800,
+        ),
+      );
       await tester.pumpAndSettle();
 
       // Trigger edit via right-click.
@@ -664,8 +707,7 @@ void main() {
       expect(textField.controller?.text, isEmpty);
     });
 
-    testWidgets('sending edit passes editEventId to sendTextEvent',
-        (tester) async {
+    testWidgets('sending edit passes editEventId to sendTextEvent', (tester) async {
       tester.view.physicalSize = const Size(800, 600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(() {
@@ -681,19 +723,23 @@ void main() {
       when(mockTimeline.events).thenReturn([event]);
       when(mockRoom.getTimeline(eventContextId: anyNamed('eventContextId'), onUpdate: anyNamed('onUpdate')))
           .thenAnswer((_) async => mockTimeline);
-      when(mockRoom.sendTextEvent(
-        any,
-        inReplyTo: anyNamed('inReplyTo'),
-        editEventId: anyNamed('editEventId'),
-      ),).thenAnswer((_) async => r'$sent1');
+      when(
+        mockRoom.sendTextEvent(
+          any,
+          inReplyTo: anyNamed('inReplyTo'),
+          editEventId: anyNamed('editEventId'),
+        ),
+      ).thenAnswer((_) async => r'$sent1');
 
-      await tester.pumpWidget(_buildChatWidget(
-        mockClient: mockClient,
-        mockMatrix: mockMatrix,
-        prefsService: prefsService,
-        selectionService: selectionService,
-        width: 800,
-      ),);
+      await tester.pumpWidget(
+        _buildChatWidget(
+          mockClient: mockClient,
+          mockMatrix: mockMatrix,
+          prefsService: prefsService,
+          selectionService: selectionService,
+          width: 800,
+        ),
+      );
       await tester.pumpAndSettle();
 
       // Trigger edit.
@@ -710,18 +756,19 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.enter);
       await tester.pumpAndSettle();
 
-      verify(mockRoom.sendTextEvent(
-        'Updated text',
-        editEventId: r'$evt1',
-      ),).called(1);
+      verify(
+        mockRoom.sendTextEvent(
+          'Updated text',
+          editEventId: r'$evt1',
+        ),
+      ).called(1);
     });
   });
 
   // ── Delete flow in ChatScreen ──────────────────────────────
 
   group('ChatScreen delete flow', () {
-    testWidgets('delete shows confirmation dialog with "Delete" for own msg',
-        (tester) async {
+    testWidgets('delete shows confirmation dialog with "Delete" for own msg', (tester) async {
       tester.view.physicalSize = const Size(800, 600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(() {
@@ -738,13 +785,15 @@ void main() {
       when(mockRoom.getTimeline(eventContextId: anyNamed('eventContextId'), onUpdate: anyNamed('onUpdate')))
           .thenAnswer((_) async => mockTimeline);
 
-      await tester.pumpWidget(_buildChatWidget(
-        mockClient: mockClient,
-        mockMatrix: mockMatrix,
-        prefsService: prefsService,
-        selectionService: selectionService,
-        width: 800,
-      ),);
+      await tester.pumpWidget(
+        _buildChatWidget(
+          mockClient: mockClient,
+          mockMatrix: mockMatrix,
+          prefsService: prefsService,
+          selectionService: selectionService,
+          width: 800,
+        ),
+      );
       await tester.pumpAndSettle();
 
       // Right-click → Delete.
@@ -783,16 +832,17 @@ void main() {
       when(mockTimeline.events).thenReturn([event]);
       when(mockRoom.getTimeline(eventContextId: anyNamed('eventContextId'), onUpdate: anyNamed('onUpdate')))
           .thenAnswer((_) async => mockTimeline);
-      when(mockRoom.redactEvent(r'$evt1'))
-          .thenAnswer((_) async => r'$redact1');
+      when(mockRoom.redactEvent(r'$evt1')).thenAnswer((_) async => r'$redact1');
 
-      await tester.pumpWidget(_buildChatWidget(
-        mockClient: mockClient,
-        mockMatrix: mockMatrix,
-        prefsService: prefsService,
-        selectionService: selectionService,
-        width: 800,
-      ),);
+      await tester.pumpWidget(
+        _buildChatWidget(
+          mockClient: mockClient,
+          mockMatrix: mockMatrix,
+          prefsService: prefsService,
+          selectionService: selectionService,
+          width: 800,
+        ),
+      );
       await tester.pumpAndSettle();
 
       // Right-click → Delete.
@@ -811,8 +861,7 @@ void main() {
       verify(mockRoom.redactEvent(r'$evt1')).called(1);
     });
 
-    testWidgets('cancelling delete dialog does not call redactEvent',
-        (tester) async {
+    testWidgets('cancelling delete dialog does not call redactEvent', (tester) async {
       tester.view.physicalSize = const Size(800, 600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(() {
@@ -829,13 +878,15 @@ void main() {
       when(mockRoom.getTimeline(eventContextId: anyNamed('eventContextId'), onUpdate: anyNamed('onUpdate')))
           .thenAnswer((_) async => mockTimeline);
 
-      await tester.pumpWidget(_buildChatWidget(
-        mockClient: mockClient,
-        mockMatrix: mockMatrix,
-        prefsService: prefsService,
-        selectionService: selectionService,
-        width: 800,
-      ),);
+      await tester.pumpWidget(
+        _buildChatWidget(
+          mockClient: mockClient,
+          mockMatrix: mockMatrix,
+          prefsService: prefsService,
+          selectionService: selectionService,
+          width: 800,
+        ),
+      );
       await tester.pumpAndSettle();
 
       // Right-click → Delete → Cancel.
@@ -856,8 +907,7 @@ void main() {
   // ── Redacted messages disable interactions ─────────────────
 
   group('Redacted message interactions', () {
-    testWidgets('redacted messages do not show context menu on desktop',
-        (tester) async {
+    testWidgets('redacted messages do not show context menu on desktop', (tester) async {
       final event = _makeEvent(
         eventId: r'$evt1',
         senderId: '@me:example.com',
@@ -867,10 +917,12 @@ void main() {
       when(event.redactedBecause).thenReturn(null);
 
       // Build with no action callbacks (as ChatScreen does for redacted).
-      await tester.pumpWidget(_buildBubble(
-        event: event,
-        isMe: true,
-      ),);
+      await tester.pumpWidget(
+        _buildBubble(
+          event: event,
+          isMe: true,
+        ),
+      );
       await tester.pumpAndSettle();
 
       // Right-click should not produce a context menu with Reply/Edit/Delete.
@@ -890,8 +942,7 @@ void main() {
   // ── Edit events filtered from timeline ─────────────────────
 
   group('Sender avatar profile sheet', () {
-    testWidgets('tapping a sender avatar opens the member profile sheet',
-        (tester) async {
+    testWidgets('tapping a sender avatar opens the member profile sheet', (tester) async {
       final event = _makeEvent(
         eventId: r'$evt1',
         senderId: '@alice:example.com',
@@ -901,12 +952,14 @@ void main() {
       when(sender.id).thenReturn('@alice:example.com');
       when(sender.membership).thenReturn(Membership.join);
 
-      await tester.pumpWidget(_buildBubbleWithProviders(
-        event: event,
-        isMe: false,
-        mockMatrix: mockMatrix,
-        selectionService: selectionService,
-      ),);
+      await tester.pumpWidget(
+        _buildBubbleWithProviders(
+          event: event,
+          isMe: false,
+          mockMatrix: mockMatrix,
+          selectionService: selectionService,
+        ),
+      );
       await tester.pumpAndSettle();
 
       expect(find.byType(UserAvatar), findsOneWidget);
@@ -938,12 +991,14 @@ void main() {
       when(sender.id).thenReturn('@me:example.com');
       when(sender.membership).thenReturn(Membership.join);
 
-      await tester.pumpWidget(_buildBubbleWithProviders(
-        event: event,
-        isMe: false,
-        mockMatrix: mockMatrix,
-        selectionService: selectionService,
-      ),);
+      await tester.pumpWidget(
+        _buildBubbleWithProviders(
+          event: event,
+          isMe: false,
+          mockMatrix: mockMatrix,
+          selectionService: selectionService,
+        ),
+      );
       await tester.pumpAndSettle();
 
       await tester.tap(find.byType(UserAvatar));
@@ -955,8 +1010,7 @@ void main() {
   });
 
   group('Edit events filtered from visible timeline', () {
-    testWidgets('edit relation events are not shown in message list',
-        (tester) async {
+    testWidgets('edit relation events are not shown in message list', (tester) async {
       tester.view.physicalSize = const Size(800, 600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(() {
@@ -979,13 +1033,15 @@ void main() {
       when(mockRoom.getTimeline(eventContextId: anyNamed('eventContextId'), onUpdate: anyNamed('onUpdate')))
           .thenAnswer((_) async => mockTimeline);
 
-      await tester.pumpWidget(_buildChatWidget(
-        mockClient: mockClient,
-        mockMatrix: mockMatrix,
-        prefsService: prefsService,
-        selectionService: selectionService,
-        width: 800,
-      ),);
+      await tester.pumpWidget(
+        _buildChatWidget(
+          mockClient: mockClient,
+          mockMatrix: mockMatrix,
+          prefsService: prefsService,
+          selectionService: selectionService,
+          width: 800,
+        ),
+      );
       await tester.pumpAndSettle();
 
       // Only the original message should be visible, not the edit event.

--- a/test/widgets/room_members_section_test.dart
+++ b/test/widgets/room_members_section_test.dart
@@ -82,10 +82,11 @@ Widget _wrapDialog(MemberSheetDialog dialog) => MaterialApp(
 
 void main() {
   group('RoomMembersSection', () {
-    testWidgets('shows no members when empty', (tester) async {
+    testWidgets('shows nothing when empty', (tester) async {
       await tester.pumpWidget(_wrapSection(_list([])));
       await tester.pump();
-      expect(find.text('No members'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text('No members'), findsNothing);
     });
 
     testWidgets('shows members after loading', (tester) async {

--- a/test/widgets/room_members_section_test.dart
+++ b/test/widgets/room_members_section_test.dart
@@ -1,113 +1,103 @@
-﻿import 'dart:async';
-
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/presence_service.dart';
+import 'package:kohera/features/rooms/models/kohera_room_member.dart';
 import 'package:kohera/features/rooms/models/room_role.dart';
+import 'package:kohera/features/rooms/widgets/member_sheet_dialog.dart';
 import 'package:kohera/features/rooms/widgets/room_members_section.dart';
 import 'package:kohera/shared/services/avatar_resolver.dart';
-import 'package:matrix/matrix.dart';
-import 'package:matrix/src/utils/cached_stream_controller.dart';
-import 'package:mockito/annotations.dart';
-import 'package:mockito/mockito.dart';
-import 'package:provider/provider.dart';
 
-@GenerateNiceMocks([
-  MockSpec<Client>(),
-  MockSpec<MatrixService>(),
-  MockSpec<Room>(),
-  MockSpec<User>(),
-])
-import 'room_members_section_test.mocks.dart';
+// ── Fakes ──────────────────────────────────────────────────────
 
 class _NullAvatarResolver implements AvatarResolver {
   const _NullAvatarResolver();
   @override
-  Future<AvatarThumbnail?> resolve(String? mxcUrl, {required double size}) async => null;
+  Future<AvatarThumbnail?> resolve(
+    String? mxcUrl, {
+    required double size,
+  }) async => null;
 }
 
-MockUser _makeUser(String id, String displayName, {Room? room}) {
-  final user = MockUser();
-  when(user.id).thenReturn(id);
-  when(user.displayName).thenReturn(displayName);
-  when(user.calcDisplayname()).thenReturn(displayName);
-  when(user.room).thenReturn(room ?? MockRoom());
-  when(user.membership).thenReturn(Membership.join);
-  return user;
+class _NullPresence implements PresenceService {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
 }
 
-void main() {
-  late MockClient mockClient;
-  late MockMatrixService mockMatrixService;
-  late MockRoom mockRoom;
+// ── Helpers ──────────────────────────────────────────────────
 
-  setUp(() {
-    mockClient = MockClient();
-    mockMatrixService = MockMatrixService();
-    mockRoom = MockRoom();
+KoheraRoomMember _member({
+  String userId = '@alice:example.com',
+  String displayname = 'Alice',
+  String? avatarUrl,
+  String membership = 'join',
+  int powerLevel = 0,
+}) =>
+    KoheraRoomMember(
+      userId: userId,
+      displayname: displayname,
+      avatarUrl: avatarUrl,
+      membership: membership,
+      powerLevel: powerLevel,
+    );
 
-    when(mockMatrixService.client).thenReturn(mockClient);
-    when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
-    when(mockClient.onPresenceChanged)
-        .thenReturn(CachedStreamController<CachedPresence>());
-    when(mockMatrixService.avatarResolver).thenReturn(const _NullAvatarResolver());
-    when(mockMatrixService.presence)
-        .thenReturn(PresenceService(client: mockClient));
-    when(mockRoom.id).thenReturn('!room:example.com');
-    when(mockRoom.client).thenReturn(mockClient);
-    when(mockRoom.summary).thenReturn(RoomSummary.fromJson({
-      'm.joined_member_count': 3,
-      'm.invited_member_count': 0,
-    }),);
-    when(mockRoom.getPowerLevelByUserId(any)).thenReturn(0);
-    when(mockRoom.canKick).thenReturn(false);
-    when(mockRoom.canBan).thenReturn(false);
-    when(mockClient.userID).thenReturn('@me:example.com');
-  });
+KoheraRoomMemberList _list(
+  List<KoheraRoomMember> members, {
+  bool complete = true,
+  int count = 0,
+}) =>
+    KoheraRoomMemberList(
+      members: members,
+      participantListComplete: complete,
+      memberCount: count,
+    );
 
-  Widget buildTestWidget() {
-    return MaterialApp(
-      theme: ThemeData(splashFactory: InkRipple.splashFactory),
-      home: ChangeNotifierProvider<MatrixService>.value(
-        value: mockMatrixService,
-        child: Scaffold(
-          body: SingleChildScrollView(
-            child: RoomMembersSection(room: mockRoom),
+const _avatarResolver = _NullAvatarResolver();
+
+PresenceService _nullPresence() => _NullPresence();
+
+Widget _wrapSection(
+  KoheraRoomMemberList members, {
+  void Function(KoheraRoomMember)? onMemberTap,
+}) =>
+    MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: RoomMembersSection(
+            members: members,
+            onMemberTap: onMemberTap ?? (_) {},
+            avatarResolver: _avatarResolver,
+            presence: _nullPresence(),
           ),
         ),
       ),
     );
-  }
 
+Widget _wrapDialog(MemberSheetDialog dialog) => MaterialApp(
+      home: Scaffold(
+        body: Center(child: dialog),
+      ),
+    );
+
+// ── RoomMembersSection tests ──────────────────────────────────
+
+void main() {
   group('RoomMembersSection', () {
-    testWidgets('shows loading indicator while fetching members',
-        (tester) async {
-      final completer = Completer<List<User>>();
-      when(mockRoom.requestParticipants(any))
-          .thenAnswer((_) => completer.future);
-
-      await tester.pumpWidget(buildTestWidget());
+    testWidgets('shows no members when empty', (tester) async {
+      await tester.pumpWidget(_wrapSection(_list([])));
       await tester.pump();
-
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
-      expect(find.text('MEMBERS'), findsOneWidget);
-
-      // Complete the future to avoid pending timer issues
-      completer.complete([]);
-      await tester.pumpAndSettle();
+      expect(find.text('No members'), findsOneWidget);
     });
 
     testWidgets('shows members after loading', (tester) async {
-      final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-      final bob = _makeUser('@bob:example.com', 'Bob', room: mockRoom);
-
-      when(mockRoom.requestParticipants(any))
-          .thenAnswer((_) async => [alice, bob]);
-
-      await tester.pumpWidget(buildTestWidget());
-      await tester.pumpAndSettle();
+      await tester.pumpWidget(
+        _wrapSection(
+          _list([
+            _member(userId: '@alice:e.com'),
+            _member(displayname: 'Bob', userId: '@bob:e.com'),
+          ]),
+        ),
+      );
+      await tester.pump();
 
       expect(find.text('Alice'), findsOneWidget);
       expect(find.text('Bob'), findsOneWidget);
@@ -115,626 +105,459 @@ void main() {
 
     testWidgets('shows only first 5 members with expand button',
         (tester) async {
-      final users = List.generate(
+      final members = List.generate(
         8,
-        (i) => _makeUser('@user$i:example.com', 'User $i', room: mockRoom),
+        (i) => _member(
+          displayname: 'User$i',
+          userId: '@user$i:e.com',
+        ),
       );
+      await tester.pumpWidget(_wrapSection(_list(members)));
+      await tester.pump();
 
-      when(mockRoom.requestParticipants(any)).thenAnswer((_) async => users);
-
-      await tester.pumpWidget(buildTestWidget());
-      await tester.pumpAndSettle();
-
-      // First 5 should be visible
-      for (var i = 0; i < 5; i++) {
-        expect(find.text('User $i'), findsOneWidget);
-      }
-      // 6th should not be visible yet
-      expect(find.text('User 5'), findsNothing);
-
-      // Expand button should show
       expect(find.text('Show all 8 members'), findsOneWidget);
+      expect(find.text('User0'), findsOneWidget);
+      expect(find.text('User4'), findsOneWidget);
+      expect(find.text('User5'), findsNothing);
     });
 
     testWidgets('expand button shows all members', (tester) async {
-      final users = List.generate(
+      final members = List.generate(
         8,
-        (i) => _makeUser('@user$i:example.com', 'User $i', room: mockRoom),
+        (i) => _member(
+          displayname: 'User$i',
+          userId: '@user$i:e.com',
+        ),
       );
-
-      when(mockRoom.requestParticipants(any)).thenAnswer((_) async => users);
-
-      await tester.pumpWidget(buildTestWidget());
-      await tester.pumpAndSettle();
+      await tester.pumpWidget(_wrapSection(_list(members)));
+      await tester.pump();
 
       await tester.tap(find.text('Show all 8 members'));
-      await tester.pumpAndSettle();
+      await tester.pump();
 
-      // All 8 should be visible now
-      for (var i = 0; i < 8; i++) {
-        expect(find.text('User $i'), findsOneWidget);
-      }
-      expect(find.text('Show all 8 members'), findsNothing);
+      expect(find.text('User5'), findsOneWidget);
+      expect(find.text('User7'), findsOneWidget);
     });
 
     testWidgets('shows Admin badge for power level >= 100', (tester) async {
-      final admin = _makeUser('@admin:example.com', 'Admin User', room: mockRoom);
-      when(mockRoom.getPowerLevelByUserId('@admin:example.com')).thenReturn(100);
-      when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [admin]);
-
-      await tester.pumpWidget(buildTestWidget());
-      await tester.pumpAndSettle();
+      await tester.pumpWidget(
+        _wrapSection(
+          _list([
+            _member(powerLevel: 100),
+          ]),
+        ),
+      );
+      await tester.pump();
 
       expect(find.text('Admin'), findsOneWidget);
     });
 
     testWidgets('shows Mod badge for power level >= 50', (tester) async {
-      final mod = _makeUser('@mod:example.com', 'Mod User', room: mockRoom);
-      when(mockRoom.getPowerLevelByUserId('@mod:example.com')).thenReturn(50);
-      when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [mod]);
-
-      await tester.pumpWidget(buildTestWidget());
-      await tester.pumpAndSettle();
+      await tester.pumpWidget(
+        _wrapSection(
+          _list([
+            _member(displayname: 'Bob', powerLevel: 50),
+          ]),
+        ),
+      );
+      await tester.pump();
 
       expect(find.text('Mod'), findsOneWidget);
     });
 
-    testWidgets('search filters members by display name and MXID',
+    testWidgets('no badge for power level < 50', (tester) async {
+      await tester.pumpWidget(
+        _wrapSection(
+          _list([
+            _member(displayname: 'Carol'),
+          ]),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Admin'), findsNothing);
+      expect(find.text('Mod'), findsNothing);
+    });
+
+    testWidgets('search filters members by display name', (tester) async {
+      final members = List.generate(
+        8,
+        (i) => _member(
+          displayname: 'User$i',
+          userId: '@user$i:e.com',
+        ),
+      );
+      await tester.pumpWidget(_wrapSection(_list(members)));
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), 'user3');
+      await tester.pump();
+
+      expect(find.text('User3'), findsOneWidget);
+      expect(find.text('User0'), findsNothing);
+    });
+
+    testWidgets('search field hidden when 5 or fewer members',
         (tester) async {
-      final users = [
-        _makeUser('@alice:example.com', 'Alice', room: mockRoom),
-        _makeUser('@bob:example.com', 'Bob', room: mockRoom),
-        _makeUser('@charlie:example.com', 'Charlie', room: mockRoom),
-        _makeUser('@dave:example.com', 'Dave', room: mockRoom),
-        _makeUser('@eve:example.com', 'Eve', room: mockRoom),
-        _makeUser('@frank:example.com', 'Frank', room: mockRoom),
-      ];
-      when(mockRoom.requestParticipants(any)).thenAnswer((_) async => users);
+      await tester.pumpWidget(
+        _wrapSection(
+          _list([
+            _member(),
+            _member(displayname: 'Bob', userId: '@bob:e.com'),
+          ]),
+        ),
+      );
+      await tester.pump();
 
-      await tester.pumpWidget(buildTestWidget());
+      expect(find.byType(TextField), findsNothing);
+    });
+
+    testWidgets('tapping member calls onMemberTap', (tester) async {
+      KoheraRoomMember? tapped;
+      final member = _member(userId: '@alice:e.com');
+      await tester.pumpWidget(
+        _wrapSection(
+          _list([member]),
+          onMemberTap: (m) => tapped = m,
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('Alice'));
+      await tester.pump();
+
+      expect(tapped, isNotNull);
+      expect(tapped?.userId, '@alice:e.com');
+    });
+  });
+
+  // ── MemberSheetDialog tests ──────────────────────────────────
+
+  group('MemberSheetDialog', () {
+    testWidgets('shows member info', (tester) async {
+      await tester.pumpWidget(
+        _wrapDialog(
+          MemberSheetDialog(
+            member: _member(userId: '@alice:e.com'),
+            isMe: false,
+            ownLevel: 100,
+            canChangeRole: false,
+            canKick: false,
+            canBan: false,
+            avatarResolver: _avatarResolver,
+            presence: _nullPresence(),
+          ),
+        ),
+      );
       await tester.pumpAndSettle();
 
-      expect(find.byType(TextField), findsOneWidget);
-
-      await tester.enterText(find.byType(TextField), 'ali');
-      await tester.pumpAndSettle();
       expect(find.text('Alice'), findsOneWidget);
-      expect(find.text('Bob'), findsNothing);
-
-      await tester.enterText(find.byType(TextField), '@bob');
-      await tester.pumpAndSettle();
-      expect(find.text('Bob'), findsOneWidget);
-      expect(find.text('Alice'), findsNothing);
-
-      await tester.enterText(find.byType(TextField), 'zzzz');
-      await tester.pumpAndSettle();
-      expect(find.textContaining('No members match'), findsOneWidget);
+      expect(find.text('@alice:e.com'), findsOneWidget);
     });
 
-    testWidgets('search field hidden when 5 or fewer members', (tester) async {
-      final users = List.generate(
-        5,
-        (i) => _makeUser('@user$i:example.com', 'User $i', room: mockRoom),
+    testWidgets('shows role dropdown when canChangeRole', (tester) async {
+      await tester.pumpWidget(
+        _wrapDialog(
+          MemberSheetDialog(
+            member: _member(displayname: 'Bob'),
+            isMe: false,
+            ownLevel: 100,
+            canChangeRole: true,
+            canKick: false,
+            canBan: false,
+            avatarResolver: _avatarResolver,
+            presence: _nullPresence(),
+          ),
+        ),
       );
-      when(mockRoom.requestParticipants(any)).thenAnswer((_) async => users);
-
-      await tester.pumpWidget(buildTestWidget());
       await tester.pumpAndSettle();
 
-      expect(find.widgetWithText(TextField, 'Search members'), findsNothing);
-      expect(find.byIcon(Icons.search), findsNothing);
+      expect(find.byType(DropdownButton<RoomRole>), findsOneWidget);
     });
 
-    testWidgets('search clear button restores full list', (tester) async {
-      final users = List.generate(
-        6,
-        (i) => _makeUser('@user$i:example.com', 'User $i', room: mockRoom),
+    testWidgets('hides role dropdown when isMe', (tester) async {
+      await tester.pumpWidget(
+        _wrapDialog(
+          MemberSheetDialog(
+            member: _member(displayname: 'Me', powerLevel: 100),
+            isMe: true,
+            ownLevel: 100,
+            canChangeRole: false,
+            canKick: false,
+            canBan: false,
+            avatarResolver: _avatarResolver,
+            presence: _nullPresence(),
+          ),
+        ),
       );
-      when(mockRoom.requestParticipants(any)).thenAnswer((_) async => users);
-
-      await tester.pumpWidget(buildTestWidget());
       await tester.pumpAndSettle();
 
-      await tester.enterText(find.byType(TextField), 'user0');
-      await tester.pumpAndSettle();
-      expect(find.text('User 0'), findsOneWidget);
-      expect(find.text('User 1'), findsNothing);
-
-      await tester.tap(find.byIcon(Icons.close));
-      await tester.pumpAndSettle();
-
-      for (var i = 0; i < 5; i++) {
-        expect(find.text('User $i'), findsOneWidget);
-      }
-      expect(find.text('Show all 6 members'), findsOneWidget);
+      expect(find.byType(DropdownButton<RoomRole>), findsNothing);
     });
 
-    testWidgets('tapping member opens SimpleDialog with member info',
-        (tester) async {
-      final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-      when(mockRoom.requestParticipants(any))
-          .thenAnswer((_) async => [alice]);
-
-      await tester.pumpWidget(buildTestWidget());
+    testWidgets('shows kick action when canKick', (tester) async {
+      await tester.pumpWidget(
+        _wrapDialog(
+          MemberSheetDialog(
+            member: _member(displayname: 'Bob'),
+            isMe: false,
+            ownLevel: 100,
+            canChangeRole: false,
+            canKick: true,
+            canBan: false,
+            avatarResolver: _avatarResolver,
+            presence: _nullPresence(),
+          ),
+        ),
+      );
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Alice'));
-      await tester.pumpAndSettle();
-
-      expect(find.byType(SimpleDialog), findsOneWidget);
-      expect(find.text('@alice:example.com'), findsWidgets);
-      // 'Member' appears in both the title description and the dropdown value.
-      expect(find.text('Member'), findsWidgets);
+      expect(find.text('Kick'), findsOneWidget);
     });
 
-    testWidgets('kick action prompts for reason and forwards it to client.kick',
-        (tester) async {
-      when(mockRoom.getPowerLevelByUserId('@me:example.com')).thenReturn(50);
-      final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-      when(mockRoom.canKick).thenReturn(true);
-      when(mockRoom.requestParticipants(any))
-          .thenAnswer((_) async => [alice]);
-      when(mockClient.kick(any, any, reason: anyNamed('reason')))
-          .thenAnswer((_) async {});
-
-      await tester.pumpWidget(buildTestWidget());
+    testWidgets('hides kick action when not canKick', (tester) async {
+      await tester.pumpWidget(
+        _wrapDialog(
+          MemberSheetDialog(
+            member: _member(displayname: 'Bob'),
+            isMe: false,
+            ownLevel: 100,
+            canChangeRole: false,
+            canKick: false,
+            canBan: false,
+            avatarResolver: _avatarResolver,
+            presence: _nullPresence(),
+          ),
+        ),
+      );
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Alice'));
+      expect(find.text('Kick'), findsNothing);
+    });
+
+    testWidgets('shows ban action when canBan', (tester) async {
+      await tester.pumpWidget(
+        _wrapDialog(
+          MemberSheetDialog(
+            member: _member(displayname: 'Bob'),
+            isMe: false,
+            ownLevel: 100,
+            canChangeRole: false,
+            canKick: false,
+            canBan: true,
+            avatarResolver: _avatarResolver,
+            presence: _nullPresence(),
+          ),
+        ),
+      );
       await tester.pumpAndSettle();
 
-      await tester.tap(find.widgetWithText(SimpleDialogOption, 'Kick'));
+      expect(find.text('Ban'), findsOneWidget);
+    });
+
+    testWidgets('shows unban action for banned member', (tester) async {
+      await tester.pumpWidget(
+        _wrapDialog(
+          MemberSheetDialog(
+            member: _member(displayname: 'Bob', membership: 'ban'),
+            isMe: false,
+            ownLevel: 100,
+            canChangeRole: false,
+            canKick: false,
+            canBan: true,
+            avatarResolver: _avatarResolver,
+            presence: _nullPresence(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Unban'), findsOneWidget);
+      expect(find.text('Ban'), findsNothing);
+    });
+
+    testWidgets('shows Send message when onStartDm provided', (tester) async {
+      await tester.pumpWidget(
+        _wrapDialog(
+          MemberSheetDialog(
+            member: _member(displayname: 'Bob'),
+            isMe: false,
+            ownLevel: 100,
+            canChangeRole: false,
+            canKick: false,
+            canBan: false,
+            avatarResolver: _avatarResolver,
+            presence: _nullPresence(),
+            onStartDm: () async {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Send message'), findsOneWidget);
+    });
+
+    testWidgets('hides Send message when isMe', (tester) async {
+      await tester.pumpWidget(
+        _wrapDialog(
+          MemberSheetDialog(
+            member: _member(displayname: 'Me'),
+            isMe: true,
+            ownLevel: 100,
+            canChangeRole: false,
+            canKick: false,
+            canBan: false,
+            avatarResolver: _avatarResolver,
+            presence: _nullPresence(),
+            onStartDm: () async {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Send message'), findsNothing);
+    });
+
+    testWidgets('kick calls onKick callback', (tester) async {
+      String? kickReason;
+      await tester.pumpWidget(
+        _wrapDialog(
+          MemberSheetDialog(
+            member: _member(displayname: 'Bob', userId: '@bob:e.com'),
+            isMe: false,
+            ownLevel: 100,
+            canChangeRole: false,
+            canKick: true,
+            canBan: false,
+            avatarResolver: _avatarResolver,
+            presence: _nullPresence(),
+            onKick: (reason) async {
+              kickReason = reason;
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Kick'));
       await tester.pumpAndSettle();
 
       expect(find.text('Kick member?'), findsOneWidget);
-      expect(find.byType(TextField), findsOneWidget);
 
-      await tester.enterText(find.byType(TextField), 'spamming');
-      await tester.tap(find.widgetWithText(FilledButton, 'Kick'));
+      await tester.tap(find.text('Kick').last);
       await tester.pumpAndSettle();
 
-      verify(mockClient.kick(
-        '!room:example.com',
-        '@alice:example.com',
-        reason: 'spamming',
-      ),).called(1);
+      expect(kickReason, isNull);
     });
 
-    testWidgets('kick with empty reason sends null reason', (tester) async {
-      when(mockRoom.getPowerLevelByUserId('@me:example.com')).thenReturn(50);
-      final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-      when(mockRoom.canKick).thenReturn(true);
-      when(mockRoom.requestParticipants(any))
-          .thenAnswer((_) async => [alice]);
-      when(mockClient.kick(any, any, reason: anyNamed('reason')))
-          .thenAnswer((_) async {});
-
-      await tester.pumpWidget(buildTestWidget());
+    testWidgets('ban calls onBan callback', (tester) async {
+      String? banReason;
+      await tester.pumpWidget(
+        _wrapDialog(
+          MemberSheetDialog(
+            member: _member(displayname: 'Bob'),
+            isMe: false,
+            ownLevel: 100,
+            canChangeRole: false,
+            canKick: false,
+            canBan: true,
+            avatarResolver: _avatarResolver,
+            presence: _nullPresence(),
+            onBan: (reason) async {
+              banReason = reason;
+            },
+          ),
+        ),
+      );
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Alice'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(SimpleDialogOption, 'Kick'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(FilledButton, 'Kick'));
-      await tester.pumpAndSettle();
-
-      verify(mockClient.kick(
-        '!room:example.com',
-        '@alice:example.com',
-        reason: argThat(isNull, named: 'reason'),
-      ),).called(1);
-    });
-
-    testWidgets('cancelling kick reason dialog does not call client.kick',
-        (tester) async {
-      when(mockRoom.getPowerLevelByUserId('@me:example.com')).thenReturn(50);
-      final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-      when(mockRoom.canKick).thenReturn(true);
-      when(mockRoom.requestParticipants(any))
-          .thenAnswer((_) async => [alice]);
-
-      await tester.pumpWidget(buildTestWidget());
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('Alice'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(SimpleDialogOption, 'Kick'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
-      await tester.pumpAndSettle();
-
-      verifyNever(mockClient.kick(any, any, reason: anyNamed('reason')));
-    });
-
-    testWidgets('ban action prompts for reason and forwards it to client.ban',
-        (tester) async {
-      when(mockRoom.getPowerLevelByUserId('@me:example.com')).thenReturn(50);
-      final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-      when(mockRoom.canBan).thenReturn(true);
-      when(mockRoom.requestParticipants(any))
-          .thenAnswer((_) async => [alice]);
-      when(mockClient.ban(any, any, reason: anyNamed('reason')))
-          .thenAnswer((_) async {});
-
-      await tester.pumpWidget(buildTestWidget());
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('Alice'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(SimpleDialogOption, 'Ban'));
+      await tester.tap(find.text('Ban'));
       await tester.pumpAndSettle();
 
       expect(find.text('Ban member?'), findsOneWidget);
 
-      await tester.enterText(find.byType(TextField), 'abuse');
-      await tester.tap(find.widgetWithText(FilledButton, 'Ban'));
+      await tester.enterText(find.byType(TextField), 'Spamming');
+      await tester.tap(find.text('Ban').last);
       await tester.pumpAndSettle();
 
-      verify(mockClient.ban(
-        '!room:example.com',
-        '@alice:example.com',
-        reason: 'abuse',
-      ),).called(1);
+      expect(banReason, 'Spamming');
     });
 
-    testWidgets('kick and ban actions hidden when permissions are missing',
-        (tester) async {
-      final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-      when(mockRoom.canKick).thenReturn(false);
-      when(mockRoom.canBan).thenReturn(false);
-      when(mockRoom.requestParticipants(any))
-          .thenAnswer((_) async => [alice]);
-
-      await tester.pumpWidget(buildTestWidget());
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('Alice'));
-      await tester.pumpAndSettle();
-
-      expect(find.widgetWithText(SimpleDialogOption, 'Kick'), findsNothing);
-      expect(find.widgetWithText(SimpleDialogOption, 'Ban'), findsNothing);
-    });
-
-    testWidgets('kick and ban hidden when target power level >= viewer level',
-        (tester) async {
-      when(mockRoom.getPowerLevelByUserId('@me:example.com')).thenReturn(50);
-      when(mockRoom.getPowerLevelByUserId('@alice:example.com')).thenReturn(50);
-      final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-      when(mockRoom.canKick).thenReturn(true);
-      when(mockRoom.canBan).thenReturn(true);
-      when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
-
-      await tester.pumpWidget(buildTestWidget());
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('Alice'));
-      await tester.pumpAndSettle();
-
-      expect(find.widgetWithText(SimpleDialogOption, 'Kick'), findsNothing);
-      expect(find.widgetWithText(SimpleDialogOption, 'Ban'), findsNothing);
-    });
-
-    testWidgets('ban dialog shows correct wording', (tester) async {
-      when(mockRoom.getPowerLevelByUserId('@me:example.com')).thenReturn(50);
-      final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-      when(mockRoom.canBan).thenReturn(true);
-      when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
-
-      await tester.pumpWidget(buildTestWidget());
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('Alice'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(SimpleDialogOption, 'Ban'));
-      await tester.pumpAndSettle();
-
-      expect(find.textContaining("won't be able to rejoin"), findsOneWidget);
-    });
-
-    testWidgets('unban shown for banned user and calls client.unban',
-        (tester) async {
-      when(mockRoom.getPowerLevelByUserId('@me:example.com')).thenReturn(50);
-      final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-      when(alice.membership).thenReturn(Membership.ban);
-      when(mockRoom.canBan).thenReturn(true);
-      when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
-      when(mockClient.unban(any, any)).thenAnswer((_) async {});
-
-      await tester.pumpWidget(buildTestWidget());
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('Alice'));
-      await tester.pumpAndSettle();
-
-      expect(find.widgetWithText(SimpleDialogOption, 'Ban'), findsNothing);
-      expect(find.widgetWithText(SimpleDialogOption, 'Unban'), findsOneWidget);
-
-      await tester.tap(find.widgetWithText(SimpleDialogOption, 'Unban'));
-      await tester.pumpAndSettle();
-
-      expect(find.text('Unban member?'), findsOneWidget);
-
-      await tester.tap(find.widgetWithText(FilledButton, 'Unban'));
-      await tester.pumpAndSettle();
-
-      verify(mockClient.unban('!room:example.com', '@alice:example.com'))
-          .called(1);
-    });
-
-    testWidgets('kick error shown inline without dismissing sheet',
-        (tester) async {
-      when(mockRoom.getPowerLevelByUserId('@me:example.com')).thenReturn(50);
-      final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-      when(mockRoom.canKick).thenReturn(true);
-      when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
-      when(mockClient.kick(any, any, reason: anyNamed('reason')))
-          .thenThrow(
-        MatrixException.fromJson({
-          'errcode': 'M_FORBIDDEN',
-          'error': 'You do not have permission',
-        }),
-      );
-
-      await tester.pumpWidget(buildTestWidget());
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('Alice'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(SimpleDialogOption, 'Kick'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(FilledButton, 'Kick'));
-      await tester.pumpAndSettle();
-
-      // Sheet still open (Alice appears in tile + sheet title), error displayed inline.
-      expect(find.text('Alice'), findsWidgets);
-      expect(find.textContaining('permission'), findsOneWidget);
-    });
-
-    group('role dropdown', () {
-      testWidgets('shows dropdown with current role for a member', (tester) async {
-        final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-        when(mockRoom.getPowerLevelByUserId('@alice:example.com')).thenReturn(0);
-        when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
-
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Alice'));
-        await tester.pumpAndSettle();
-
-        expect(find.byType(DropdownButton<RoomRole>), findsOneWidget);
-        // 'Member' appears in the title description and the dropdown value.
-        expect(find.text('Member'), findsWidgets);
-      });
-
-      testWidgets('shows dropdown with current role for a moderator', (tester) async {
-        final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-        when(mockRoom.getPowerLevelByUserId('@alice:example.com')).thenReturn(50);
-        when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
-
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Alice'));
-        await tester.pumpAndSettle();
-
-        expect(find.text('Moderator'), findsWidgets);
-      });
-
-      testWidgets('dropdown is disabled when viewer cannot change power levels',
-          (tester) async {
-        final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-        when(mockRoom.getPowerLevelByUserId('@alice:example.com')).thenReturn(0);
-        when(mockRoom.canChangePowerLevel).thenReturn(false);
-        when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
-
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Alice'));
-        await tester.pumpAndSettle();
-
-        final dropdown = tester.widget<DropdownButton<RoomRole>>(
-          find.byType(DropdownButton<RoomRole>),
-        );
-        expect(dropdown.onChanged, isNull);
-      });
-
-      testWidgets('dropdown is disabled when target is at or above viewer level',
-          (tester) async {
-        // Viewer is moderator (50), target is also moderator (50).
-        when(mockClient.userID).thenReturn('@me:example.com');
-        when(mockRoom.getPowerLevelByUserId('@me:example.com')).thenReturn(50);
-        final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-        when(mockRoom.getPowerLevelByUserId('@alice:example.com')).thenReturn(50);
-        when(mockRoom.canChangePowerLevel).thenReturn(true);
-        when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
-
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Alice'));
-        await tester.pumpAndSettle();
-
-        final dropdown = tester.widget<DropdownButton<RoomRole>>(
-          find.byType(DropdownButton<RoomRole>),
-        );
-        expect(dropdown.onChanged, isNull);
-      });
-
-      testWidgets('selecting a role calls setRoomStateWithKey with correct patch',
-          (tester) async {
-        // Viewer is admin (100), target Alice is member (0).
-        when(mockClient.userID).thenReturn('@me:example.com');
-        when(mockRoom.getPowerLevelByUserId('@me:example.com')).thenReturn(100);
-        final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-        when(mockRoom.getPowerLevelByUserId('@alice:example.com')).thenReturn(0);
-        when(mockRoom.canChangePowerLevel).thenReturn(true);
-        when(mockRoom.getState(EventTypes.RoomPowerLevels)).thenReturn(null);
-        when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
-        when(mockClient.setRoomStateWithKey(any, any, any, any))
-            .thenAnswer((_) async => r'$eventId');
-
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Alice'));
-        await tester.pumpAndSettle();
-
-        // Open dropdown and select Moderator.
-        await tester.tap(find.byType(DropdownButton<RoomRole>));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('Moderator').last);
-        await tester.pumpAndSettle();
-
-        verify(mockClient.setRoomStateWithKey(
-          '!room:example.com',
-          EventTypes.RoomPowerLevels,
-          '',
-          argThat(predicate<Map<String, Object?>>(
-            (m) {
-              final users = m['users'] as Map<String, Object?>?;
-              return users?['@alice:example.com'] == 50;
+    testWidgets('role change calls onRoleChange callback', (tester) async {
+      int? newLevel;
+      await tester.pumpWidget(
+        _wrapDialog(
+          MemberSheetDialog(
+            member: _member(displayname: 'Bob'),
+            isMe: false,
+            ownLevel: 100,
+            canChangeRole: true,
+            canKick: false,
+            canBan: false,
+            avatarResolver: _avatarResolver,
+            presence: _nullPresence(),
+            onRoleChange: (level) async {
+              newLevel = level;
             },
-            'contains users.@alice:example.com == 50',
-          ),),
-        ),).called(1);
-      });
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
 
-      testWidgets('shows confirmation dialog before demoting an admin',
-          (tester) async {
-        when(mockClient.userID).thenReturn('@me:example.com');
-        // Viewer at 150 so they outrank Alice at 100 and canChangeRole is true.
-        when(mockRoom.getPowerLevelByUserId('@me:example.com')).thenReturn(150);
-        final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-        when(mockRoom.getPowerLevelByUserId('@alice:example.com')).thenReturn(100);
-        when(mockRoom.canChangePowerLevel).thenReturn(true);
-        when(mockRoom.getState(EventTypes.RoomPowerLevels)).thenReturn(null);
-        when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
-        when(mockClient.setRoomStateWithKey(any, any, any, any))
-            .thenAnswer((_) async => r'$eventId');
+      await tester.tap(find.byType(DropdownButton<RoomRole>));
+      await tester.pumpAndSettle();
 
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
+      await tester.tap(find.text('Moderator').last);
+      await tester.pumpAndSettle();
 
-        await tester.tap(find.text('Alice'));
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.byType(DropdownButton<RoomRole>));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('Member').last);
-        await tester.pumpAndSettle();
-
-        expect(find.text('Demote admin?'), findsOneWidget);
-        verifyNever(mockClient.setRoomStateWithKey(any, any, any, any));
-      });
-
-      testWidgets('cancelling demotion confirm does not call setRoomStateWithKey',
-          (tester) async {
-        when(mockClient.userID).thenReturn('@me:example.com');
-        // Viewer at 150 so they outrank Alice at 100 and canChangeRole is true.
-        when(mockRoom.getPowerLevelByUserId('@me:example.com')).thenReturn(150);
-        final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-        when(mockRoom.getPowerLevelByUserId('@alice:example.com')).thenReturn(100);
-        when(mockRoom.canChangePowerLevel).thenReturn(true);
-        when(mockRoom.getState(EventTypes.RoomPowerLevels)).thenReturn(null);
-        when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
-
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Alice'));
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.byType(DropdownButton<RoomRole>));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('Member').last);
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
-        await tester.pumpAndSettle();
-
-        verifyNever(mockClient.setRoomStateWithKey(any, any, any, any));
-      });
-
-      testWidgets('custom power level shown in dropdown', (tester) async {
-        final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-        when(mockRoom.getPowerLevelByUserId('@alice:example.com')).thenReturn(75);
-        when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
-
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Alice'));
-        await tester.pumpAndSettle();
-
-        expect(find.text('Custom (75)'), findsWidgets);
-      });
-
-      testWidgets('role section hidden for self', (tester) async {
-        when(mockClient.userID).thenReturn('@me:example.com');
-        final me = _makeUser('@me:example.com', 'Me', room: mockRoom);
-        when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [me]);
-
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Me'));
-        await tester.pumpAndSettle();
-
-        expect(find.byType(DropdownButton<RoomRole>), findsNothing);
-      });
+      expect(newLevel, 50);
     });
 
-    group('MXID copy', () {
-      testWidgets('copy button writes MXID to clipboard', (tester) async {
-        final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-        when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
+    testWidgets('shows error on kick failure', (tester) async {
+      await tester.pumpWidget(
+        _wrapDialog(
+          MemberSheetDialog(
+            member: _member(displayname: 'Bob'),
+            isMe: false,
+            ownLevel: 100,
+            canChangeRole: false,
+            canKick: true,
+            canBan: false,
+            avatarResolver: _avatarResolver,
+            presence: _nullPresence(),
+            onKick: (reason) async => throw Exception('Permission denied'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        String? copiedText;
-        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-          SystemChannels.platform,
-          (call) async {
-            if (call.method == 'Clipboard.setData') {
-              copiedText = (call.arguments as Map)['text'] as String;
-            }
-            return null;
-          },
-        );
+      await tester.tap(find.text('Kick'));
+      await tester.pumpAndSettle();
 
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
+      await tester.tap(find.text('Kick').last);
+      await tester.pumpAndSettle();
 
-        await tester.tap(find.text('Alice'));
-        await tester.pumpAndSettle();
+      expect(find.textContaining('Permission denied'), findsOneWidget);
+    });
 
-        await tester.tap(find.byIcon(Icons.copy_outlined));
-        await tester.pumpAndSettle();
+    testWidgets('shows power level description', (tester) async {
+      await tester.pumpWidget(
+        _wrapDialog(
+          MemberSheetDialog(
+            member: _member(powerLevel: 100),
+            isMe: false,
+            ownLevel: 100,
+            canChangeRole: false,
+            canKick: false,
+            canBan: false,
+            avatarResolver: _avatarResolver,
+            presence: _nullPresence(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        expect(copiedText, '@alice:example.com');
-      });
-
-      testWidgets('copy button shows snackbar confirmation', (tester) async {
-        final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
-        when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
-
-        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-          SystemChannels.platform,
-          (_) async => null,
-        );
-
-        await tester.pumpWidget(buildTestWidget());
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Alice'));
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.byIcon(Icons.copy_outlined));
-        await tester.pumpAndSettle();
-
-        expect(find.text('Copied to clipboard'), findsOneWidget);
-      });
+      expect(find.text('Admin (power level 100)'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary

Eliminates `matrix_sdk.Room` and `matrix_sdk.User` coupling from `room_members_section.dart` and `member_sheet_dialog.dart` by introducing a Kohera-owned domain model.

## Changes

### New domain model
- **`KoheraRoomMember`** — immutable value object wrapping user ID, display name, avatar URL, membership, and power level
- **`KoheraRoomMemberList`** — immutable list wrapper with `participantListComplete` and `memberCount`
- **`RoomMemberListResolver`** — boundary converter that calls `room.requestParticipants()` and maps SDK `User` objects to `KoheraRoomMember` at the conversion boundary

### Refactored widgets (SDK-free)
- **`RoomMembersSection`** — now takes `KoheraRoomMemberList` + `AvatarResolver` + `PresenceService` instead of `Room`; no `matrix_sdk` imports
- **`MemberSheetDialog`** — now takes `KoheraRoomMember` + explicit callbacks (`onStartDm`, `onRoleChange`, `onKick`, `onBan`, `onUnban`) instead of `Room` + `User`; no `matrix_sdk` imports

### Boundary callers updated
- **`RoomDetailsPanel`** — loads members via `RoomMemberListResolver`, passes `KoheraRoomMemberList` to section
- **`SpaceDetailsPanel`** — same pattern as RoomDetailsPanel
- **`ChatMessageItem`** — builds `KoheraRoomMember` from `senderFromMemoryOrFallback` and passes to `showMemberSheetDialog`

### Tests
- New `kohera_room_member_test.dart` — model unit tests
- Updated `room_members_section_test.dart` — SDK-free widget tests using Kohera models
- Updated `message_actions_test.dart` — adapted to new `showMemberSheetDialog` API
- All 2263 tests pass, zero analyze issues

Refs #697
Closes #706