### PR TITLE
refactor(#708): eliminate matrix_sdk.Room from action widgets

### DIFF
--- a/lib/core/models/kohera_push_rule_state.dart
+++ b/lib/core/models/kohera_push_rule_state.dart
@@ -1,0 +1,10 @@
+/// SDK-free representation of a Matrix push rule state for a room.
+///
+/// Mirrors `matrix_sdk.PushRuleState` without carrying a
+/// `package:matrix/matrix.dart` dependency. The conversion boundary
+/// ([RoomDetailsController]) maps between this and the SDK enum.
+enum KoheraPushRuleState {
+  notify,
+  mentionsOnly,
+  dontNotify,
+}

--- a/lib/features/home/widgets/mobile_space_drawer.dart
+++ b/lib/features/home/widgets/mobile_space_drawer.dart
@@ -137,8 +137,14 @@ class MobileSpaceDrawer extends StatelessWidget {
                         ),
                         title: Text(space.getLocalizedDisplayname()),
                         onTap: () async {
-                          final result =
-                              await InviteDialog.show(context, room: space);
+                          final result = await InviteDialog.show(
+                            context,
+                            roomId: space.id,
+                            summary: selection.summaryFor(space),
+                            inviterName: selection.inviterDisplayName(space),
+                            onAccept: space.join,
+                            onDecline: space.leave,
+                          );
                           if (result == true && context.mounted) {
                             selection.selectSpace(space.id);
                             if (context.mounted) {

--- a/lib/features/rooms/models/kohera_device_key.dart
+++ b/lib/features/rooms/models/kohera_device_key.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/foundation.dart';
+
+/// A Kohera-owned snapshot of a partner's device key for verification UI.
+///
+/// Carries no `package:matrix/matrix.dart` dependency; the conversion
+/// boundary ([RoomDetailsController]) maps SDK `DeviceKeys` to this type.
+@immutable
+class KoheraDeviceKey {
+  const KoheraDeviceKey({
+    required this.deviceId,
+    required this.displayName,
+    required this.verified,
+    required this.blocked,
+  });
+
+  final String? deviceId;
+  final String? displayName;
+  final bool verified;
+  final bool blocked;
+}

--- a/lib/features/rooms/services/room_details_controller.dart
+++ b/lib/features/rooms/services/room_details_controller.dart
@@ -1,0 +1,274 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:kohera/core/models/kohera_push_rule_state.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/services/sub_services/presence_service.dart';
+import 'package:kohera/core/services/sub_services/selection_service.dart';
+import 'package:kohera/features/e2ee/widgets/key_verification_dialog.dart';
+import 'package:kohera/features/rooms/models/kohera_device_key.dart';
+import 'package:kohera/features/rooms/models/kohera_room_member.dart';
+import 'package:kohera/features/rooms/models/kohera_room_permissions.dart';
+import 'package:kohera/features/rooms/models/kohera_room_summary.dart';
+import 'package:kohera/features/rooms/services/room_member_list_resolver.dart';
+import 'package:kohera/features/rooms/services/room_permissions_resolver.dart';
+import 'package:kohera/features/rooms/widgets/invite_user_dialog.dart';
+import 'package:kohera/features/rooms/widgets/invite_user_dialog_params.dart';
+import 'package:kohera/features/rooms/widgets/join_access_controller.dart';
+import 'package:kohera/features/rooms/widgets/member_sheet_launcher.dart';
+import 'package:kohera/features/rooms/widgets/shared_media_section.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
+import 'package:matrix/matrix.dart';
+
+/// Owns the SDK `Room` for [RoomDetailsPanel] and exposes everything the
+/// SDK-free panel needs: display models ([KoheraRoomSummary],
+/// [KoheraRoomPermissions], [KoheraRoomMemberList]), action callbacks, device
+/// verification, and the Room-typed child widgets ([JoinAccessController],
+/// [SharedMediaSection], member sheet).
+///
+/// This is the conversion boundary for slice #708: it is the only place in
+/// the room-details feature that imports `package:matrix/matrix.dart`.
+class RoomDetailsController extends ChangeNotifier {
+  RoomDetailsController({
+    required this.roomId,
+    required this.matrix,
+    required this.selection,
+  });
+
+  final String roomId;
+  final MatrixService matrix;
+  final SelectionService selection;
+
+  Room? _room;
+  StreamSubscription<SyncUpdate>? _syncSub;
+  Timer? _syncDebounce;
+  KoheraRoomMemberList? _memberList;
+  bool _loadingMembers = false;
+  int? _lastMemberCount;
+  int _memberLoadGen = 0;
+  bool _disposed = false;
+
+  bool get hasRoom => _room != null;
+
+  KoheraRoomSummary? get summary =>
+      _room == null ? null : selection.summaryFor(_room!);
+
+  KoheraRoomPermissions? get permissions => _room == null
+      ? null
+      : const RoomPermissionsResolver()
+          .convert(_room!, myUserId: matrix.client.userID ?? '');
+
+  KoheraRoomMemberList? get memberList => _memberList;
+  bool get loadingMembers => _loadingMembers;
+  int? get summaryMemberCount => _room?.summary.mJoinedMemberCount;
+  bool get participantListComplete => _room?.participantListComplete ?? false;
+
+  bool get isFavourite => _room?.isFavourite ?? false;
+  bool get isMuted => pushRuleState != KoheraPushRuleState.notify;
+  bool get encrypted => _room?.encrypted ?? false;
+  bool get isDirectChat => _room?.isDirectChat ?? false;
+  String? get partnerId => _room?.directChatMatrixID;
+
+  KoheraPushRuleState get pushRuleState =>
+      _toKohera(_room?.pushRuleState ?? PushRuleState.notify);
+
+  List<KoheraDeviceKey> get deviceKeys {
+    final partner = _room?.directChatMatrixID;
+    if (partner == null) return const [];
+    final list = matrix.client.userDeviceKeys[partner];
+    final devices = list?.deviceKeys.values.toList() ?? [];
+    return devices
+        .map(
+          (dk) => KoheraDeviceKey(
+            deviceId: dk.deviceId,
+            displayName: dk.deviceDisplayName,
+            verified: dk.verified,
+            blocked: dk.blocked,
+          ),
+        )
+        .toList();
+  }
+
+  AvatarResolver get avatarResolver => matrix.avatarResolver;
+  PresenceService get presence => matrix.presence;
+
+  // ── Lifecycle ───────────────────────────────────────────────
+
+  void init() {
+    _room = matrix.client.getRoomById(roomId);
+    if (_room == null) {
+      notifyListeners();
+      return;
+    }
+    _lastMemberCount = _room!.summary.mJoinedMemberCount;
+    unawaited(refreshDeviceKeys());
+    unawaited(loadMembers());
+    _syncSub = matrix.client.onSync.stream.listen((update) {
+      final stateEvents = update.rooms?.join?[roomId]?.state ?? [];
+      final hasPowerLevelChanges =
+          stateEvents.any((e) => e.type == EventTypes.RoomPowerLevels);
+      _syncDebounce?.cancel();
+      _syncDebounce = Timer(const Duration(seconds: 2), () {
+        if (_disposed) return;
+        notifyListeners();
+        if (hasPowerLevelChanges) {
+          final room = matrix.client.getRoomById(roomId);
+          if (room != null) unawaited(loadMembers());
+        }
+      });
+    });
+  }
+
+  /// Called by the panel on `didUpdateWidget` to detect the room appearing or
+  /// a member-count change requiring a member reload.
+  void checkRoomChanged() {
+    final room = matrix.client.getRoomById(roomId);
+    if (room != null && _room == null) {
+      _room = room;
+      _lastMemberCount = room.summary.mJoinedMemberCount;
+      notifyListeners();
+      unawaited(loadMembers());
+      return;
+    }
+    final count = room?.summary.mJoinedMemberCount;
+    if (count != null && count != _lastMemberCount && !_loadingMembers) {
+      unawaited(loadMembers());
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _syncDebounce?.cancel();
+    unawaited(_syncSub?.cancel());
+    super.dispose();
+  }
+
+  // ── Actions ────────────────────────────────────────────────
+
+  Future<void> toggleMute() async {
+    final room = _room!;
+    final current = room.pushRuleState;
+    await room.setPushRuleState(
+      current == PushRuleState.notify
+          ? PushRuleState.dontNotify
+          : PushRuleState.notify,
+    );
+  }
+
+  Future<void> toggleFavourite() async {
+    final room = _room!;
+    final target = !room.isFavourite;
+    await room.setFavourite(target);
+    await room.client.onSync.stream
+        .firstWhere((_) => room.isFavourite == target)
+        .timeout(
+      const Duration(seconds: 5),
+      onTimeout: () => SyncUpdate(nextBatch: ''),
+    );
+  }
+
+  Future<void> setPushRule(KoheraPushRuleState state) async {
+    await _room!.setPushRuleState(_fromKohera(state));
+  }
+
+  Future<void> invite(String mxid) async {
+    await _room!.invite(mxid);
+  }
+
+  Future<void> setAvatar(Uint8List? bytes, String? filename) async {
+    await _room!.setAvatar(
+      bytes == null ? null : MatrixFile(bytes: bytes, name: filename ?? ''),
+    );
+  }
+
+  Future<void> setName(String name) async {
+    await _room!.setName(name);
+  }
+
+  Future<void> setDescription(String topic) async {
+    await _room!.setDescription(topic);
+  }
+
+  Future<void> enableEncryption() async {
+    await _room!.enableEncryption();
+  }
+
+  Future<void> leave() async {
+    await _room!.leave();
+    selection.selectRoom(null);
+  }
+
+  Future<int?> resolveMemberCount(String id) async {
+    final r = matrix.client.getRoomById(id);
+    if (r == null) return null;
+    final members = await matrix.client.getJoinedMembersByRoom(id);
+    return members?.length;
+  }
+
+  Future<void> loadMembers() async {
+    final room = _room;
+    if (room == null) return;
+    final gen = ++_memberLoadGen;
+    _loadingMembers = true;
+    notifyListeners();
+    try {
+      final list = await const RoomMemberListResolver().resolve(room);
+      if (_disposed || gen != _memberLoadGen) return;
+      _memberList = list;
+      _loadingMembers = false;
+      _lastMemberCount = list.memberCount;
+      notifyListeners();
+    } catch (e) {
+      debugPrint('[Kohera] Failed to load members: $e');
+      if (!_disposed) {
+        _loadingMembers = false;
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<void> refreshDeviceKeys() async {
+    await matrix.client.updateUserDeviceKeys();
+    if (!_disposed) notifyListeners();
+  }
+
+  Future<void> verifyDevice(BuildContext context, String? deviceId) async {
+    final partner = _room?.directChatMatrixID;
+    if (partner == null || deviceId == null) return;
+    final dkList = matrix.client.userDeviceKeys[partner];
+    final dk = dkList?.deviceKeys[deviceId];
+    if (dk == null) return;
+    final verification = await dk.startVerification();
+    if (!context.mounted) return;
+    await KeyVerificationDialog.show(context, verification: verification);
+    await matrix.client.updateUserDeviceKeys();
+    if (!_disposed) notifyListeners();
+  }
+
+  InviteUserDialogParams inviteDialogParams() => inviteUserDialogParams(_room!);
+
+  Future<void> showMemberSheet(
+    BuildContext context,
+    KoheraRoomMember member,
+  ) =>
+      showRoomMemberSheet(context, room: _room!, member: member);
+
+  Widget buildJoinAccessSection() => JoinAccessController(room: _room!);
+  Widget buildSharedMediaSection() => SharedMediaSection(room: _room!);
+
+  // ── Push rule mapping ──────────────────────────────────────
+
+  static KoheraPushRuleState _toKohera(PushRuleState s) => switch (s) {
+        PushRuleState.notify => KoheraPushRuleState.notify,
+        PushRuleState.mentionsOnly => KoheraPushRuleState.mentionsOnly,
+        PushRuleState.dontNotify => KoheraPushRuleState.dontNotify,
+      };
+
+  static PushRuleState _fromKohera(KoheraPushRuleState s) => switch (s) {
+        KoheraPushRuleState.notify => PushRuleState.notify,
+        KoheraPushRuleState.mentionsOnly => PushRuleState.mentionsOnly,
+        KoheraPushRuleState.dontNotify => PushRuleState.dontNotify,
+      };
+}

--- a/lib/features/rooms/services/room_details_controller.dart
+++ b/lib/features/rooms/services/room_details_controller.dart
@@ -201,8 +201,7 @@ class RoomDetailsController extends ChangeNotifier {
   }
 
   Future<int?> resolveMemberCount(String id) async {
-    final r = matrix.client.getRoomById(id);
-    if (r == null) return null;
+    if (matrix.client.getRoomById(id) == null) return null;
     final members = await matrix.client.getJoinedMembersByRoom(id);
     return members?.length;
   }

--- a/lib/features/rooms/widgets/add_existing_rooms_dialog.dart
+++ b/lib/features/rooms/widgets/add_existing_rooms_dialog.dart
@@ -1,38 +1,55 @@
 import 'package:flutter/material.dart';
 import 'package:kohera/core/extensions/context_extension.dart';
-import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/features/rooms/models/kohera_room_summary.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/widgets/loading_button_child.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
-import 'package:matrix/matrix.dart' hide Visibility;
 
 // ── Add Existing Rooms to Space Dialog ───────────────────────────
 
 class AddExistingRoomsDialog extends StatefulWidget {
   const AddExistingRoomsDialog._({
-    required this.space,
-    required this.matrixService,
+    required this.candidateRooms,
+    required this.existingChildIds,
+    required this.avatarResolver,
+    required this.onAddRooms,
   });
 
-  final Room space;
-  final MatrixService matrixService;
+  /// Joined rooms (as SDK-free summaries) the user may add. The dialog filters
+  /// out spaces and rooms already in the space.
+  final List<KoheraRoomSummary> candidateRooms;
+
+  /// Room IDs already children of the space (excluded from the list).
+  final Set<String> existingChildIds;
+
+  /// Resolves candidate avatar URIs to HTTP thumbnails.
+  final AvatarResolver? avatarResolver;
+
+  /// Adds the selected room IDs to the space. Returns the number of rooms that
+  /// failed to add (0 = success). The parent performs the SDK `setSpaceChild`
+  /// calls and invalidates the space tree.
+  final Future<int> Function(List<String> roomIds) onAddRooms;
 
   static Future<void> show(
     BuildContext context, {
-    required Room space,
-    required MatrixService matrixService,
+    required List<KoheraRoomSummary> candidateRooms,
+    required Set<String> existingChildIds,
+    required AvatarResolver? avatarResolver,
+    required Future<int> Function(List<String> roomIds) onAddRooms,
   }) {
     return showDialog(
       context: context,
       builder: (_) => AddExistingRoomsDialog._(
-        space: space,
-        matrixService: matrixService,
+        candidateRooms: candidateRooms,
+        existingChildIds: existingChildIds,
+        avatarResolver: avatarResolver,
+        onAddRooms: onAddRooms,
       ),
     );
   }
 
   @override
-  State<AddExistingRoomsDialog> createState() =>
-      _AddExistingRoomsDialogState();
+  State<AddExistingRoomsDialog> createState() => _AddExistingRoomsDialogState();
 }
 
 class _AddExistingRoomsDialogState extends State<AddExistingRoomsDialog> {
@@ -40,7 +57,7 @@ class _AddExistingRoomsDialogState extends State<AddExistingRoomsDialog> {
   final Set<String> _selected = {};
   bool _loading = false;
   String _query = '';
-  late List<Room> _eligibleRooms;
+  late List<KoheraRoomSummary> _eligibleRooms;
 
   @override
   void initState() {
@@ -54,19 +71,13 @@ class _AddExistingRoomsDialogState extends State<AddExistingRoomsDialog> {
     super.dispose();
   }
 
-  List<Room> _computeEligibleRooms() {
-    final existingChildIds =
-        widget.space.spaceChildren.map((c) => c.roomId).toSet();
-    return widget.matrixService.client.rooms
-        .where((r) =>
-            r.membership == Membership.join &&
-            !r.isSpace &&
-            !existingChildIds.contains(r.id),)
+  List<KoheraRoomSummary> _computeEligibleRooms() {
+    return widget.candidateRooms
+        .where((r) => !r.isSpace && !widget.existingChildIds.contains(r.roomId))
         .toList()
-      ..sort((a, b) => a
-          .getLocalizedDisplayname()
-          .toLowerCase()
-          .compareTo(b.getLocalizedDisplayname().toLowerCase()),);
+      ..sort(
+        (a, b) => a.displayname.toLowerCase().compareTo(b.displayname.toLowerCase()),
+      );
   }
 
   Future<void> _submit() async {
@@ -74,17 +85,7 @@ class _AddExistingRoomsDialogState extends State<AddExistingRoomsDialog> {
 
     setState(() => _loading = true);
 
-    var failures = 0;
-    for (final roomId in _selected) {
-      try {
-        await widget.space.setSpaceChild(roomId);
-      } catch (e) {
-        debugPrint('[Kohera] Failed to add room to space: $e');
-        failures++;
-      }
-    }
-
-    widget.matrixService.selection.invalidateSpaceTree();
+    final failures = await widget.onAddRooms(_selected.toList());
 
     if (!mounted) return;
 
@@ -102,10 +103,9 @@ class _AddExistingRoomsDialogState extends State<AddExistingRoomsDialog> {
     final filtered = _query.isEmpty
         ? _eligibleRooms
         : _eligibleRooms
-            .where((r) => r
-                .getLocalizedDisplayname()
-                .toLowerCase()
-                .contains(_query.toLowerCase()),)
+            .where(
+              (r) => r.displayname.toLowerCase().contains(_query.toLowerCase()),
+            )
             .toList();
 
     return AlertDialog(
@@ -115,7 +115,8 @@ class _AddExistingRoomsDialogState extends State<AddExistingRoomsDialog> {
         height: 400,
         child: _eligibleRooms.isEmpty
             ? const Center(
-                child: Text('All your rooms are already in this space.'),)
+                child: Text('All your rooms are already in this space.'),
+              )
             : Column(
                 children: [
                   TextField(
@@ -137,26 +138,26 @@ class _AddExistingRoomsDialogState extends State<AddExistingRoomsDialog> {
                             itemCount: filtered.length,
                             itemBuilder: (context, index) {
                               final room = filtered[index];
-                              final checked = _selected.contains(room.id);
+                              final checked = _selected.contains(room.roomId);
                               return CheckboxListTile(
                                 value: checked,
                                 onChanged: _loading
                                     ? null
                                     : (v) => setState(() {
                                           if (v == true) {
-                                            _selected.add(room.id);
+                                            _selected.add(room.roomId);
                                           } else {
-                                            _selected.remove(room.id);
+                                            _selected.remove(room.roomId);
                                           }
                                         }),
                                 secondary: RoomAvatarWidget(
-                                  avatarUrl: room.avatar?.toString(),
-                                  displayname: room.getLocalizedDisplayname(),
-                                  avatarResolver: widget.matrixService.avatarResolver,
+                                  avatarUrl: room.avatarUrl,
+                                  displayname: room.displayname,
+                                  avatarResolver: widget.avatarResolver,
                                   size: 36,
                                 ),
                                 title: Text(
-                                  room.getLocalizedDisplayname(),
+                                  room.displayname,
                                   overflow: TextOverflow.ellipsis,
                                 ),
                               );

--- a/lib/features/rooms/widgets/add_room_to_space_dialog.dart
+++ b/lib/features/rooms/widgets/add_room_to_space_dialog.dart
@@ -1,31 +1,56 @@
 import 'package:flutter/material.dart';
 import 'package:kohera/core/extensions/context_extension.dart';
-import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/features/rooms/models/kohera_room_summary.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/widgets/loading_button_child.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
-import 'package:matrix/matrix.dart' hide Visibility;
 
 // ── Add Room to Space Dialog ─────────────────────────────────────
 
 class AddRoomToSpaceDialog extends StatefulWidget {
   const AddRoomToSpaceDialog._({
-    required this.room,
-    required this.matrixService,
+    required this.roomId,
+    required this.candidateSpaces,
+    required this.memberSpaceIds,
+    required this.avatarResolver,
+    required this.onAddToSpaces,
   });
 
-  final Room room;
-  final MatrixService matrixService;
+  /// The room being added to spaces.
+  final String roomId;
+
+  /// Spaces the user may add the room to (parent pre-filters by permission),
+  /// as SDK-free summaries. The dialog excludes those in [memberSpaceIds].
+  final List<KoheraRoomSummary> candidateSpaces;
+
+  /// Space IDs the room is already a child of (excluded from the list).
+  final Set<String> memberSpaceIds;
+
+  /// Resolves candidate avatar URIs to HTTP thumbnails.
+  final AvatarResolver? avatarResolver;
+
+  /// Adds the room to the selected spaces. Keys are selected space IDs, values
+  /// are the per-space "suggested" flags. Returns the number of failures
+  /// (0 = success). The parent performs the SDK `setSpaceChild` calls and
+  /// invalidates the space tree.
+  final Future<int> Function(Map<String, bool> selections) onAddToSpaces;
 
   static Future<void> show(
     BuildContext context, {
-    required Room room,
-    required MatrixService matrixService,
+    required String roomId,
+    required List<KoheraRoomSummary> candidateSpaces,
+    required Set<String> memberSpaceIds,
+    required AvatarResolver? avatarResolver,
+    required Future<int> Function(Map<String, bool> selections) onAddToSpaces,
   }) {
     return showDialog(
       context: context,
       builder: (_) => AddRoomToSpaceDialog._(
-        room: room,
-        matrixService: matrixService,
+        roomId: roomId,
+        candidateSpaces: candidateSpaces,
+        memberSpaceIds: memberSpaceIds,
+        avatarResolver: avatarResolver,
+        onAddToSpaces: onAddToSpaces,
       ),
     );
   }
@@ -39,39 +64,23 @@ class _AddRoomToSpaceDialogState extends State<AddRoomToSpaceDialog> {
   final Map<String, bool> _suggested = {};
   bool _loading = false;
 
-  List<Room> get _eligibleSpaces {
-    final memberships = widget.matrixService.selection.spaceMemberships(widget.room.id);
-    return widget.matrixService.selection.spaces
-        .where((s) =>
-            s.canChangeStateEvent('m.space.child') &&
-            !memberships.contains(s.id),)
-        .toList();
-  }
+  List<KoheraRoomSummary> get _eligibleSpaces => widget.candidateSpaces
+      .where((s) => !widget.memberSpaceIds.contains(s.roomId))
+      .toList();
 
   bool get _hasSelection => _selected.values.any((v) => v);
 
   Future<void> _submit() async {
-    final spaces = _eligibleSpaces
-        .where((s) => _selected[s.id] == true)
-        .toList();
-    if (spaces.isEmpty) return;
+    final selections = Map<String, bool>.fromEntries(
+      _selected.entries
+          .where((e) => e.value)
+          .map((e) => MapEntry(e.key, _suggested[e.key] == true)),
+    );
+    if (selections.isEmpty) return;
 
     setState(() => _loading = true);
 
-    var failures = 0;
-    for (final space in spaces) {
-      try {
-        await space.setSpaceChild(
-          widget.room.id,
-          suggested: _suggested[space.id] == true ? true : null,
-        );
-      } catch (e) {
-        debugPrint('[Kohera] Failed to add room to space: $e');
-        failures++;
-      }
-    }
-
-    widget.matrixService.selection.invalidateSpaceTree();
+    final failures = await widget.onAddToSpaces(selections);
 
     if (!mounted) return;
 
@@ -98,22 +107,22 @@ class _AddRoomToSpaceDialogState extends State<AddRoomToSpaceDialog> {
                   itemCount: eligible.length,
                   itemBuilder: (context, index) {
                     final space = eligible[index];
-                    final checked = _selected[space.id] == true;
+                    final checked = _selected[space.roomId] == true;
                     return CheckboxListTile(
                       value: checked,
                       onChanged: _loading
                           ? null
                           : (v) => setState(
-                              () => _selected[space.id] = v ?? false,
+                              () => _selected[space.roomId] = v ?? false,
                             ),
                       secondary: RoomAvatarWidget(
-                        avatarUrl: space.avatar?.toString(),
-                        displayname: space.getLocalizedDisplayname(),
-                        avatarResolver: widget.matrixService.avatarResolver,
+                        avatarUrl: space.avatarUrl,
+                        displayname: space.displayname,
+                        avatarResolver: widget.avatarResolver,
                         size: 36,
                       ),
                       title: Text(
-                        space.getLocalizedDisplayname(),
+                        space.displayname,
                         overflow: TextOverflow.ellipsis,
                       ),
                       subtitle: Row(
@@ -124,10 +133,10 @@ class _AddRoomToSpaceDialogState extends State<AddRoomToSpaceDialog> {
                           SizedBox(
                             height: 24,
                             child: Switch(
-                              value: _suggested[space.id] == true,
+                              value: _suggested[space.roomId] == true,
                               onChanged: checked && !_loading
                                   ? (v) => setState(
-                                      () => _suggested[space.id] = v,
+                                      () => _suggested[space.roomId] = v,
                                     )
                                   : null,
                             ),

--- a/lib/features/rooms/widgets/invite_dialog.dart
+++ b/lib/features/rooms/widgets/invite_dialog.dart
@@ -1,24 +1,60 @@
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/matrix_service.dart';
-import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/utils/confirm_dialog.dart';
+import 'package:kohera/features/rooms/models/kohera_room_summary.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
-import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
 /// Shared dialog for accepting or declining a room/space invitation.
 ///
+/// SDK-free: display data comes from [KoheraRoomSummary] and the accept/decline
+/// actions are delegated to callbacks supplied by the parent, which retains
+/// `Room` access.
+///
 /// Returns `true` if accepted, `false` if declined, `null` if dismissed.
 class InviteDialog extends StatefulWidget {
-  const InviteDialog({required this.room, super.key});
+  const InviteDialog({
+    required this.roomId,
+    required this.summary,
+    required this.onAccept,
+    required this.onDecline,
+    this.inviterName,
+    super.key,
+  });
 
-  final Room room;
+  /// The Matrix room/space ID being invited to.
+  final String roomId;
+
+  /// Pre-computed display fields (displayname, avatar, isSpace, …).
+  final KoheraRoomSummary summary;
+
+  /// Resolved display name of the inviter, or `null` if unknown.
+  final String? inviterName;
+
+  /// Joins the room/space. Throwing errors are caught and shown inline.
+  final Future<void> Function() onAccept;
+
+  /// Leaves (declines) the room/space. Throwing errors are caught and shown.
+  final Future<void> Function() onDecline;
 
   /// Show the invite dialog and return the user's decision.
-  static Future<bool?> show(BuildContext context, {required Room room}) {
+  static Future<bool?> show(
+    BuildContext context, {
+    required String roomId,
+    required KoheraRoomSummary summary,
+    required Future<void> Function() onAccept,
+    required Future<void> Function() onDecline,
+    String? inviterName,
+  }) {
     return showDialog<bool>(
       context: context,
-      builder: (_) => InviteDialog(room: room),
+      builder: (_) => InviteDialog(
+        roomId: roomId,
+        summary: summary,
+        inviterName: inviterName,
+        onAccept: onAccept,
+        onDecline: onDecline,
+      ),
     );
   }
 
@@ -31,15 +67,13 @@ class _InviteDialogState extends State<InviteDialog> {
   bool _declining = false;
   String? _error;
 
-  String? get _inviterName {
-    final selection = context.read<SelectionService>();
-    return selection.inviterDisplayName(widget.room);
-  }
-
   Future<void> _accept() async {
-    setState(() { _accepting = true; _error = null; });
+    setState(() {
+      _accepting = true;
+      _error = null;
+    });
     try {
-      await widget.room.join();
+      await widget.onAccept();
       if (mounted) Navigator.pop(context, true);
     } catch (e) {
       debugPrint('[Kohera] Accept invite failed: $e');
@@ -56,14 +90,17 @@ class _InviteDialogState extends State<InviteDialog> {
     final confirmed = await confirmDialog(
       context,
       title: 'Decline invite',
-      message: 'Decline invite to ${widget.room.getLocalizedDisplayname()}?',
+      message: 'Decline invite to ${widget.summary.displayname}?',
       confirmLabel: 'Decline',
     );
     if (!confirmed || !mounted) return;
 
-    setState(() { _declining = true; _error = null; });
+    setState(() {
+      _declining = true;
+      _error = null;
+    });
     try {
-      await widget.room.leave();
+      await widget.onDecline();
       if (mounted) Navigator.pop(context, false);
     } catch (e) {
       debugPrint('[Kohera] Decline invite failed: $e');
@@ -80,20 +117,20 @@ class _InviteDialogState extends State<InviteDialog> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
-    final name = widget.room.getLocalizedDisplayname();
-    final inviter = _inviterName;
+    final name = widget.summary.displayname;
+    final inviter = widget.inviterName;
     final inFlight = _accepting || _declining;
 
     return AlertDialog(
-      title: Text(widget.room.isSpace ? 'Space invite' : 'Room invite'),
+      title: Text(widget.summary.isSpace ? 'Space invite' : 'Room invite'),
       content: SizedBox(
         width: 400,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
             RoomAvatarWidget(
-              avatarUrl: widget.room.avatar?.toString(),
-              displayname: widget.room.getLocalizedDisplayname(),
+              avatarUrl: widget.summary.avatarUrl,
+              displayname: widget.summary.displayname,
               avatarResolver: context.read<MatrixService>().avatarResolver,
               size: 56,
             ),

--- a/lib/features/rooms/widgets/invite_user_dialog.dart
+++ b/lib/features/rooms/widgets/invite_user_dialog.dart
@@ -1,23 +1,59 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:kohera/core/utils/known_contacts.dart' show knownContacts, roomContacts;
-import 'package:matrix/matrix.dart' hide Visibility;
+import 'package:kohera/shared/models/kohera_user_summary.dart';
+
+/// SDK-free inputs for [InviteUserDialog].
+///
+/// The parent (which retains `Room`/`Client` access) computes the member set,
+/// contact suggestions, and the user-directory search callback, then passes
+/// them in. The dialog itself has no `package:matrix/matrix.dart` dependency.
+class InviteUserDialogParams {
+  const InviteUserDialogParams({
+    required this.roomId,
+    required this.existingMemberIds,
+    required this.knownContacts,
+    required this.roomContacts,
+    required this.onSearchUserDirectory,
+  });
+
+  /// The Matrix room/space ID the user will be invited to.
+  final String roomId;
+
+  /// MXIDs already participating in the room (to exclude from suggestions).
+  final Set<String> existingMemberIds;
+
+  /// Recent DM contacts, as SDK-free summaries.
+  final List<KoheraUserSummary> knownContacts;
+
+  /// Contacts from other joined group rooms, as SDK-free summaries.
+  final List<KoheraUserSummary> roomContacts;
+
+  /// Searches the homeserver user directory for [query], returning matches
+  /// as SDK-free summaries.
+  final Future<List<KoheraUserSummary>> Function(String query)
+      onSearchUserDirectory;
+}
 
 /// A reusable dialog that prompts for a Matrix user ID to invite to a room
 /// or space. Suggests recent contacts and searches the homeserver's user
 /// directory as the user types.
 ///
+/// SDK-free: all data and search access is provided via [InviteUserDialogParams].
+///
 /// Returns the validated MXID string on success, or `null` if cancelled.
 class InviteUserDialog extends StatefulWidget {
-  const InviteUserDialog._({required this.room});
+  const InviteUserDialog({required this.params, super.key});
 
-  final Room room;
+  final InviteUserDialogParams params;
 
-  static Future<String?> show(BuildContext context, {required Room room}) {
+  static Future<String?> show(
+    BuildContext context, {
+    required InviteUserDialogParams params,
+  }) {
     return showDialog<String>(
       context: context,
-      builder: (_) => InviteUserDialog._(room: room),
+      builder: (_) => InviteUserDialog(params: params),
     );
   }
 
@@ -33,26 +69,14 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
   final _focusNode = FocusNode();
   String? _error;
   bool _searching = false;
-  List<Profile> _searchResults = [];
+  List<KoheraUserSummary> _searchResults = [];
   Timer? _debounce;
   int _searchGeneration = 0;
-  List<Profile>? _cachedContacts;
-  List<Profile>? _cachedRoomContacts;
-  Set<String>? _cachedExistingMembers;
-  bool _suggestionsReady = false;
 
   @override
   void initState() {
     super.initState();
     _focusNode.addListener(_onFocusChanged);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      _existingMembers();
-      _knownContacts();
-      _roomContacts();
-      if (!mounted) return;
-      setState(() => _suggestionsReady = true);
-    });
   }
 
   @override
@@ -66,52 +90,6 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
 
   void _onFocusChanged() {
     if (mounted) setState(() {});
-  }
-
-  Client? get _client {
-    try {
-      return widget.room.client;
-    } catch (_) {
-      return null;
-    }
-  }
-
-  Set<String> _existingMembers() {
-    if (_cachedExistingMembers != null) return _cachedExistingMembers!;
-    try {
-      _cachedExistingMembers = widget.room
-          .getParticipants()
-          .map((u) => u.id)
-          .toSet();
-    } catch (_) {
-      _cachedExistingMembers = const <String>{};
-    }
-    return _cachedExistingMembers!;
-  }
-
-  List<Profile> _knownContacts() {
-    if (_cachedContacts != null) return _cachedContacts!;
-    final client = _client;
-    if (client == null) return _cachedContacts = const [];
-    try {
-      _cachedContacts = knownContacts(client);
-    } catch (_) {
-      _cachedContacts = const [];
-    }
-    return _cachedContacts!;
-  }
-
-  List<Profile> _roomContacts() {
-    if (_cachedRoomContacts != null) return _cachedRoomContacts!;
-    final client = _client;
-    if (client == null) return _cachedRoomContacts = const [];
-    try {
-      final dmIds = _knownContacts().map((p) => p.userId).toSet();
-      _cachedRoomContacts = roomContacts(client, excludeMxids: dmIds);
-    } catch (_) {
-      _cachedRoomContacts = const [];
-    }
-    return _cachedRoomContacts!;
   }
 
   void _onQueryChanged(String text) {
@@ -131,16 +109,14 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
   }
 
   Future<void> _runSearch(String query) async {
-    final client = _client;
-    if (client == null) return;
     _searchGeneration++;
     final gen = _searchGeneration;
     setState(() => _searching = true);
     try {
-      final response = await client.searchUserDirectory(query, limit: 20);
+      final results = await widget.params.onSearchUserDirectory(query);
       if (!mounted || gen != _searchGeneration) return;
       setState(() {
-        _searchResults = response.results;
+        _searchResults = results;
         _searching = false;
       });
     } catch (_) {
@@ -152,7 +128,7 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
     }
   }
 
-  void _selectProfile(Profile profile) {
+  void _selectProfile(KoheraUserSummary profile) {
     Navigator.pop(context, profile.userId);
   }
 
@@ -170,21 +146,25 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
   }
 
   List<Widget> _buildSuggestions(ColorScheme cs) {
-    if (!_suggestionsReady) return [];
     final query = _controller.text.trim();
-    final existing = _existingMembers();
+    final existing = widget.params.existingMemberIds;
     final tiles = <Widget>[];
 
     if (query.isNotEmpty) {
-      final filtered = _searchResults.where((p) => !existing.contains(p.userId)).toList();
+      final filtered =
+          _searchResults.where((p) => !existing.contains(p.userId)).toList();
       for (final p in filtered) {
         tiles.add(_profileTile(p, cs));
       }
       return tiles;
     }
 
-    final dmContacts = _knownContacts().where((p) => !existing.contains(p.userId)).toList();
-    final groupContacts = _roomContacts().where((p) => !existing.contains(p.userId)).toList();
+    final dmContacts = widget.params.knownContacts
+        .where((p) => !existing.contains(p.userId))
+        .toList();
+    final groupContacts = widget.params.roomContacts
+        .where((p) => !existing.contains(p.userId))
+        .toList();
 
     if (dmContacts.isEmpty && groupContacts.isEmpty) return [];
 
@@ -217,9 +197,10 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
         ),
       );
 
-  Widget _profileTile(Profile p, ColorScheme cs) {
-    final label = p.displayName ?? p.userId;
-    final initial = label.isNotEmpty ? label.characters.first.toUpperCase() : '?';
+  Widget _profileTile(KoheraUserSummary p, ColorScheme cs) {
+    final label = p.displayname;
+    final initial =
+        label.isNotEmpty ? label.characters.first.toUpperCase() : '?';
     return ListTile(
       dense: true,
       leading: CircleAvatar(
@@ -235,7 +216,7 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
         overflow: TextOverflow.ellipsis,
         style: const TextStyle(fontSize: 14),
       ),
-      subtitle: p.displayName != null
+      subtitle: p.displayname != p.userId
           ? Text(
               p.userId,
               style: const TextStyle(fontSize: 11),
@@ -281,18 +262,7 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
                   padding: EdgeInsets.only(top: 4),
                   child: LinearProgressIndicator(),
                 ),
-              if (!_suggestionsReady)
-                const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 24),
-                  child: Center(
-                    child: SizedBox(
-                      height: 24,
-                      width: 24,
-                      child: CircularProgressIndicator(strokeWidth: 2.5),
-                    ),
-                  ),
-                )
-              else if (suggestions.isNotEmpty)
+              if (suggestions.isNotEmpty)
                 ConstrainedBox(
                   constraints: const BoxConstraints(maxHeight: 220),
                   child: ListView(

--- a/lib/features/rooms/widgets/invite_user_dialog.dart
+++ b/lib/features/rooms/widgets/invite_user_dialog.dart
@@ -112,20 +112,17 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
     _searchGeneration++;
     final gen = _searchGeneration;
     setState(() => _searching = true);
+    List<KoheraUserSummary> results;
     try {
-      final results = await widget.params.onSearchUserDirectory(query);
-      if (!mounted || gen != _searchGeneration) return;
-      setState(() {
-        _searchResults = results;
-        _searching = false;
-      });
+      results = await widget.params.onSearchUserDirectory(query);
     } catch (_) {
-      if (!mounted || gen != _searchGeneration) return;
-      setState(() {
-        _searchResults = [];
-        _searching = false;
-      });
+      results = const [];
     }
+    if (!mounted || gen != _searchGeneration) return;
+    setState(() {
+      _searchResults = results;
+      _searching = false;
+    });
   }
 
   void _selectProfile(KoheraUserSummary profile) {
@@ -151,12 +148,11 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
     final tiles = <Widget>[];
 
     if (query.isNotEmpty) {
-      final filtered =
-          _searchResults.where((p) => !existing.contains(p.userId)).toList();
-      for (final p in filtered) {
-        tiles.add(_profileTile(p, cs));
-      }
-      return tiles;
+      final filtered = _searchResults
+          .where((p) => !existing.contains(p.userId))
+          .map((p) => _profileTile(p, cs))
+          .toList();
+      return filtered;
     }
 
     final dmContacts = widget.params.knownContacts
@@ -170,16 +166,12 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
 
     if (dmContacts.isNotEmpty) {
       tiles.add(_sectionLabel('Recent contacts', cs));
-      for (final p in dmContacts) {
-        tiles.add(_profileTile(p, cs));
-      }
+      tiles.addAll(dmContacts.map((p) => _profileTile(p, cs)));
     }
 
     if (groupContacts.isNotEmpty) {
       tiles.add(_sectionLabel('From other rooms', cs));
-      for (final p in groupContacts) {
-        tiles.add(_profileTile(p, cs));
-      }
+      tiles.addAll(groupContacts.map((p) => _profileTile(p, cs)));
     }
 
     return tiles;

--- a/lib/features/rooms/widgets/invite_user_dialog_params.dart
+++ b/lib/features/rooms/widgets/invite_user_dialog_params.dart
@@ -1,0 +1,60 @@
+import 'package:kohera/core/utils/known_contacts.dart';
+import 'package:kohera/features/rooms/widgets/invite_user_dialog.dart';
+import 'package:kohera/shared/models/kohera_user_summary.dart';
+import 'package:matrix/matrix.dart';
+
+/// Builds SDK-free [InviteUserDialogParams] for a Matrix [room].
+///
+/// This is parent-side code: it performs the SDK calls (members, contacts,
+/// user-directory search) that the SDK-free [InviteUserDialog] delegates out.
+/// Callers which still hold a [Room] use this; widgets that are themselves
+/// SDK-free source their params from a controller instead.
+InviteUserDialogParams inviteUserDialogParams(Room room) {
+  final client = room.client;
+
+  Set<String> existingMemberIds() {
+    try {
+      return room.getParticipants().map((u) => u.id).toSet();
+    } catch (_) {
+      return const <String>{};
+    }
+  }
+
+  List<KoheraUserSummary> contacts() {
+    try {
+      return knownContacts(client).map(_toSummary).toList(growable: false);
+    } catch (_) {
+      return const <KoheraUserSummary>[];
+    }
+  }
+
+  final dmContacts = contacts();
+  final dmIds = dmContacts.map((c) => c.userId).toSet();
+
+  List<KoheraUserSummary> groupContacts() {
+    try {
+      return roomContacts(client, excludeMxids: dmIds)
+          .map(_toSummary)
+          .toList(growable: false);
+    } catch (_) {
+      return const <KoheraUserSummary>[];
+    }
+  }
+
+  return InviteUserDialogParams(
+    roomId: room.id,
+    existingMemberIds: existingMemberIds(),
+    knownContacts: dmContacts,
+    roomContacts: groupContacts(),
+    onSearchUserDirectory: (query) async {
+      final response = await client.searchUserDirectory(query, limit: 20);
+      return response.results.map(_toSummary).toList(growable: false);
+    },
+  );
+}
+
+KoheraUserSummary _toSummary(Profile p) => KoheraUserSummary(
+      userId: p.userId,
+      displayname: p.displayName ?? p.userId,
+      avatarUrl: p.avatarUrl?.toString(),
+    );

--- a/lib/features/rooms/widgets/room_context_menu.dart
+++ b/lib/features/rooms/widgets/room_context_menu.dart
@@ -105,8 +105,31 @@ Future<void> showRoomContextMenu(
     case _RoomContextAction.addToSpace:
       await AddRoomToSpaceDialog.show(
         context,
-        room: room,
-        matrixService: matrix,
+        roomId: room.id,
+        candidateSpaces: selection.spaces
+            .where((s) => s.canChangeStateEvent('m.space.child'))
+            .map(selection.summaryFor)
+            .toList(),
+        memberSpaceIds: memberships,
+        avatarResolver: matrix.avatarResolver,
+        onAddToSpaces: (selections) async {
+          var failures = 0;
+          for (final entry in selections.entries) {
+            final space = matrix.client.getRoomById(entry.key);
+            if (space == null) continue;
+            try {
+              await space.setSpaceChild(
+                room.id,
+                suggested: entry.value ? true : null,
+              );
+            } catch (e) {
+              debugPrint('[Kohera] Failed to add room to space: $e');
+              failures++;
+            }
+          }
+          selection.invalidateSpaceTree();
+          return failures;
+        },
       );
     case _RoomContextAction.removeFromSpace:
       if (activeSpace != null) {

--- a/lib/features/rooms/widgets/room_details_panel.dart
+++ b/lib/features/rooms/widgets/room_details_panel.dart
@@ -1,36 +1,34 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
+import 'package:kohera/core/models/kohera_push_rule_state.dart';
 import 'package:kohera/core/routing/nav_helper.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/utils/confirm_dialog.dart';
-import 'package:kohera/features/e2ee/widgets/key_verification_dialog.dart';
-import 'package:kohera/features/rooms/models/kohera_room_member.dart';
-import 'package:kohera/features/rooms/services/room_member_list_resolver.dart';
-import 'package:kohera/features/rooms/services/room_permissions_resolver.dart';
+import 'package:kohera/features/rooms/models/kohera_device_key.dart';
+import 'package:kohera/features/rooms/services/room_details_controller.dart';
 import 'package:kohera/features/rooms/widgets/admin_settings_section.dart';
 import 'package:kohera/features/rooms/widgets/invite_user_dialog.dart';
-import 'package:kohera/features/rooms/widgets/join_access_controller.dart';
-import 'package:kohera/features/rooms/widgets/member_sheet_launcher.dart';
 import 'package:kohera/features/rooms/widgets/room_members_section.dart';
-import 'package:kohera/features/rooms/widgets/shared_media_section.dart';
 import 'package:kohera/shared/widgets/avatar_edit_overlay.dart';
 import 'package:kohera/shared/widgets/detail_action_button.dart';
 import 'package:kohera/shared/widgets/joined_member_count.dart';
-import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
 /// Displays room details: header, actions, members, encryption,
 /// media gallery, notification settings, and admin controls.
+///
+/// SDK-free: all data and SDK actions are provided by [RoomDetailsController],
+/// the conversion boundary that owns the `Room`. The panel only depends on
+/// Kohera domain models and callbacks.
 ///
 /// When [isFullPage] is true, wraps itself in a Scaffold with an AppBar
 /// (for mobile/tablet push route). Otherwise renders as a bare panel
 /// (for the desktop side panel).
 class RoomDetailsPanel extends StatefulWidget {
   const RoomDetailsPanel({
-    required this.roomId, super.key,
+    required this.roomId,
+    super.key,
     this.isFullPage = false,
   });
 
@@ -42,15 +40,11 @@ class RoomDetailsPanel extends StatefulWidget {
 }
 
 class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
+  late RoomDetailsController _controller;
   final Set<String> _inFlight = {};
   String? _error;
-  StreamSubscription<SyncUpdate>? _syncSub;
-  Timer? _syncDebounce;
   bool _deviceKeysExpanded = false;
-  KoheraRoomMemberList? _memberList;
-  bool _loadingMembers = false;
-  int? _lastMemberCount;
-  int _memberLoadGen = 0;
+  bool _created = false;
 
   bool get _loading => _inFlight.isNotEmpty;
   bool _busy(String action) => _inFlight.contains(action);
@@ -58,92 +52,43 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
   // ── Lifecycle ───────────────────────────────────────────────
 
   @override
-  void initState() {
-    super.initState();
-    _refreshDeviceKeys();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      final room = context.read<MatrixService>().client.getRoomById(widget.roomId);
-      if (room != null) unawaited(_loadMembers(room));
-    });
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_created) {
+      _created = true;
+      _controller = RoomDetailsController(
+        roomId: widget.roomId,
+        matrix: context.read<MatrixService>(),
+        selection: context.read<SelectionService>(),
+      )..addListener(_onChanged);
+      _controller.init();
+    }
+  }
+
+  void _onChanged() {
+    if (mounted) setState(() {});
   }
 
   @override
   void didUpdateWidget(RoomDetailsPanel oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final room = context.read<MatrixService>().client.getRoomById(widget.roomId);
-    final count = room?.summary.mJoinedMemberCount;
-    if (count != null && count != _lastMemberCount && !_loadingMembers) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted && room != null) unawaited(_loadMembers(room));
-      });
-    }
+    _controller.checkRoomChanged();
   }
 
   @override
   void dispose() {
-    _syncDebounce?.cancel();
-    unawaited(_syncSub?.cancel());
+    _controller.removeListener(_onChanged);
+    _controller.dispose();
     super.dispose();
-  }
-
-  void _refreshDeviceKeys() {
-    final client = context.read<MatrixService>().client;
-    unawaited(client.updateUserDeviceKeys().then((_) {
-      if (mounted) setState(() {});
-    },),);
-    unawaited(_syncSub?.cancel());
-    _syncSub = client.onSync.stream.listen((update) {
-      // Detect power-level changes to reload members.
-      final stateEvents = update.rooms?.join?[widget.roomId]?.state ?? [];
-      final hasPowerLevelChanges =
-          stateEvents.any((e) => e.type == EventTypes.RoomPowerLevels);
-      _syncDebounce?.cancel();
-      _syncDebounce = Timer(const Duration(seconds: 2), () {
-        if (!mounted) return;
-        setState(() {});
-        if (hasPowerLevelChanges && _memberList != null) {
-          final room = client.getRoomById(widget.roomId);
-          if (room != null) unawaited(_loadMembers(room));
-        }
-      });
-    });
   }
 
   // ── Actions ────────────────────────────────────────────────
 
-  Future<void> _loadMembers(Room room) async {
-    final gen = ++_memberLoadGen;
-    setState(() {
-      _loadingMembers = true;
-    });
-    try {
-      final list = await const RoomMemberListResolver().resolve(room);
-      if (!mounted || gen != _memberLoadGen) return;
-      setState(() {
-        _memberList = list;
-        _loadingMembers = false;
-        _lastMemberCount = list.memberCount;
-      });
-    } catch (e) {
-      debugPrint('[Kohera] Failed to load members: $e');
-      if (mounted) {
-        setState(() {
-          _loadingMembers = false;
-        });
-      }
-    }
-  }
-
-  Future<void> _showMemberSheet(
-    BuildContext context,
-    Room room,
-    KoheraRoomMember member,
-  ) {
-    return showRoomMemberSheet(context, room: room, member: member);
-  }
-
   Future<void> _run(String action, Future<void> Function() task) async {
-    setState(() { _inFlight.add(action); _error = null; });
+    setState(() {
+      _inFlight.add(action);
+      _error = null;
+    });
     try {
       await task();
     } catch (e) {
@@ -154,74 +99,69 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
     }
   }
 
-  Future<void> _toggleMute(Room room) => _run('mute', () async {
-    final current = room.pushRuleState;
-    await room.setPushRuleState(
-      current == PushRuleState.notify
-          ? PushRuleState.dontNotify
-          : PushRuleState.notify,
-    );
-  });
-
-  Future<void> _toggleFavourite(Room room) => _run('favourite', () async {
-    final target = !room.isFavourite;
-    await room.setFavourite(target);
-    await room.client.onSync.stream
-        .firstWhere((_) => room.isFavourite == target)
-        .timeout(const Duration(seconds: 5), onTimeout: () => SyncUpdate(nextBatch: ''));
-  });
-
-  Future<void> _showInviteDialog(Room room) async {
-    final result = await InviteUserDialog.show(context, room: room);
+  Future<void> _showInviteDialog() async {
+    final result =
+        await InviteUserDialog.show(context, params: _controller.inviteDialogParams());
     if (result == null || !mounted) return;
 
     final scaffold = ScaffoldMessenger.of(context);
     await _run('invite', () async {
-      await room.invite(result);
+      await _controller.invite(result);
       scaffold.showSnackBar(
         SnackBar(content: Text('Invited $result')),
       );
     });
   }
 
-  Future<void> _confirmLeave(Room room) async {
+  Future<void> _confirmLeave() async {
     final confirmed = await confirmDialog(
       context,
       title: 'Leave room?',
-      message: 'You will leave "${room.getLocalizedDisplayname()}".',
+      message: 'You will leave "${_controller.summary?.displayname ?? widget.roomId}".',
       confirmLabel: 'Leave',
       destructive: true,
     );
 
     if (!confirmed || !mounted) return;
 
-    final selectionService = context.read<SelectionService>();
     final navigator = Navigator.of(context);
     await _run('leave', () async {
-      await room.leave();
-      selectionService.selectRoom(null);
+      await _controller.leave();
       if (mounted && widget.isFullPage) navigator.pop();
     });
   }
 
-  Future<void> _setPushRule(Room room, PushRuleState state) =>
-      _run('pushRule', () => room.setPushRuleState(state));
+  Future<void> _setPushRule(KoheraPushRuleState state) =>
+      _run('pushRule', () => _controller.setPushRule(state));
+
+  Future<void> _verifyDevice(KoheraDeviceKey dk) async {
+    final scaffold = ScaffoldMessenger.of(context);
+    try {
+      await _controller.verifyDevice(context, dk.deviceId);
+    } catch (e) {
+      debugPrint('[Kohera] Failed to start verification: $e');
+      if (mounted) {
+        scaffold.showSnackBar(
+          const SnackBar(content: Text('Failed to start verification')),
+        );
+      }
+    }
+  }
 
   // ── Build ──────────────────────────────────────────────────
 
   @override
   Widget build(BuildContext context) {
-    final matrix = context.watch<MatrixService>();
-    final room = matrix.client.getRoomById(widget.roomId);
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
 
-    if (room == null) {
+    if (!_controller.hasRoom) {
       final body = Center(child: Text('Room not found', style: tt.bodyLarge));
       return widget.isFullPage ? Scaffold(appBar: AppBar(), body: body) : body;
     }
 
-    final content = _buildContent(room, matrix, cs, tt);
+    final summary = _controller.summary!;
+    final content = _buildContent(cs, tt);
 
     if (widget.isFullPage) {
       return Scaffold(
@@ -233,7 +173,7 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
               pathParameters: {RouteParams.roomId: widget.roomId},
             ),
           ),
-          title: Text(room.getLocalizedDisplayname()),
+          title: Text(summary.displayname),
         ),
         body: content,
       );
@@ -245,51 +185,47 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
     );
   }
 
-  Widget _buildContent(Room room, MatrixService matrix, ColorScheme cs, TextTheme tt) {
-    // Initial member load is triggered in initState — no side effects in build.
+  Widget _buildContent(ColorScheme cs, TextTheme tt) {
+    final permissions = _controller.permissions;
     return ListView(
       padding: const EdgeInsets.only(bottom: 32),
       children: [
         if (_loading) const LinearProgressIndicator(),
-        _buildHeader(room, cs, tt),
+        _buildHeader(cs, tt),
         const Divider(),
-        _buildActionsRow(room, cs, tt),
+        _buildActionsRow(cs, tt),
         if (_error != null)
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
             child: Text(_error!, style: TextStyle(color: cs.error, fontSize: 13)),
           ),
         const Divider(),
-        JoinAccessController(room: room),
+        _controller.buildJoinAccessSection(),
         const Divider(),
-        if (_memberList != null)
+        if (_controller.memberList != null)
           RoomMembersSection(
-            members: _memberList!,
-            onMemberTap: (member) =>
-                _showMemberSheet(context, room, member),
-            avatarResolver: matrix.avatarResolver,
-            presence: matrix.presence,
+            members: _controller.memberList!,
+            onMemberTap: (member) => _controller.showMemberSheet(context, member),
+            avatarResolver: _controller.avatarResolver,
+            presence: _controller.presence,
           ),
         const Divider(),
-        _buildEncryptionSection(room, cs, tt),
+        _buildEncryptionSection(cs, tt),
         const Divider(),
-        SharedMediaSection(room: room),
+        _controller.buildSharedMediaSection(),
         const Divider(),
-        _buildNotificationSection(room, cs, tt),
-        if (room.canChangeStateEvent(EventTypes.RoomName) ||
-            room.canChangeStateEvent(EventTypes.RoomTopic) ||
-            room.canChangeStateEvent(EventTypes.Encryption) ||
-            room.canChangePowerLevel) ...[
+        _buildNotificationSection(cs, tt),
+        if (permissions != null &&
+            (permissions.canEditName ||
+                permissions.canEditTopic ||
+                permissions.canEnableEncryption ||
+                permissions.canChangePowerLevels)) ...[
           const Divider(),
           AdminSettingsSection(
-            permissions:
-                const RoomPermissionsResolver().convert(
-              room,
-              myUserId: matrix.client.userID ?? '',
-            ),
-            onSaveName: room.setName,
-            onSaveTopic: room.setDescription,
-            onEnableEncryption: room.enableEncryption,
+            permissions: permissions,
+            onSaveName: _controller.setName,
+            onSaveTopic: _controller.setDescription,
+            onEnableEncryption: _controller.enableEncryption,
           ),
         ],
       ],
@@ -298,22 +234,29 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
 
   // ── Header ─────────────────────────────────────────────────
 
-  Widget _buildHeader(Room room, ColorScheme cs, TextTheme tt) {
+  Widget _buildHeader(ColorScheme cs, TextTheme tt) {
+    final summary = _controller.summary!;
     return Padding(
       padding: const EdgeInsets.all(20),
       child: Column(
         children: [
-          AvatarEditOverlay(room: room),
+          AvatarEditOverlay(
+            roomId: _controller.roomId,
+            summary: summary,
+            canEditAvatar: _controller.permissions?.canEditAvatar ?? false,
+            avatarResolver: _controller.avatarResolver,
+            onSetAvatar: _controller.setAvatar,
+          ),
           const SizedBox(height: 12),
           Text(
-            room.getLocalizedDisplayname(),
+            summary.displayname,
             style: tt.titleLarge,
             textAlign: TextAlign.center,
           ),
-          if (room.topic.isNotEmpty) ...[
+          if (summary.topic != null && summary.topic!.isNotEmpty) ...[
             const SizedBox(height: 6),
             Text(
-              room.topic,
+              summary.topic!,
               style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
               textAlign: TextAlign.center,
               maxLines: 4,
@@ -322,15 +265,10 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
           ],
           const SizedBox(height: 4),
           JoinedMemberCount(
-            roomId: room.id,
-            summaryMemberCount: room.summary.mJoinedMemberCount ?? 0,
-            participantListComplete: room.participantListComplete,
-            resolveMemberCount: (id) async {
-              final r = room.client.getRoomById(id);
-              if (r == null) return null;
-              final members = await r.client.getJoinedMembersByRoom(id);
-              return members?.length;
-            },
+            roomId: _controller.roomId,
+            summaryMemberCount: _controller.summaryMemberCount ?? 0,
+            participantListComplete: _controller.participantListComplete,
+            resolveMemberCount: _controller.resolveMemberCount,
             builder: (context, memberCount) => Text(
               memberCount == 1 ? '1 member' : '$memberCount members',
               style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
@@ -343,8 +281,8 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
 
   // ── Actions row ────────────────────────────────────────────
 
-  Widget _buildActionsRow(Room room, ColorScheme cs, TextTheme tt) {
-    final isMuted = room.pushRuleState != PushRuleState.notify;
+  Widget _buildActionsRow(ColorScheme cs, TextTheme tt) {
+    final isMuted = _controller.isMuted;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
       child: Row(
@@ -353,23 +291,23 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
           DetailActionButton(
             icon: isMuted ? Icons.notifications_off_outlined : Icons.notifications_outlined,
             label: isMuted ? 'Unmute' : 'Mute',
-            onTap: _busy('mute') ? null : () => _toggleMute(room),
+            onTap: _busy('mute') ? null : () => _run('mute', _controller.toggleMute),
           ),
           DetailActionButton(
-            icon: room.isFavourite ? Icons.star_rounded : Icons.star_border_rounded,
-            label: room.isFavourite ? 'Starred' : 'Star',
-            onTap: _busy('favourite') ? null : () => _toggleFavourite(room),
+            icon: _controller.isFavourite ? Icons.star_rounded : Icons.star_border_rounded,
+            label: _controller.isFavourite ? 'Starred' : 'Star',
+            onTap: _busy('favourite') ? null : () => _run('favourite', _controller.toggleFavourite),
           ),
           DetailActionButton(
             icon: Icons.person_add_outlined,
             label: 'Invite',
-            onTap: _busy('invite') ? null : () => _showInviteDialog(room),
+            onTap: _busy('invite') ? null : _showInviteDialog,
           ),
           DetailActionButton(
             icon: Icons.exit_to_app_rounded,
             label: 'Leave',
             color: cs.error,
-            onTap: _busy('leave') ? null : () => _confirmLeave(room),
+            onTap: _busy('leave') ? null : _confirmLeave,
           ),
         ],
       ),
@@ -378,8 +316,8 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
 
   // ── Encryption section ─────────────────────────────────────
 
-  Widget _buildEncryptionSection(Room room, ColorScheme cs, TextTheme tt) {
-    final encrypted = room.encrypted;
+  Widget _buildEncryptionSection(ColorScheme cs, TextTheme tt) {
+    final encrypted = _controller.encrypted;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -396,20 +334,16 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
             style: tt.bodySmall,
           ),
         ),
-        if (encrypted && room.isDirectChat)
-          _buildDeviceVerificationSection(room, cs, tt),
+        if (encrypted && _controller.isDirectChat)
+          _buildDeviceVerificationSection(cs, tt),
       ],
     );
   }
 
-  Widget _buildDeviceVerificationSection(Room room, ColorScheme cs, TextTheme tt) {
-    final client = context.read<MatrixService>().client;
-    final partnerId = room.directChatMatrixID;
-    if (partnerId == null) return const SizedBox.shrink();
+  Widget _buildDeviceVerificationSection(ColorScheme cs, TextTheme tt) {
+    if (_controller.partnerId == null) return const SizedBox.shrink();
 
-    final deviceKeysList = client.userDeviceKeys[partnerId];
-    final devices = deviceKeysList?.deviceKeys.values.toList() ?? [];
-
+    final devices = _controller.deviceKeys;
     if (devices.isEmpty) {
       return Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -439,9 +373,7 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
             style: tt.bodyMedium,
           ),
           trailing: Icon(
-            _deviceKeysExpanded
-                ? Icons.expand_less
-                : Icons.expand_more,
+            _deviceKeysExpanded ? Icons.expand_less : Icons.expand_more,
           ),
           onTap: () => setState(() => _deviceKeysExpanded = !_deviceKeysExpanded),
         ),
@@ -451,7 +383,7 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
     );
   }
 
-  Widget _buildDeviceKeyTile(DeviceKeys dk, ColorScheme cs, TextTheme tt) {
+  Widget _buildDeviceKeyTile(KoheraDeviceKey dk, ColorScheme cs, TextTheme tt) {
     final (IconData icon, String label, Color color) = dk.blocked
         ? (Icons.block, 'Blocked', cs.error)
         : dk.verified
@@ -463,7 +395,7 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
       contentPadding: const EdgeInsets.only(left: 56, right: 16),
       leading: Icon(Icons.devices, size: 18, color: cs.onSurfaceVariant),
       title: Text(
-        dk.deviceDisplayName ?? dk.deviceId ?? 'Unknown device',
+        dk.displayName ?? dk.deviceId ?? 'Unknown device',
         style: tt.bodySmall,
         overflow: TextOverflow.ellipsis,
       ),
@@ -477,34 +409,16 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
       ),
       trailing: !dk.verified && !dk.blocked
           ? TextButton(
-              onPressed: () => _verifyPartnerDevice(dk),
+              onPressed: () => _verifyDevice(dk),
               child: const Text('Verify'),
             )
           : null,
     );
   }
 
-  Future<void> _verifyPartnerDevice(DeviceKeys dk) async {
-    final client = context.read<MatrixService>().client;
-    final scaffold = ScaffoldMessenger.of(context);
-    try {
-      final verification = await dk.startVerification();
-      if (!mounted) return;
-      await KeyVerificationDialog.show(context, verification: verification);
-      // Refresh device keys after verification completes
-      await client.updateUserDeviceKeys();
-      if (mounted) setState(() {});
-    } catch (e) {
-      debugPrint('[Kohera] Failed to start verification: $e');
-      scaffold.showSnackBar(
-        const SnackBar(content: Text('Failed to start verification')),
-      );
-    }
-  }
-
   // ── Notification settings ──────────────────────────────────
 
-  Widget _buildNotificationSection(Room room, ColorScheme cs, TextTheme tt) {
+  Widget _buildNotificationSection(ColorScheme cs, TextTheme tt) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -518,22 +432,22 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
             ),
           ),
         ),
-        RadioGroup<PushRuleState>(
-          groupValue: room.pushRuleState,
-          onChanged: _busy('pushRule') ? (_) {} : (v) => _setPushRule(room, v!),
+        RadioGroup<KoheraPushRuleState>(
+          groupValue: _controller.pushRuleState,
+          onChanged: _busy('pushRule') ? (_) {} : (v) => _setPushRule(v!),
           child: const Column(
             children: [
-              RadioListTile<PushRuleState>(
+              RadioListTile<KoheraPushRuleState>(
                 title: Text('All messages'),
-                value: PushRuleState.notify,
+                value: KoheraPushRuleState.notify,
               ),
-              RadioListTile<PushRuleState>(
+              RadioListTile<KoheraPushRuleState>(
                 title: Text('Mentions only'),
-                value: PushRuleState.mentionsOnly,
+                value: KoheraPushRuleState.mentionsOnly,
               ),
-              RadioListTile<PushRuleState>(
+              RadioListTile<KoheraPushRuleState>(
                 title: Text('Muted'),
-                value: PushRuleState.dontNotify,
+                value: KoheraPushRuleState.dontNotify,
               ),
             ],
           ),

--- a/lib/features/rooms/widgets/room_details_panel.dart
+++ b/lib/features/rooms/widgets/room_details_panel.dart
@@ -160,7 +160,6 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
       return widget.isFullPage ? Scaffold(appBar: AppBar(), body: body) : body;
     }
 
-    final summary = _controller.summary!;
     final content = _buildContent(cs, tt);
 
     if (widget.isFullPage) {
@@ -173,7 +172,7 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
               pathParameters: {RouteParams.roomId: widget.roomId},
             ),
           ),
-          title: Text(summary.displayname),
+          title: Text(_controller.summary!.displayname),
         ),
         body: content,
       );
@@ -193,7 +192,7 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
         if (_loading) const LinearProgressIndicator(),
         _buildHeader(cs, tt),
         const Divider(),
-        _buildActionsRow(cs, tt),
+        _buildActionsRow(cs),
         if (_error != null)
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -281,7 +280,7 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
 
   // ── Actions row ────────────────────────────────────────────
 
-  Widget _buildActionsRow(ColorScheme cs, TextTheme tt) {
+  Widget _buildActionsRow(ColorScheme cs) {
     final isMuted = _controller.isMuted;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
@@ -384,11 +383,22 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
   }
 
   Widget _buildDeviceKeyTile(KoheraDeviceKey dk, ColorScheme cs, TextTheme tt) {
-    final (IconData icon, String label, Color color) = dk.blocked
-        ? (Icons.block, 'Blocked', cs.error)
-        : dk.verified
-            ? (Icons.verified, 'Verified', cs.primary)
-            : (Icons.shield_outlined, 'Unverified', cs.onSurfaceVariant);
+    final IconData icon;
+    final String label;
+    final Color color;
+    if (dk.blocked) {
+      icon = Icons.block;
+      label = 'Blocked';
+      color = cs.error;
+    } else if (dk.verified) {
+      icon = Icons.verified;
+      label = 'Verified';
+      color = cs.primary;
+    } else {
+      icon = Icons.shield_outlined;
+      label = 'Unverified';
+      color = cs.onSurfaceVariant;
+    }
 
     return ListTile(
       dense: true,

--- a/lib/features/rooms/widgets/room_section_header.dart
+++ b/lib/features/rooms/widgets/room_section_header.dart
@@ -7,6 +7,7 @@ import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/rooms/widgets/new_room_dialog.dart';
 import 'package:kohera/features/rooms/widgets/room_list_models.dart';
+import 'package:kohera/features/spaces/widgets/create_subspace_action.dart';
 import 'package:kohera/features/spaces/widgets/create_subspace_dialog.dart';
 import 'package:kohera/features/spaces/widgets/space_reparent_controller.dart';
 import 'package:provider/provider.dart';
@@ -224,8 +225,13 @@ class RoomSectionHeader extends StatelessWidget {
           if (spaceRoom != null) {
             unawaited(CreateSubspaceDialog.show(
               context,
-              matrixService: matrixService,
-              parentSpace: spaceRoom,
+              parentSpaceRef: (
+                id: spaceRoom.id,
+                displayname: spaceRoom.getLocalizedDisplayname(),
+              ),
+              loadCapabilities: () => loadSubspaceCapabilities(matrixService),
+              onCreateSubspace: (request) =>
+                  createSubspace(matrixService, spaceRoom, request),
             ),);
           }
       }

--- a/lib/features/spaces/widgets/create_subspace_action.dart
+++ b/lib/features/spaces/widgets/create_subspace_action.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:kohera/core/models/join_mode.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/features/spaces/widgets/create_subspace_dialog.dart';
+import 'package:matrix/matrix.dart';
+
+/// Loads restricted/knock join-rule capabilities for the subspace dialog.
+///
+/// Parent-side code: calls `SpaceAccessService` to determine whether the
+/// server supports restricted join rules and which room version to use.
+Future<SubspaceCapabilities> loadSubspaceCapabilities(
+  MatrixService matrix,
+) async {
+  final access = matrix.spaceAccess;
+  final knockVersion =
+      await access.pickRestrictedRoomVersion(wantKnock: true);
+  final basicVersion =
+      await access.pickRestrictedRoomVersion(wantKnock: false);
+  return SubspaceCapabilities(
+    restrictedRoomVersion: knockVersion ?? basicVersion,
+    disabledModes: knockVersion == null
+        ? const {JoinMode.knockRestricted: 'Not supported by this server'}
+        : const <JoinMode, String>{},
+  );
+}
+
+/// Creates a subspace room and registers it as a child of [parentSpace].
+///
+/// Parent-side code: performs the SDK `createRoom` (with optional restricted
+/// join-rules initial state), waits for sync, and calls `setSpaceChild`.
+/// Throws on failure (the dialog catches and displays the error).
+Future<void> createSubspace(
+  MatrixService matrix,
+  Room parentSpace,
+  CreateSubspaceRequest request,
+) async {
+  final client = matrix.client;
+
+  final useRestricted = request.restrictedRoomVersion != null &&
+      request.joinMode.isRestrictedFamily &&
+      request.allowedSpaceIds.isNotEmpty;
+  final joinRulesEvent = useRestricted
+      ? matrix.spaceAccess.buildJoinRulesStateEvent(
+          request.joinMode,
+          request.allowedSpaceIds,
+        )
+      : null;
+
+  final roomId = await client.createRoom(
+    name: request.name,
+    topic: request.topic,
+    creationContent: {'type': 'm.space'},
+    visibility: Visibility.private,
+    roomVersion: useRestricted ? request.restrictedRoomVersion : null,
+    initialState: [
+      if (joinRulesEvent != null) joinRulesEvent,
+    ],
+    powerLevelContentOverride: {'events_default': 100},
+  );
+
+  await client
+      .waitForRoomInSync(roomId, join: true)
+      .timeout(const Duration(seconds: 30));
+
+  await parentSpace.setSpaceChild(roomId);
+  matrix.selection.invalidateSpaceTree();
+
+  debugPrint('[Kohera] Subspace created: $roomId under ${parentSpace.id}');
+}

--- a/lib/features/spaces/widgets/create_subspace_dialog.dart
+++ b/lib/features/spaces/widgets/create_subspace_dialog.dart
@@ -5,31 +5,78 @@ import 'package:kohera/core/models/join_mode.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/shared/widgets/join_access_section.dart';
 import 'package:kohera/shared/widgets/loading_button_child.dart';
-import 'package:matrix/matrix.dart';
+
+/// SDK-free request describing the subspace the user wants to create. The
+/// dialog collects these fields and hands them to [CreateSubspaceDialog.onCreateSubspace],
+/// whose implementation (parent-side) performs the SDK calls.
+class CreateSubspaceRequest {
+  const CreateSubspaceRequest({
+    required this.name,
+    required this.topic,
+    required this.joinMode,
+    required this.allowedSpaceIds,
+    required this.restrictedRoomVersion,
+  });
+
+  final String name;
+  final String? topic;
+  final JoinMode joinMode;
+  final List<String> allowedSpaceIds;
+  final String? restrictedRoomVersion;
+}
+
+/// Server capability info for restricted/knock join rules, computed
+/// parent-side (via `SpaceAccessService`) and passed to the dialog.
+class SubspaceCapabilities {
+  const SubspaceCapabilities({
+    required this.restrictedRoomVersion,
+    required this.disabledModes,
+  });
+
+  /// The room version to use for restricted join rules, or `null` if the
+  /// server does not support them.
+  final String? restrictedRoomVersion;
+
+  /// Join modes to disable in the picker, mapped to a tooltip reason.
+  final Map<JoinMode, String> disabledModes;
+}
 
 /// Dialog to create a new subspace within a parent space.
 ///
-/// Creates a new space room and registers it as a child of [parentSpace]
-/// via `setSpaceChild`.
+/// SDK-free: display data comes from [parentSpaceRef], server capability
+/// info is loaded via [loadCapabilities], and the actual room creation is
+/// delegated to [onCreateSubspace]. The parent retains `Room`/`Client` access
+/// and performs the SDK calls.
 class CreateSubspaceDialog extends StatefulWidget {
   const CreateSubspaceDialog._({
-    required this.matrixService,
-    required this.parentSpace,
+    required this.parentSpaceRef,
+    required this.loadCapabilities,
+    required this.onCreateSubspace,
   });
 
-  final MatrixService matrixService;
-  final Room parentSpace;
+  /// Reference (id + displayname) to the parent space.
+  final SpaceRef parentSpaceRef;
+
+  /// Loads restricted-join server capabilities.
+  final Future<SubspaceCapabilities> Function() loadCapabilities;
+
+  /// Creates the subspace described by the request. Throws on failure
+  /// (the dialog catches and displays errors).
+  final Future<void> Function(CreateSubspaceRequest request) onCreateSubspace;
 
   static Future<void> show(
     BuildContext context, {
-    required MatrixService matrixService,
-    required Room parentSpace,
+    required SpaceRef parentSpaceRef,
+    required Future<SubspaceCapabilities> Function() loadCapabilities,
+    required Future<void> Function(CreateSubspaceRequest request)
+        onCreateSubspace,
   }) {
     return showDialog(
       context: context,
       builder: (_) => CreateSubspaceDialog._(
-        matrixService: matrixService,
-        parentSpace: parentSpace,
+        parentSpaceRef: parentSpaceRef,
+        loadCapabilities: loadCapabilities,
+        onCreateSubspace: onCreateSubspace,
       ),
     );
   }
@@ -46,7 +93,7 @@ class _CreateSubspaceDialogState extends State<CreateSubspaceDialog> {
   String? _networkError;
 
   JoinMode _joinMode = JoinMode.invite;
-  List<Room> _allowedJoinSpaces = const [];
+  List<SpaceRef> _allowedJoinSpaces = const [];
   Map<JoinMode, String> _disabledModes = const {};
   String? _restrictedRoomVersion;
   bool _restrictedAvailable = false;
@@ -57,39 +104,32 @@ class _CreateSubspaceDialogState extends State<CreateSubspaceDialog> {
     unawaited(_loadRestrictedCapabilities());
   }
 
-  Future<void> _loadRestrictedCapabilities() async {
-    final access = widget.matrixService.spaceAccess;
-    final knockVersion =
-        await access.pickRestrictedRoomVersion(wantKnock: true);
-    final basicVersion =
-        await access.pickRestrictedRoomVersion(wantKnock: false);
-    if (!mounted) return;
-    setState(() {
-      _restrictedRoomVersion = knockVersion ?? basicVersion;
-      _restrictedAvailable = _restrictedRoomVersion != null;
-      _disabledModes = knockVersion == null
-          ? const {
-              JoinMode.knockRestricted: 'Not supported by this server',
-            }
-          : const <JoinMode, String>{};
-      if (_restrictedAvailable && _allowedJoinSpaces.isEmpty) {
-        _joinMode = JoinMode.restricted;
-        _allowedJoinSpaces = [widget.parentSpace];
-      }
-    });
-    if (!_restrictedAvailable) {
-      final versions = await access.serverSupportedRoomVersions();
-      debugPrint(
-        '[Kohera] Restricted join unavailable: server room versions=$versions',
-      );
-    }
-  }
-
   @override
   void dispose() {
     _nameController.dispose();
     _topicController.dispose();
     super.dispose();
+  }
+
+  Future<void> _loadRestrictedCapabilities() async {
+    final caps = await widget.loadCapabilities();
+    if (!mounted) return;
+    setState(() {
+      _restrictedRoomVersion = caps.restrictedRoomVersion;
+      _restrictedAvailable = caps.restrictedRoomVersion != null;
+      _disabledModes = caps.disabledModes;
+      if (_restrictedAvailable && _allowedJoinSpaces.isEmpty) {
+        _joinMode = JoinMode.restricted;
+        _allowedJoinSpaces = [widget.parentSpaceRef];
+      }
+    });
+  }
+
+  List<SpaceRef> _refsForIds(List<String> ids) {
+    final candidateById = {widget.parentSpaceRef.id: widget.parentSpaceRef};
+    return ids
+        .map((id) => candidateById[id] ?? (id: id, displayname: id))
+        .toList();
   }
 
   Future<void> _submit() async {
@@ -109,49 +149,26 @@ class _CreateSubspaceDialogState extends State<CreateSubspaceDialog> {
     });
 
     try {
-      final client = widget.matrixService.client;
       final topic = _topicController.text.trim();
-
-      final useRestricted = _restrictedAvailable &&
-          _joinMode.isRestrictedFamily &&
-          _allowedJoinSpaces.isNotEmpty;
-      final joinRulesEvent = useRestricted
-          ? widget.matrixService.spaceAccess.buildJoinRulesStateEvent(
-              _joinMode,
+      await widget.onCreateSubspace(
+        CreateSubspaceRequest(
+          name: name,
+          topic: topic.isNotEmpty ? topic : null,
+          joinMode: _joinMode,
+          allowedSpaceIds:
               _allowedJoinSpaces.map((s) => s.id).toList(growable: false),
-            )
-          : null;
-
-      // Create the subspace room.
-      final roomId = await client.createRoom(
-        name: name,
-        topic: topic.isNotEmpty ? topic : null,
-        creationContent: {'type': 'm.space'},
-        visibility: Visibility.private,
-        roomVersion: useRestricted ? _restrictedRoomVersion : null,
-        initialState: [
-          if (joinRulesEvent != null) joinRulesEvent,
-        ],
-        powerLevelContentOverride: {'events_default': 100},
+          restrictedRoomVersion: _restrictedRoomVersion,
+        ),
       );
-
-      await client
-          .waitForRoomInSync(roomId, join: true)
-          .timeout(const Duration(seconds: 30));
-
-      // Register as child of the parent space.
-      await widget.parentSpace.setSpaceChild(roomId);
-      widget.matrixService.selection.invalidateSpaceTree();
-
-      debugPrint('[Kohera] Subspace created: $roomId under ${widget.parentSpace.id}');
-
       if (!mounted) return;
       Navigator.pop(context);
     } on TimeoutException {
       debugPrint('[Kohera] Subspace creation timed out');
       if (!mounted) return;
-      setState(() => _networkError =
-          'Timed out waiting for the server. The subspace may still be created.',);
+      setState(
+        () => _networkError =
+            'Timed out waiting for the server. The subspace may still be created.',
+      );
     } catch (e) {
       debugPrint('[Kohera] Subspace creation failed: $e');
       if (!mounted) return;
@@ -174,7 +191,7 @@ class _CreateSubspaceDialogState extends State<CreateSubspaceDialog> {
           children: [
             Text(
               'This subspace will be created inside '
-              '"${widget.parentSpace.getLocalizedDisplayname()}".',
+              '"${widget.parentSpaceRef.displayname}".',
               style: TextStyle(color: cs.onSurfaceVariant, fontSize: 13),
             ),
             const SizedBox(height: 16),
@@ -200,17 +217,17 @@ class _CreateSubspaceDialogState extends State<CreateSubspaceDialog> {
             ),
             if (_restrictedAvailable) ...[
               const SizedBox(height: 8),
-              JoinAccessSection(
+              JoinAccessSection.refs(
                 mode: _joinMode,
                 allowedSpaces: _allowedJoinSpaces,
-                candidateSpaces: [widget.parentSpace],
+                candidateSpaces: [widget.parentSpaceRef],
                 needsUpgrade: false,
                 canEdit: !_loading,
                 disabledModes: _disabledModes,
                 padding: const EdgeInsets.symmetric(vertical: 12),
                 onModeChanged: (m) => setState(() => _joinMode = m),
-                onAllowedSpacesChanged: (l) =>
-                    setState(() => _allowedJoinSpaces = l),
+                onAllowedSpacesChanged: (ids) =>
+                    setState(() => _allowedJoinSpaces = _refsForIds(ids)),
               ),
             ],
             if (_networkError != null)

--- a/lib/features/spaces/widgets/space_context_menu.dart
+++ b/lib/features/spaces/widgets/space_context_menu.dart
@@ -8,7 +8,9 @@ import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/rooms/widgets/add_existing_rooms_dialog.dart';
 import 'package:kohera/features/rooms/widgets/invite_user_dialog.dart';
+import 'package:kohera/features/rooms/widgets/invite_user_dialog_params.dart';
 import 'package:kohera/features/rooms/widgets/new_room_dialog.dart';
+import 'package:kohera/features/spaces/widgets/create_subspace_action.dart';
 import 'package:kohera/features/spaces/widgets/create_subspace_dialog.dart';
 import 'package:kohera/features/spaces/widgets/notification_radio_group.dart';
 import 'package:kohera/features/spaces/widgets/space_details_panel.dart' show SpaceDetailsPanel;
@@ -103,8 +105,26 @@ Future<void> showSpaceContextMenu(
         final matrix = context.read<MatrixService>();
         await AddExistingRoomsDialog.show(
           context,
-          space: space,
-          matrixService: matrix,
+          candidateRooms: matrix.client.rooms
+              .where((r) => r.membership == Membership.join)
+              .map(matrix.selection.summaryFor)
+              .toList(),
+          existingChildIds:
+              space.spaceChildren.map((c) => c.roomId).whereType<String>().toSet(),
+          avatarResolver: matrix.avatarResolver,
+          onAddRooms: (roomIds) async {
+            var failures = 0;
+            for (final id in roomIds) {
+              try {
+                await space.setSpaceChild(id);
+              } catch (e) {
+                debugPrint('[Kohera] Failed to add room to space: $e');
+                failures++;
+              }
+            }
+            matrix.selection.invalidateSpaceTree();
+            return failures;
+          },
         );
       }
     case SpaceContextAction.createRoom:
@@ -128,8 +148,12 @@ Future<void> showSpaceContextMenu(
         final matrix = context.read<MatrixService>();
         await CreateSubspaceDialog.show(
           context,
-          matrixService: matrix,
-          parentSpace: space,
+          parentSpaceRef: (
+            id: space.id,
+            displayname: space.getLocalizedDisplayname(),
+          ),
+          loadCapabilities: () => loadSubspaceCapabilities(matrix),
+          onCreateSubspace: (request) => createSubspace(matrix, space, request),
         );
       }
     case SpaceContextAction.notifications:
@@ -218,7 +242,8 @@ Future<void> _handleMarkAsRead(Room space) async {
 }
 
 Future<void> _handleInvite(BuildContext context, Room space) async {
-  final mxid = await InviteUserDialog.show(context, room: space);
+  final mxid =
+      await InviteUserDialog.show(context, params: inviteUserDialogParams(space));
 
   if (mxid == null || !context.mounted) return;
 

--- a/lib/features/spaces/widgets/space_details_panel.dart
+++ b/lib/features/spaces/widgets/space_details_panel.dart
@@ -10,6 +10,7 @@ import 'package:kohera/features/rooms/services/room_member_list_resolver.dart';
 import 'package:kohera/features/rooms/services/room_permissions_resolver.dart';
 import 'package:kohera/features/rooms/widgets/admin_settings_section.dart';
 import 'package:kohera/features/rooms/widgets/invite_user_dialog.dart';
+import 'package:kohera/features/rooms/widgets/invite_user_dialog_params.dart';
 import 'package:kohera/features/rooms/widgets/join_access_controller.dart';
 import 'package:kohera/features/rooms/widgets/member_sheet_launcher.dart';
 import 'package:kohera/features/rooms/widgets/room_members_section.dart';
@@ -145,7 +146,8 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
   }
 
   Future<void> _showInviteDialog(Room space) async {
-    final result = await InviteUserDialog.show(context, room: space);
+    final result =
+        await InviteUserDialog.show(context, params: inviteUserDialogParams(space));
     if (result == null || !mounted) return;
 
     await _run('invite', () async {
@@ -276,11 +278,22 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
   // ── Header ─────────────────────────────────────────────────
 
   Widget _buildHeader(Room space, ColorScheme cs, TextTheme tt) {
+    final matrix = context.read<MatrixService>();
     return Padding(
       padding: const EdgeInsets.all(20),
       child: Column(
         children: [
-          AvatarEditOverlay(room: space),
+          AvatarEditOverlay(
+            roomId: space.id,
+            summary: matrix.selection.summaryFor(space),
+            canEditAvatar: space.canChangeStateEvent(EventTypes.RoomAvatar),
+            avatarResolver: matrix.avatarResolver,
+            onSetAvatar: (bytes, filename) async {
+              await space.setAvatar(
+                bytes == null ? null : MatrixFile(bytes: bytes, name: filename ?? ''),
+              );
+            },
+          ),
           const SizedBox(height: 12),
           Text(
             space.getLocalizedDisplayname(),

--- a/lib/features/spaces/widgets/space_rail.dart
+++ b/lib/features/spaces/widgets/space_rail.dart
@@ -251,7 +251,12 @@ class _SpaceRailState extends State<SpaceRail> {
                                 onTap: () async {
                                   final result = await InviteDialog.show(
                                     context,
-                                    room: space,
+                                    roomId: space.id,
+                                    summary: selection.summaryFor(space),
+                                    inviterName:
+                                        selection.inviterDisplayName(space),
+                                    onAccept: space.join,
+                                    onDecline: space.leave,
                                   );
                                   if (result == true && mounted) {
                                     selection.selectSpace(space.id);

--- a/lib/shared/widgets/avatar_edit_overlay.dart
+++ b/lib/shared/widgets/avatar_edit_overlay.dart
@@ -1,21 +1,38 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:kohera/core/services/client_avatar_resolver.dart';
+import 'package:kohera/features/rooms/models/kohera_room_summary.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
-import 'package:matrix/matrix.dart';
 
 /// Wraps a [RoomAvatarWidget] with avatar editing controls.
 ///
-/// Tapping the avatar opens the image picker to upload a new photo.
-/// A small "x" badge at the top-right removes the current avatar.
-/// Only shows controls if the user has permission to change the avatar.
+/// SDK-free: display data comes from [summary] and [canEditAvatar]; avatar
+/// mutations are delegated to [onSetAvatar] (the parent performs the SDK
+/// `room.setAvatar` call). Tapping the avatar opens the image picker to
+/// upload a new photo; a small "x" badge at the top-right removes the current
+/// avatar. Only shows controls if [canEditAvatar] is true.
 class AvatarEditOverlay extends StatefulWidget {
   const AvatarEditOverlay({
-    required this.room, super.key,
+    required this.roomId,
+    required this.summary,
+    required this.canEditAvatar,
+    required this.avatarResolver,
+    required this.onSetAvatar,
     this.size = 72,
+    super.key,
   });
 
-  final Room room;
+  final String roomId;
+  final KoheraRoomSummary summary;
+  final bool canEditAvatar;
+  final AvatarResolver? avatarResolver;
+
+  /// Sets the room avatar. Pass bytes + filename to upload, or `null`/`null` to
+  /// remove the avatar. The parent performs the SDK `room.setAvatar` call.
+  final Future<void> Function(Uint8List? bytes, String? filename) onSetAvatar;
+
   final double size;
 
   @override
@@ -25,15 +42,13 @@ class AvatarEditOverlay extends StatefulWidget {
 class _AvatarEditOverlayState extends State<AvatarEditOverlay> {
   bool _busy = false;
 
-  bool get _canEdit => widget.room.canChangeStateEvent(EventTypes.RoomAvatar);
-
   @override
   Widget build(BuildContext context) {
-    if (!_canEdit) {
+    if (!widget.canEditAvatar) {
       return RoomAvatarWidget(
-        avatarUrl: widget.room.avatar?.toString(),
-        displayname: widget.room.getLocalizedDisplayname(),
-        avatarResolver: ClientAvatarResolver(widget.room.client),
+        avatarUrl: widget.summary.avatarUrl,
+        displayname: widget.summary.displayname,
+        avatarResolver: widget.avatarResolver,
         size: widget.size,
       );
     }
@@ -54,19 +69,20 @@ class _AvatarEditOverlayState extends State<AvatarEditOverlay> {
             child: GestureDetector(
               onTap: _busy ? null : _uploadAvatar,
               child: RoomAvatarWidget(
-                avatarUrl: widget.room.avatar?.toString(),
-                displayname: widget.room.getLocalizedDisplayname(),
-                avatarResolver: ClientAvatarResolver(widget.room.client),
+                avatarUrl: widget.summary.avatarUrl,
+                displayname: widget.summary.displayname,
+                avatarResolver: widget.avatarResolver,
                 size: widget.size,
               ),
             ),
           ),
-          if (widget.room.avatar != null)
+          if (widget.summary.avatarUrl != null)
             Positioned(
               top: -badgeOffset,
               right: -badgeOffset,
               child: MouseRegion(
-                cursor: _busy ? SystemMouseCursors.basic : SystemMouseCursors.click,
+                cursor:
+                    _busy ? SystemMouseCursors.basic : SystemMouseCursors.click,
                 child: GestureDetector(
                   onTap: _busy ? null : _removeAvatar,
                   child: Container(
@@ -104,7 +120,7 @@ class _AvatarEditOverlayState extends State<AvatarEditOverlay> {
       if (picked == null) return;
 
       final bytes = await picked.readAsBytes();
-      await widget.room.setAvatar(MatrixFile(bytes: bytes, name: picked.name));
+      await widget.onSetAvatar(bytes, picked.name);
       debugPrint('[Kohera] Room avatar uploaded: ${picked.name} (${bytes.length} bytes)');
       if (mounted) {
         scaffold.showSnackBar(
@@ -127,7 +143,7 @@ class _AvatarEditOverlayState extends State<AvatarEditOverlay> {
     final scaffold = ScaffoldMessenger.of(context);
     setState(() => _busy = true);
     try {
-      await widget.room.setAvatar(null);
+      await widget.onSetAvatar(null, null);
       debugPrint('[Kohera] Room avatar removed');
       if (mounted) {
         scaffold.showSnackBar(

--- a/lib/shared/widgets/join_access_section.dart
+++ b/lib/shared/widgets/join_access_section.dart
@@ -2,26 +2,60 @@ import 'package:flutter/material.dart';
 import 'package:kohera/core/models/join_mode.dart';
 import 'package:matrix/matrix.dart';
 
+/// A self-contained (id + displayname) reference to a space, used by the
+/// SDK-free [JoinAccessSection.refs] constructor so shared widgets do not
+/// depend on features-layer domain models.
+typedef SpaceRef = ({String id, String displayname});
+
 class JoinAccessSection extends StatelessWidget {
+  /// Original constructor: spaces are SDK [Room] objects. Kept unchanged for
+  /// existing callers ([JoinAccessController], [NewRoomDialog]).
   const JoinAccessSection({
     required this.mode,
-    required this.allowedSpaces,
-    required this.candidateSpaces,
+    required List<Room> allowedSpaces,
+    required List<Room> candidateSpaces,
     required this.needsUpgrade,
     required this.canEdit,
     required this.onModeChanged,
-    required this.onAllowedSpacesChanged,
+    required ValueChanged<List<Room>> onAllowedSpacesChanged,
     this.onUpgradeRequested,
     this.disabledModes = const {},
     this.padding = const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
     this.saving = false,
     this.savedHint = false,
     super.key,
-  });
+  })  : _allowedRooms = allowedSpaces,
+        _candidateRooms = candidateSpaces,
+        _onAllowedChangedRooms = onAllowedSpacesChanged,
+        _allowedRefs = null,
+        _candidateRefs = null,
+        _onAllowedChangedIds = null;
+
+  /// SDK-free constructor: spaces are [SpaceRef] records and the selection
+  /// callback emits room IDs. Used by SDK-free dialogs (e.g.
+  /// [CreateSubspaceDialog]) that have no [Room] dependency.
+  const JoinAccessSection.refs({
+    required this.mode,
+    required List<SpaceRef> allowedSpaces,
+    required List<SpaceRef> candidateSpaces,
+    required this.needsUpgrade,
+    required this.canEdit,
+    required this.onModeChanged,
+    required ValueChanged<List<String>> onAllowedSpacesChanged,
+    this.onUpgradeRequested,
+    this.disabledModes = const {},
+    this.padding = const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+    this.saving = false,
+    this.savedHint = false,
+    super.key,
+  })  : _allowedRooms = null,
+        _candidateRooms = null,
+        _onAllowedChangedRooms = null,
+        _allowedRefs = allowedSpaces,
+        _candidateRefs = candidateSpaces,
+        _onAllowedChangedIds = onAllowedSpacesChanged;
 
   final JoinMode mode;
-  final List<Room> allowedSpaces;
-  final List<Room> candidateSpaces;
   final bool needsUpgrade;
   final bool canEdit;
   /// Modes that should be disabled in the dropdown, mapped to the tooltip
@@ -31,8 +65,22 @@ class JoinAccessSection extends StatelessWidget {
   final bool saving;
   final bool savedHint;
   final ValueChanged<JoinMode> onModeChanged;
-  final ValueChanged<List<Room>> onAllowedSpacesChanged;
   final VoidCallback? onUpgradeRequested;
+
+  // Room-based variant (default constructor).
+  final List<Room>? _allowedRooms;
+  final List<Room>? _candidateRooms;
+  final ValueChanged<List<Room>>? _onAllowedChangedRooms;
+
+  // Ref-based variant (SDK-free constructor).
+  final List<SpaceRef>? _allowedRefs;
+  final List<SpaceRef>? _candidateRefs;
+  final ValueChanged<List<String>>? _onAllowedChangedIds;
+
+  bool get _isRefsVariant => _allowedRefs != null;
+
+  bool get _allowedIsEmpty =>
+      _isRefsVariant ? _allowedRefs!.isEmpty : _allowedRooms!.isEmpty;
 
   @override
   Widget build(BuildContext context) {
@@ -42,7 +90,7 @@ class JoinAccessSection extends StatelessWidget {
     final showPicker = restrictedFamily;
     final showUpgrade = needsUpgrade && restrictedFamily;
     final emptyAllowError =
-        restrictedFamily && allowedSpaces.isEmpty ? _emptyError(tt, cs) : null;
+        restrictedFamily && _allowedIsEmpty ? _emptyError(tt, cs) : null;
 
     final dropdown = DropdownButtonFormField<JoinMode>(
       key: const Key('join_access_mode_dropdown'),
@@ -94,13 +142,7 @@ class JoinAccessSection extends StatelessWidget {
             ),
           if (showPicker) ...[
             const SizedBox(height: 12),
-            _SpacePicker(
-              key: const Key('join_access_space_picker'),
-              candidates: candidateSpaces,
-              selected: allowedSpaces,
-              enabled: canEdit,
-              onChanged: onAllowedSpacesChanged,
-            ),
+            _spacePicker,
           ],
           if (emptyAllowError != null) ...[
             const SizedBox(height: 8),
@@ -115,6 +157,25 @@ class JoinAccessSection extends StatelessWidget {
           ],
         ],
       ),
+    );
+  }
+
+  Widget get _spacePicker {
+    if (_isRefsVariant) {
+      return _SpaceRefPicker(
+        key: const Key('join_access_space_picker'),
+        candidates: _candidateRefs!,
+        selected: _allowedRefs!,
+        enabled: canEdit,
+        onChanged: _onAllowedChangedIds!,
+      );
+    }
+    return _SpacePicker(
+      key: const Key('join_access_space_picker'),
+      candidates: _candidateRooms!,
+      selected: _allowedRooms!,
+      enabled: canEdit,
+      onChanged: _onAllowedChangedRooms!,
     );
   }
 
@@ -192,6 +253,62 @@ class _SpacePicker extends StatelessWidget {
                       if (!selectedIds.contains(room.id)) next.add(room);
                     } else {
                       next.removeWhere((r) => r.id == room.id);
+                    }
+                    onChanged(next);
+                  }
+                : null,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// SDK-free variant of [_SpacePicker] operating on [SpaceRef] records and
+/// emitting selected room IDs.
+class _SpaceRefPicker extends StatelessWidget {
+  const _SpaceRefPicker({
+    required this.candidates,
+    required this.selected,
+    required this.enabled,
+    required this.onChanged,
+    super.key,
+  });
+
+  final List<SpaceRef> candidates;
+  final List<SpaceRef> selected;
+  final bool enabled;
+  final ValueChanged<List<String>> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    if (candidates.isEmpty) {
+      return Text(
+        'No eligible parent spaces',
+        style: tt.bodySmall,
+      );
+    }
+    final selectedIds = selected.map((r) => r.id).toSet();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Spaces whose members can join', style: tt.labelMedium),
+        const SizedBox(height: 4),
+        ...candidates.map(
+          (ref) => CheckboxListTile(
+            key: Key('join_access_space_${ref.id}'),
+            dense: true,
+            controlAffinity: ListTileControlAffinity.leading,
+            title: Text(ref.displayname),
+            value: selectedIds.contains(ref.id),
+            onChanged: enabled
+                ? (checked) {
+                    final next = [...selectedIds];
+                    if (checked ?? false) {
+                      if (!next.contains(ref.id)) next.add(ref.id);
+                    } else {
+                      next.remove(ref.id);
                     }
                     onChanged(next);
                   }

--- a/test/widgets/add_existing_rooms_dialog_test.dart
+++ b/test/widgets/add_existing_rooms_dialog_test.dart
@@ -1,57 +1,31 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:kohera/core/services/matrix_service.dart';
-import 'package:kohera/core/services/sub_services/selection_service.dart';
+import 'package:kohera/features/rooms/models/kohera_room_summary.dart';
 import 'package:kohera/features/rooms/widgets/add_existing_rooms_dialog.dart';
-import 'package:matrix/matrix.dart' hide Visibility;
-import 'package:matrix/src/utils/cached_stream_controller.dart';
-import 'package:matrix/src/utils/space_child.dart';
-import 'package:mockito/annotations.dart';
-import 'package:mockito/mockito.dart';
 
-@GenerateNiceMocks([
-  MockSpec<MatrixService>(),
-  MockSpec<Room>(),
-  MockSpec<Client>(),
-])
-import 'add_existing_rooms_dialog_test.mocks.dart';
+KoheraRoomSummary makeRoom(String id, String name, {bool isSpace = false}) =>
+    KoheraRoomSummary(
+      roomId: id,
+      displayname: name,
+      isDirectChat: false,
+      isEncrypted: false,
+      isSpace: isSpace,
+      notificationCount: 0,
+      highlightCount: 0,
+      typingDisplayNames: const [],
+      pinnedEventIds: const [],
+      spaceChildCount: 0,
+      isFavourite: false,
+      lastEventPreview: '',
+      lastEventIsThreadReply: false,
+    );
 
 void main() {
-  late MockMatrixService mockMatrix;
-  late MockRoom mockSpace;
-  late MockClient mockClient;
-
-  MockRoom makeRoom(String id, String name) {
-    final room = MockRoom();
-    when(room.id).thenReturn(id);
-    when(room.getLocalizedDisplayname()).thenReturn(name);
-    when(room.membership).thenReturn(Membership.join);
-    when(room.isSpace).thenReturn(false);
-    when(room.avatar).thenReturn(null);
-    when(room.directChatMatrixID).thenReturn(null);
-    when(room.client).thenReturn(mockClient);
-    return room;
-  }
-
-  late SelectionService selectionService;
-
-  setUp(() {
-    mockMatrix = MockMatrixService();
-    mockSpace = MockRoom();
-    mockClient = MockClient();
-
-    when(mockMatrix.client).thenReturn(mockClient);
-    when(mockSpace.spaceChildren).thenReturn([]);
-    when(mockSpace.setSpaceChild(any)).thenAnswer((_) async {});
-    when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
-    when(mockClient.rooms).thenReturn([]);
-    selectionService = SelectionService(client: mockClient);
-    when(mockMatrix.selection).thenReturn(selectionService);
-  });
-
-  Widget buildTestWidget({List<Room>? clientRooms}) {
-    when(mockClient.rooms).thenReturn(clientRooms ?? []);
-
+  Widget buildTestWidget({
+    required List<KoheraRoomSummary> candidateRooms,
+    required Future<int> Function(List<String> roomIds) onAddRooms,
+    Set<String> existingChildIds = const {},
+  }) {
     return MaterialApp(
       theme: ThemeData(splashFactory: InkRipple.splashFactory),
       home: Scaffold(
@@ -60,8 +34,10 @@ void main() {
             child: ElevatedButton(
               onPressed: () => AddExistingRoomsDialog.show(
                 context,
-                space: mockSpace,
-                matrixService: mockMatrix,
+                candidateRooms: candidateRooms,
+                existingChildIds: existingChildIds,
+                avatarResolver: null,
+                onAddRooms: onAddRooms,
               ),
               child: const Text('Open'),
             ),
@@ -71,15 +47,28 @@ void main() {
     );
   }
 
-  Future<void> openDialog(WidgetTester tester, {List<Room>? clientRooms}) async {
-    await tester.pumpWidget(buildTestWidget(clientRooms: clientRooms));
+  Future<void> openDialog(
+    WidgetTester tester, {
+    required List<KoheraRoomSummary> candidateRooms,
+    required Future<int> Function(List<String> roomIds) onAddRooms,
+    Set<String> existingChildIds = const {},
+  }) async {
+    await tester.pumpWidget(
+      buildTestWidget(
+        candidateRooms: candidateRooms,
+        existingChildIds: existingChildIds,
+        onAddRooms: onAddRooms,
+      ),
+    );
     await tester.tap(find.text('Open'));
     await tester.pumpAndSettle();
   }
 
+  Future<int> noopAdd(List<String> ids) async => 0;
+
   group('AddExistingRoomsDialog', () {
     testWidgets('shows empty state when all rooms in space', (tester) async {
-      await openDialog(tester, clientRooms: []);
+      await openDialog(tester, candidateRooms: const [], onAddRooms: noopAdd);
 
       expect(
         find.text('All your rooms are already in this space.'),
@@ -88,41 +77,34 @@ void main() {
     });
 
     testWidgets('shows eligible rooms', (tester) async {
-      final room1 = makeRoom('!r1:x', 'Alpha');
-      final room2 = makeRoom('!r2:x', 'Beta');
-
-      await openDialog(tester, clientRooms: [room1, room2]);
+      await openDialog(
+        tester,
+        candidateRooms: [makeRoom('!r1:x', 'Alpha'), makeRoom('!r2:x', 'Beta')],
+        onAddRooms: noopAdd,
+      );
 
       expect(find.text('Alpha'), findsOneWidget);
       expect(find.text('Beta'), findsOneWidget);
     });
 
     testWidgets('excludes rooms already in space', (tester) async {
-      final room1 = makeRoom('!r1:x', 'Alpha');
-      final room2 = makeRoom('!r2:x', 'Beta');
-
-      when(mockSpace.spaceChildren).thenReturn([
-        SpaceChild.fromState(
-          StrippedStateEvent(
-            type: EventTypes.SpaceChild,
-            content: {},
-            senderId: '',
-            stateKey: '!r1:x',
-          ),
-        ),
-      ]);
-
-      await openDialog(tester, clientRooms: [room1, room2]);
+      await openDialog(
+        tester,
+        candidateRooms: [makeRoom('!r1:x', 'Alpha'), makeRoom('!r2:x', 'Beta')],
+        existingChildIds: const {'!r1:x'},
+        onAddRooms: noopAdd,
+      );
 
       expect(find.text('Alpha'), findsNothing);
       expect(find.text('Beta'), findsOneWidget);
     });
 
     testWidgets('excludes space rooms', (tester) async {
-      final room1 = makeRoom('!r1:x', 'Alpha');
-      when(room1.isSpace).thenReturn(true);
-
-      await openDialog(tester, clientRooms: [room1]);
+      await openDialog(
+        tester,
+        candidateRooms: [makeRoom('!r1:x', 'Alpha', isSpace: true)],
+        onAddRooms: noopAdd,
+      );
 
       expect(
         find.text('All your rooms are already in this space.'),
@@ -131,10 +113,11 @@ void main() {
     });
 
     testWidgets('search filters by display name', (tester) async {
-      final room1 = makeRoom('!r1:x', 'Alpha');
-      final room2 = makeRoom('!r2:x', 'Beta');
-
-      await openDialog(tester, clientRooms: [room1, room2]);
+      await openDialog(
+        tester,
+        candidateRooms: [makeRoom('!r1:x', 'Alpha'), makeRoom('!r2:x', 'Beta')],
+        onAddRooms: noopAdd,
+      );
 
       await tester.enterText(find.byType(TextField), 'alp');
       await tester.pumpAndSettle();
@@ -144,10 +127,11 @@ void main() {
     });
 
     testWidgets('selection updates Add button text', (tester) async {
-      final room1 = makeRoom('!r1:x', 'Alpha');
-      final room2 = makeRoom('!r2:x', 'Beta');
-
-      await openDialog(tester, clientRooms: [room1, room2]);
+      await openDialog(
+        tester,
+        candidateRooms: [makeRoom('!r1:x', 'Alpha'), makeRoom('!r2:x', 'Beta')],
+        onAddRooms: noopAdd,
+      );
 
       expect(find.text('Add (0)'), findsOneWidget);
 
@@ -162,12 +146,17 @@ void main() {
       expect(find.text('Add (2)'), findsOneWidget);
     });
 
-    testWidgets('submit calls setSpaceChild for each selected room',
+    testWidgets('submit calls onAddRooms with selected room ids',
         (tester) async {
-      final room1 = makeRoom('!r1:x', 'Alpha');
-      final room2 = makeRoom('!r2:x', 'Beta');
-
-      await openDialog(tester, clientRooms: [room1, room2]);
+      List<String>? submitted;
+      await openDialog(
+        tester,
+        candidateRooms: [makeRoom('!r1:x', 'Alpha'), makeRoom('!r2:x', 'Beta')],
+        onAddRooms: (ids) async {
+          submitted = ids;
+          return 0;
+        },
+      );
 
       await tester.tap(find.text('Alpha'));
       await tester.pumpAndSettle();
@@ -177,17 +166,15 @@ void main() {
       await tester.tap(find.text('Add (2)'));
       await tester.pumpAndSettle();
 
-      verify(mockSpace.setSpaceChild('!r1:x')).called(1);
-      verify(mockSpace.setSpaceChild('!r2:x')).called(1);
+      expect(submitted, ['!r1:x', '!r2:x']);
     });
 
     testWidgets('partial failure shows SnackBar', (tester) async {
-      final room1 = makeRoom('!r1:x', 'Alpha');
-      final room2 = makeRoom('!r2:x', 'Beta');
-
-      when(mockSpace.setSpaceChild('!r2:x')).thenThrow(Exception('fail'));
-
-      await openDialog(tester, clientRooms: [room1, room2]);
+      await openDialog(
+        tester,
+        candidateRooms: [makeRoom('!r1:x', 'Alpha'), makeRoom('!r2:x', 'Beta')],
+        onAddRooms: (ids) async => 1,
+      );
 
       await tester.tap(find.text('Alpha'));
       await tester.pumpAndSettle();

--- a/test/widgets/add_room_to_space_dialog_test.dart
+++ b/test/widgets/add_room_to_space_dialog_test.dart
@@ -1,81 +1,30 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:kohera/core/services/matrix_service.dart';
-import 'package:kohera/core/services/sub_services/selection_service.dart';
+import 'package:kohera/features/rooms/models/kohera_room_summary.dart';
 import 'package:kohera/features/rooms/widgets/add_room_to_space_dialog.dart';
-import 'package:matrix/matrix.dart' hide Visibility;
-import 'package:matrix/src/utils/cached_stream_controller.dart';
-import 'package:matrix/src/utils/space_child.dart';
-import 'package:mockito/annotations.dart';
-import 'package:mockito/mockito.dart';
 
-@GenerateNiceMocks([
-  MockSpec<MatrixService>(),
-  MockSpec<Room>(),
-  MockSpec<Client>(),
-])
-import 'add_room_to_space_dialog_test.mocks.dart';
+KoheraRoomSummary makeSpace(String id, String name) => KoheraRoomSummary(
+      roomId: id,
+      displayname: name,
+      isDirectChat: false,
+      isEncrypted: false,
+      isSpace: true,
+      notificationCount: 0,
+      highlightCount: 0,
+      typingDisplayNames: const [],
+      pinnedEventIds: const [],
+      spaceChildCount: 0,
+      isFavourite: false,
+      lastEventPreview: '',
+      lastEventIsThreadReply: false,
+    );
 
 void main() {
-  late MockMatrixService mockMatrix;
-  late MockRoom mockRoom;
-  late MockClient mockClient;
-
-  late SelectionService selectionService;
-
-  MockRoom makeSpace(String id, String name, {bool canEdit = true}) {
-    final space = MockRoom();
-    when(space.id).thenReturn(id);
-    when(space.getLocalizedDisplayname()).thenReturn(name);
-    when(space.canChangeStateEvent('m.space.child')).thenReturn(canEdit);
-    when(space.avatar).thenReturn(null);
-    when(space.directChatMatrixID).thenReturn(null);
-    when(space.client).thenReturn(mockClient);
-    when(space.isSpace).thenReturn(true);
-    when(space.membership).thenReturn(Membership.join);
-    when(space.spaceChildren).thenReturn([]);
-    when(space.setSpaceChild(any, suggested: anyNamed('suggested')))
-        .thenAnswer((_) async {});
-    return space;
-  }
-
-  setUp(() {
-    mockMatrix = MockMatrixService();
-    mockRoom = MockRoom();
-    mockClient = MockClient();
-
-    when(mockMatrix.client).thenReturn(mockClient);
-    when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
-    when(mockClient.rooms).thenReturn([]);
-    when(mockRoom.id).thenReturn('!room:example.com');
-    when(mockRoom.isSpace).thenReturn(false);
-    when(mockRoom.membership).thenReturn(Membership.join);
-    when(mockClient.getRoomById('!room:example.com')).thenReturn(mockRoom);
-  });
-
   Widget buildTestWidget({
-    List<Room>? spaces,
-    Set<String> memberships = const {},
+    required List<KoheraRoomSummary> candidateSpaces,
+    required Future<int> Function(Map<String, bool> selections) onAddToSpaces,
+    Set<String> memberSpaceIds = const {},
   }) {
-    final allSpaces = spaces ?? [];
-    when(mockClient.rooms).thenReturn(allSpaces);
-
-    for (final s in allSpaces) {
-      if (memberships.contains((s as MockRoom).id)) {
-        when(s.spaceChildren).thenReturn([
-          SpaceChild.fromState(StrippedStateEvent(
-            type: EventTypes.SpaceChild,
-            content: {'via': ['example.com']},
-            stateKey: '!room:example.com',
-            senderId: '@admin:example.com',
-          ),),
-        ]);
-      }
-    }
-
-    selectionService = SelectionService(client: mockClient);
-    when(mockMatrix.selection).thenReturn(selectionService);
-
     return MaterialApp(
       theme: ThemeData(splashFactory: InkRipple.splashFactory),
       home: Scaffold(
@@ -84,8 +33,11 @@ void main() {
             child: ElevatedButton(
               onPressed: () => AddRoomToSpaceDialog.show(
                 context,
-                room: mockRoom,
-                matrixService: mockMatrix,
+                roomId: '!room:example.com',
+                candidateSpaces: candidateSpaces,
+                memberSpaceIds: memberSpaceIds,
+                avatarResolver: null,
+                onAddToSpaces: onAddToSpaces,
               ),
               child: const Text('Open'),
             ),
@@ -97,12 +49,17 @@ void main() {
 
   Future<void> openDialog(
     WidgetTester tester, {
-    List<Room>? spaces,
-    Set<String> memberships = const {},
+    required List<KoheraRoomSummary> candidateSpaces,
+    required Future<int> Function(Map<String, bool> selections) onAddToSpaces,
+    Set<String> memberSpaceIds = const {},
     bool hasListView = false,
   }) async {
     await tester.pumpWidget(
-      buildTestWidget(spaces: spaces, memberships: memberships),
+      buildTestWidget(
+        candidateSpaces: candidateSpaces,
+        onAddToSpaces: onAddToSpaces,
+        memberSpaceIds: memberSpaceIds,
+      ),
     );
     await tester.tap(find.text('Open'));
     if (hasListView) {
@@ -113,9 +70,15 @@ void main() {
     }
   }
 
+  Future<int> noopAdd(Map<String, bool> selections) async => 0;
+
   group('AddRoomToSpaceDialog', () {
     testWidgets('shows empty state when room in all spaces', (tester) async {
-      await openDialog(tester, spaces: []);
+      await openDialog(
+        tester,
+        candidateSpaces: const [],
+        onAddToSpaces: noopAdd,
+      );
 
       expect(
         find.text('This room is already in all your spaces.'),
@@ -124,10 +87,12 @@ void main() {
     });
 
     testWidgets('shows eligible spaces', (tester) async {
-      final space1 = makeSpace('!s1:x', 'Space A');
-      final space2 = makeSpace('!s2:x', 'Space B');
-
-      await openDialog(tester, spaces: [space1, space2], hasListView: true);
+      await openDialog(
+        tester,
+        candidateSpaces: [makeSpace('!s1:x', 'Space A'), makeSpace('!s2:x', 'Space B')],
+        onAddToSpaces: noopAdd,
+        hasListView: true,
+      );
 
       expect(find.text('Space A'), findsOneWidget);
       expect(find.text('Space B'), findsOneWidget);
@@ -135,13 +100,11 @@ void main() {
 
     testWidgets('excludes spaces where room is already a member',
         (tester) async {
-      final space1 = makeSpace('!s1:x', 'Space A');
-      final space2 = makeSpace('!s2:x', 'Space B');
-
       await openDialog(
         tester,
-        spaces: [space1, space2],
-        memberships: {'!s1:x'},
+        candidateSpaces: [makeSpace('!s1:x', 'Space A'), makeSpace('!s2:x', 'Space B')],
+        memberSpaceIds: const {'!s1:x'},
+        onAddToSpaces: noopAdd,
         hasListView: true,
       );
 
@@ -149,10 +112,12 @@ void main() {
       expect(find.text('Space B'), findsOneWidget);
     });
 
-    testWidgets('excludes spaces user cannot edit', (tester) async {
-      makeSpace('!s1:x', 'Space A', canEdit: false);
-
-      await openDialog(tester, spaces: []);
+    testWidgets('shows empty state when no eligible spaces', (tester) async {
+      await openDialog(
+        tester,
+        candidateSpaces: const [],
+        onAddToSpaces: noopAdd,
+      );
 
       expect(
         find.text('This room is already in all your spaces.'),
@@ -161,8 +126,12 @@ void main() {
     });
 
     testWidgets('selection enables Add button', (tester) async {
-      final space1 = makeSpace('!s1:x', 'Space A');
-      await openDialog(tester, spaces: [space1], hasListView: true);
+      await openDialog(
+        tester,
+        candidateSpaces: [makeSpace('!s1:x', 'Space A')],
+        onAddToSpaces: noopAdd,
+        hasListView: true,
+      );
 
       final addButton = tester.widget<FilledButton>(
         find.widgetWithText(FilledButton, 'Add'),
@@ -180,8 +149,12 @@ void main() {
 
     testWidgets('suggested switch enabled only when space selected',
         (tester) async {
-      final space1 = makeSpace('!s1:x', 'Space A');
-      await openDialog(tester, spaces: [space1], hasListView: true);
+      await openDialog(
+        tester,
+        candidateSpaces: [makeSpace('!s1:x', 'Space A')],
+        onAddToSpaces: noopAdd,
+        hasListView: true,
+      );
 
       final switchWidget = tester.widget<Switch>(find.byType(Switch));
       expect(switchWidget.onChanged, isNull);
@@ -193,10 +166,18 @@ void main() {
       expect(switchWidget2.onChanged, isNotNull);
     });
 
-    testWidgets('submit calls setSpaceChild with suggested flag',
+    testWidgets('submit calls onAddToSpaces with suggested flag',
         (tester) async {
-      final space1 = makeSpace('!s1:x', 'Space A');
-      await openDialog(tester, spaces: [space1], hasListView: true);
+      Map<String, bool>? submitted;
+      await openDialog(
+        tester,
+        candidateSpaces: [makeSpace('!s1:x', 'Space A')],
+        onAddToSpaces: (selections) async {
+          submitted = selections;
+          return 0;
+        },
+        hasListView: true,
+      );
 
       await tester.tap(find.text('Space A'));
       await tester.pump();
@@ -208,16 +189,16 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      verify(space1.setSpaceChild('!room:example.com', suggested: true))
-          .called(1);
+      expect(submitted, {'!s1:x': true});
     });
 
     testWidgets('partial failure shows SnackBar', (tester) async {
-      final space1 = makeSpace('!s1:x', 'Space A');
-      when(space1.setSpaceChild(any, suggested: anyNamed('suggested')))
-          .thenThrow(Exception('fail'));
-
-      await openDialog(tester, spaces: [space1], hasListView: true);
+      await openDialog(
+        tester,
+        candidateSpaces: [makeSpace('!s1:x', 'Space A')],
+        onAddToSpaces: (selections) async => 1,
+        hasListView: true,
+      );
 
       await tester.tap(find.text('Space A'));
       await tester.pump();
@@ -230,17 +211,23 @@ void main() {
     });
 
     testWidgets('cancel closes without side effects', (tester) async {
-      final space1 = makeSpace('!s1:x', 'Space A');
-      await openDialog(tester, spaces: [space1], hasListView: true);
+      var called = false;
+      await openDialog(
+        tester,
+        candidateSpaces: [makeSpace('!s1:x', 'Space A')],
+        onAddToSpaces: (selections) async {
+          called = true;
+          return 0;
+        },
+        hasListView: true,
+      );
 
       await tester.tap(find.text('Cancel'));
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
 
       expect(find.text('Add to space'), findsNothing);
-      verifyNever(
-        space1.setSpaceChild(any, suggested: anyNamed('suggested')),
-      );
+      expect(called, isFalse);
     });
   });
 }

--- a/test/widgets/avatar_edit_overlay_test.dart
+++ b/test/widgets/avatar_edit_overlay_test.dart
@@ -29,7 +29,6 @@ void main() {
     required Future<void> Function(Uint8List? bytes, String? filename)
         onSetAvatar,
     String? avatarUrl,
-    double size = 72,
   }) {
     return MaterialApp(
       theme: ThemeData(splashFactory: InkRipple.splashFactory),
@@ -40,7 +39,6 @@ void main() {
           canEditAvatar: canEditAvatar,
           avatarResolver: null,
           onSetAvatar: onSetAvatar,
-          size: size,
         ),
       ),
     );

--- a/test/widgets/avatar_edit_overlay_test.dart
+++ b/test/widgets/avatar_edit_overlay_test.dart
@@ -1,39 +1,59 @@
-﻿import 'package:flutter/material.dart';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/features/rooms/models/kohera_room_summary.dart';
 import 'package:kohera/shared/widgets/avatar_edit_overlay.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
-import 'package:matrix/matrix.dart';
-import 'package:mockito/annotations.dart';
-import 'package:mockito/mockito.dart';
 
-@GenerateNiceMocks([MockSpec<Room>(), MockSpec<Client>()])
-import 'avatar_edit_overlay_test.mocks.dart';
+KoheraRoomSummary _summary({String? avatarUrl}) => KoheraRoomSummary(
+      roomId: '!room:example.com',
+      displayname: 'Test Room',
+      avatarUrl: avatarUrl,
+      isDirectChat: false,
+      isEncrypted: false,
+      isSpace: false,
+      notificationCount: 0,
+      highlightCount: 0,
+      typingDisplayNames: const [],
+      pinnedEventIds: const [],
+      spaceChildCount: 0,
+      isFavourite: false,
+      lastEventPreview: '',
+      lastEventIsThreadReply: false,
+    );
 
 void main() {
-  late MockRoom mockRoom;
-  late MockClient mockClient;
-
-  setUp(() {
-    mockRoom = MockRoom();
-    mockClient = MockClient();
-    when(mockRoom.client).thenReturn(mockClient);
-    when(mockRoom.avatar).thenReturn(null);
-    when(mockRoom.getLocalizedDisplayname()).thenReturn('Test Room');
-  });
-
-  Widget buildTestWidget({double size = 72}) {
+  Widget buildTestWidget({
+    required bool canEditAvatar,
+    required Future<void> Function(Uint8List? bytes, String? filename)
+        onSetAvatar,
+    String? avatarUrl,
+    double size = 72,
+  }) {
     return MaterialApp(
       theme: ThemeData(splashFactory: InkRipple.splashFactory),
       home: Scaffold(
-        body: AvatarEditOverlay(room: mockRoom, size: size),
+        body: AvatarEditOverlay(
+          roomId: '!room:example.com',
+          summary: _summary(avatarUrl: avatarUrl),
+          canEditAvatar: canEditAvatar,
+          avatarResolver: null,
+          onSetAvatar: onSetAvatar,
+          size: size,
+        ),
       ),
     );
   }
 
+  Future<void> noopSet(Uint8List? bytes, String? filename) async {}
+
   group('AvatarEditOverlay', () {
-    testWidgets('renders plain RoomAvatarWidget when user lacks permission', (tester) async {
-      when(mockRoom.canChangeStateEvent(EventTypes.RoomAvatar)).thenReturn(false);
-      await tester.pumpWidget(buildTestWidget());
+    testWidgets('renders plain RoomAvatarWidget when user lacks permission',
+        (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(canEditAvatar: false, onSetAvatar: noopSet),
+      );
       await tester.pump();
 
       expect(find.byType(RoomAvatarWidget), findsOneWidget);
@@ -41,43 +61,57 @@ void main() {
     });
 
     testWidgets('shows edit overlay when user has permission', (tester) async {
-      when(mockRoom.canChangeStateEvent(EventTypes.RoomAvatar)).thenReturn(true);
-      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpWidget(
+        buildTestWidget(canEditAvatar: true, onSetAvatar: noopSet),
+      );
       await tester.pump();
 
       expect(find.byType(RoomAvatarWidget), findsOneWidget);
-      expect(find.byType(GestureDetector), findsOneWidget);
+      expect(find.byType(GestureDetector), findsWidgets);
     });
 
     testWidgets('shows remove badge when avatar exists', (tester) async {
-      when(mockRoom.canChangeStateEvent(EventTypes.RoomAvatar)).thenReturn(true);
-      when(mockRoom.avatar).thenReturn(Uri.parse('mxc://example.com/avatar'));
-      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpWidget(
+        buildTestWidget(
+          canEditAvatar: true,
+          avatarUrl: 'mxc://example.com/avatar',
+          onSetAvatar: noopSet,
+        ),
+      );
       await tester.pump();
 
       expect(find.byIcon(Icons.close_rounded), findsOneWidget);
     });
 
     testWidgets('hides remove badge when no avatar', (tester) async {
-      when(mockRoom.canChangeStateEvent(EventTypes.RoomAvatar)).thenReturn(true);
-      when(mockRoom.avatar).thenReturn(null);
-      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpWidget(
+        buildTestWidget(canEditAvatar: true, onSetAvatar: noopSet),
+      );
       await tester.pump();
 
       expect(find.byIcon(Icons.close_rounded), findsNothing);
     });
 
-    testWidgets('calls room.setAvatar(null) on remove tap', (tester) async {
-      when(mockRoom.canChangeStateEvent(EventTypes.RoomAvatar)).thenReturn(true);
-      when(mockRoom.avatar).thenReturn(Uri.parse('mxc://example.com/avatar'));
-      when(mockRoom.setAvatar(null)).thenAnswer((_) async => '');
-      await tester.pumpWidget(buildTestWidget());
+    testWidgets('calls onSetAvatar(null, null) on remove tap', (tester) async {
+      Uint8List? capturedBytes;
+      String? capturedFilename;
+      await tester.pumpWidget(
+        buildTestWidget(
+          canEditAvatar: true,
+          avatarUrl: 'mxc://example.com/avatar',
+          onSetAvatar: (bytes, filename) async {
+            capturedBytes = bytes;
+            capturedFilename = filename;
+          },
+        ),
+      );
       await tester.pump();
 
       await tester.tap(find.byIcon(Icons.close_rounded));
       await tester.pumpAndSettle();
 
-      verify(mockRoom.setAvatar(null)).called(1);
+      expect(capturedBytes, isNull);
+      expect(capturedFilename, isNull);
     });
   });
 }

--- a/test/widgets/create_subspace_dialog_test.dart
+++ b/test/widgets/create_subspace_dialog_test.dart
@@ -1,9 +1,12 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/models/join_mode.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/services/sub_services/space_access_service.dart';
+import 'package:kohera/features/spaces/widgets/create_subspace_action.dart';
 import 'package:kohera/features/spaces/widgets/create_subspace_dialog.dart';
+import 'package:kohera/shared/widgets/join_access_section.dart';
 import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/annotations.dart';
@@ -17,35 +20,22 @@ import 'package:mockito/mockito.dart';
 ])
 import 'create_subspace_dialog_test.mocks.dart';
 
+const _defaultCaps = SubspaceCapabilities(
+  restrictedRoomVersion: null,
+  disabledModes: {JoinMode.knockRestricted: 'Not supported by this server'},
+);
+
+SpaceRef _parentRef(String name) =>
+    (id: '!parent:example.com', displayname: name);
+
 void main() {
-  late MockClient mockClient;
-  late MockMatrixService mockMatrixService;
-  late MockRoom mockParentSpace;
-  late MockSpaceAccessService mockAccess;
+  // ── Dialog UI tests (SDK-free, callback-based) ──────────────────────
 
-  late SelectionService selectionService;
-
-  setUp(() {
-    mockClient = MockClient();
-    mockMatrixService = MockMatrixService();
-    mockParentSpace = MockRoom();
-    mockAccess = MockSpaceAccessService();
-    when(mockClient.rooms).thenReturn([]);
-    when(mockClient.onSync)
-        .thenReturn(CachedStreamController<SyncUpdate>());
-    selectionService = SelectionService(client: mockClient);
-    when(mockMatrixService.client).thenReturn(mockClient);
-    when(mockMatrixService.selection).thenReturn(selectionService);
-    when(mockMatrixService.spaceAccess).thenReturn(mockAccess);
-    when(mockAccess.pickRestrictedRoomVersion(
-      wantKnock: anyNamed('wantKnock'),
-    ),).thenAnswer((_) async => null);
-    when(mockParentSpace.getLocalizedDisplayname())
-        .thenReturn('Parent Space');
-    when(mockParentSpace.id).thenReturn('!parent:example.com');
-  });
-
-  Widget buildTestWidget() {
+  Widget buildTestWidget({
+    required Future<void> Function(CreateSubspaceRequest request)
+        onCreateSubspace,
+    SubspaceCapabilities caps = _defaultCaps,
+  }) {
     return MaterialApp(
       theme: ThemeData(splashFactory: InkRipple.splashFactory),
       home: Scaffold(
@@ -53,8 +43,9 @@ void main() {
           builder: (context) => ElevatedButton(
             onPressed: () => CreateSubspaceDialog.show(
               context,
-              matrixService: mockMatrixService,
-              parentSpace: mockParentSpace,
+              parentSpaceRef: _parentRef('Parent Space'),
+              loadCapabilities: () async => caps,
+              onCreateSubspace: onCreateSubspace,
             ),
             child: const Text('Open'),
           ),
@@ -64,100 +55,201 @@ void main() {
   }
 
   Future<void> openDialog(WidgetTester tester) async {
-    await tester.pumpWidget(buildTestWidget());
+    await tester.pumpWidget(
+      buildTestWidget(onCreateSubspace: (request) async {}),
+    );
     await tester.tap(find.text('Open'));
     await tester.pumpAndSettle();
   }
 
-  testWidgets('shows name and topic fields with parent space context',
+  group('CreateSubspaceDialog', () {
+    testWidgets('shows name and topic fields with parent space context',
+        (tester) async {
+      await openDialog(tester);
+
+      expect(find.text('Create subspace'), findsOneWidget);
+      expect(find.widgetWithText(TextField, 'Name'), findsOneWidget);
+      expect(
+        find.widgetWithText(TextField, 'Topic (optional)'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('Parent Space'), findsOneWidget);
+    });
+
+    testWidgets('validates empty name', (tester) async {
+      await openDialog(tester);
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Create'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Name is required'), findsOneWidget);
+    });
+
+    testWidgets('submitting calls onCreateSubspace with the request and closes',
+        (tester) async {
+      CreateSubspaceRequest? captured;
+      await tester.pumpWidget(
+        buildTestWidget(
+          onCreateSubspace: (request) async {
+            captured = request;
+          },
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Name'),
+        'My Subspace',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Topic (optional)'),
+        'A topic',
+      );
+      await tester.tap(find.widgetWithText(FilledButton, 'Create'));
+      await tester.pumpAndSettle();
+
+      expect(captured, isNotNull);
+      expect(captured!.name, 'My Subspace');
+      expect(captured!.topic, 'A topic');
+      expect(find.text('Create subspace'), findsNothing);
+    });
+
+    testWidgets('shows error on failure', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          onCreateSubspace: (request) async => throw Exception('Server error'),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Name'),
+        'Bad Subspace',
+      );
+      await tester.tap(find.widgetWithText(FilledButton, 'Create'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Server error'), findsOneWidget);
+      expect(find.text('Create subspace'), findsOneWidget);
+    });
+
+    testWidgets('cancel closes dialog', (tester) async {
+      await openDialog(tester);
+
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Create subspace'), findsNothing);
+    });
+
+    testWidgets(
+      'restricted-capable server shows join access section and submits '
+      'restricted request',
       (tester) async {
-    await openDialog(tester);
+        CreateSubspaceRequest? captured;
+        await tester.pumpWidget(
+          buildTestWidget(
+            caps: const SubspaceCapabilities(
+              restrictedRoomVersion: '10',
+              disabledModes: {},
+            ),
+            onCreateSubspace: (request) async {
+              captured = request;
+            },
+          ),
+        );
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
 
-    expect(find.text('Create subspace'), findsOneWidget);
-    expect(find.widgetWithText(TextField, 'Name'), findsOneWidget);
-    expect(
-        find.widgetWithText(TextField, 'Topic (optional)'), findsOneWidget,);
-    expect(find.textContaining('Parent Space'), findsOneWidget);
+        expect(
+          find.byKey(const Key('join_access_mode_dropdown')),
+          findsOneWidget,
+        );
+
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Name'),
+          'Gated',
+        );
+        await tester.tap(find.widgetWithText(FilledButton, 'Create'));
+        await tester.pumpAndSettle();
+
+        expect(captured, isNotNull);
+        expect(captured!.joinMode, JoinMode.restricted);
+        expect(captured!.allowedSpaceIds, ['!parent:example.com']);
+        expect(captured!.restrictedRoomVersion, '10');
+      },
+    );
   });
 
-  testWidgets('validates empty name', (tester) async {
-    await openDialog(tester);
+  // ── Helper tests (SDK create flow) ─────────────────────────────────
 
-    await tester.tap(find.widgetWithText(FilledButton, 'Create'));
-    await tester.pumpAndSettle();
+  group('createSubspace action', () {
+    late MockClient mockClient;
+    late MockMatrixService mockMatrixService;
+    late MockRoom mockParentSpace;
+    late MockSpaceAccessService mockAccess;
+    late SelectionService selectionService;
 
-    expect(find.text('Name is required'), findsOneWidget);
-  });
+    setUp(() {
+      mockClient = MockClient();
+      mockMatrixService = MockMatrixService();
+      mockParentSpace = MockRoom();
+      mockAccess = MockSpaceAccessService();
+      when(mockClient.rooms).thenReturn([]);
+      when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
+      selectionService = SelectionService(client: mockClient);
+      when(mockMatrixService.client).thenReturn(mockClient);
+      when(mockMatrixService.selection).thenReturn(selectionService);
+      when(mockMatrixService.spaceAccess).thenReturn(mockAccess);
+      when(mockParentSpace.id).thenReturn('!parent:example.com');
 
-  testWidgets('submitting calls createRoom and setSpaceChild', (tester) async {
-    when(mockClient.createRoom(
-      name: anyNamed('name'),
-      topic: anyNamed('topic'),
-      creationContent: anyNamed('creationContent'),
-      visibility: anyNamed('visibility'),
-      roomVersion: anyNamed('roomVersion'),
-      initialState: anyNamed('initialState'),
-      powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
-    ),).thenAnswer((_) async => '!subspace:example.com');
+      when(
+        mockClient.createRoom(
+          name: anyNamed('name'),
+          topic: anyNamed('topic'),
+          creationContent: anyNamed('creationContent'),
+          visibility: anyNamed('visibility'),
+          roomVersion: anyNamed('roomVersion'),
+          initialState: anyNamed('initialState'),
+          powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
+        ),
+      ).thenAnswer((_) async => '!subspace:example.com');
+      when(mockClient.waitForRoomInSync(any, join: anyNamed('join')))
+          .thenAnswer((_) async => SyncUpdate(nextBatch: ''));
+    });
 
-    when(mockClient.waitForRoomInSync(any, join: anyNamed('join')))
-        .thenAnswer((_) async => SyncUpdate(nextBatch: ''));
+    test('calls createRoom and setSpaceChild', () async {
+      await createSubspace(
+        mockMatrixService,
+        mockParentSpace,
+        const CreateSubspaceRequest(
+          name: 'My Subspace',
+          topic: 'A topic',
+          joinMode: JoinMode.invite,
+          allowedSpaceIds: [],
+          restrictedRoomVersion: null,
+        ),
+      );
 
-    await openDialog(tester);
+      verify(
+        mockClient.createRoom(
+          name: 'My Subspace',
+          topic: 'A topic',
+          creationContent: anyNamed('creationContent'),
+          visibility: anyNamed('visibility'),
+          roomVersion: anyNamed('roomVersion'),
+          initialState: anyNamed('initialState'),
+          powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
+        ),
+      ).called(1);
 
-    await tester.enterText(
-        find.widgetWithText(TextField, 'Name'), 'My Subspace',);
-    await tester.enterText(
-        find.widgetWithText(TextField, 'Topic (optional)'), 'A topic',);
-    await tester.tap(find.widgetWithText(FilledButton, 'Create'));
-    await tester.pumpAndSettle();
+      verify(mockParentSpace.setSpaceChild('!subspace:example.com')).called(1);
+    });
 
-    verify(mockClient.createRoom(
-      name: 'My Subspace',
-      topic: 'A topic',
-      creationContent: anyNamed('creationContent'),
-      visibility: anyNamed('visibility'),
-      roomVersion: anyNamed('roomVersion'),
-      initialState: anyNamed('initialState'),
-      powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
-    ),).called(1);
-
-    verify(mockParentSpace.setSpaceChild('!subspace:example.com')).called(1);
-
-    // Dialog should close on success.
-    expect(find.text('Create subspace'), findsNothing);
-  });
-
-  testWidgets('shows error on failure', (tester) async {
-    when(mockClient.createRoom(
-      name: anyNamed('name'),
-      topic: anyNamed('topic'),
-      creationContent: anyNamed('creationContent'),
-      visibility: anyNamed('visibility'),
-      roomVersion: anyNamed('roomVersion'),
-      initialState: anyNamed('initialState'),
-      powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
-    ),).thenThrow(Exception('Server error'));
-
-    await openDialog(tester);
-
-    await tester.enterText(
-        find.widgetWithText(TextField, 'Name'), 'Bad Subspace',);
-    await tester.tap(find.widgetWithText(FilledButton, 'Create'));
-    await tester.pumpAndSettle();
-
-    expect(find.textContaining('Server error'), findsOneWidget);
-    // Dialog should remain open.
-    expect(find.text('Create subspace'), findsOneWidget);
-  });
-
-  testWidgets(
-    'restricted-capable server creates subspace with join_rules initial_state',
-    (tester) async {
-      when(mockAccess.pickRestrictedRoomVersion(wantKnock: true))
-          .thenAnswer((_) async => '10');
-      when(mockAccess.pickRestrictedRoomVersion(wantKnock: false))
-          .thenAnswer((_) async => '10');
+    test('restricted request creates subspace with join_rules initial_state',
+        () async {
       when(mockAccess.buildJoinRulesStateEvent(any, any)).thenReturn(
         StateEvent(
           type: EventTypes.RoomJoinRules,
@@ -169,54 +261,79 @@ void main() {
           },
         ),
       );
-      when(mockClient.createRoom(
-        name: anyNamed('name'),
-        topic: anyNamed('topic'),
-        creationContent: anyNamed('creationContent'),
-        visibility: anyNamed('visibility'),
-        roomVersion: anyNamed('roomVersion'),
-        initialState: anyNamed('initialState'),
-        powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
-      ),).thenAnswer((_) async => '!sub:example.com');
-      when(mockClient.waitForRoomInSync(any, join: anyNamed('join')))
-          .thenAnswer((_) async => SyncUpdate(nextBatch: ''));
 
-      await openDialog(tester);
-
-      await tester.enterText(
-        find.widgetWithText(TextField, 'Name'),
-        'Gated',
+      await createSubspace(
+        mockMatrixService,
+        mockParentSpace,
+        const CreateSubspaceRequest(
+          name: 'Gated',
+          topic: null,
+          joinMode: JoinMode.restricted,
+          allowedSpaceIds: ['!parent:example.com'],
+          restrictedRoomVersion: '10',
+        ),
       );
-      await tester.tap(find.widgetWithText(FilledButton, 'Create'));
-      await tester.pumpAndSettle();
 
-      final captured = verify(mockClient.createRoom(
-        name: 'Gated',
-        topic: anyNamed('topic'),
-        creationContent: anyNamed('creationContent'),
-        visibility: anyNamed('visibility'),
-        roomVersion: '10',
-        initialState: captureAnyNamed('initialState'),
-        powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
-      ),).captured.single as List<StateEvent>;
-      final joinRules = captured.firstWhere(
-        (s) => s.type == EventTypes.RoomJoinRules,
-      );
+      final captured = verify(
+        mockClient.createRoom(
+          name: 'Gated',
+          topic: anyNamed('topic'),
+          creationContent: anyNamed('creationContent'),
+          visibility: anyNamed('visibility'),
+          roomVersion: '10',
+          initialState: captureAnyNamed('initialState'),
+          powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
+        ),
+      ).captured.single as List<StateEvent>;
+      final joinRules =
+          captured.firstWhere((s) => s.type == EventTypes.RoomJoinRules);
       expect(joinRules.content['join_rule'], 'restricted');
-      expect(joinRules.content['allow'], [
-        {'type': 'm.room_membership', 'room_id': '!parent:example.com'},
-      ]);
-    },
-  );
+      expect(
+        joinRules.content['allow'],
+        [
+          {'type': 'm.room_membership', 'room_id': '!parent:example.com'},
+        ],
+      );
+    });
+  });
 
-  testWidgets('cancel closes dialog', (tester) async {
-    await openDialog(tester);
+  group('loadSubspaceCapabilities', () {
+    late MockClient mockClient;
+    late MockMatrixService mockMatrixService;
+    late MockSpaceAccessService mockAccess;
 
-    expect(find.text('Create subspace'), findsOneWidget);
+    setUp(() {
+      mockClient = MockClient();
+      mockMatrixService = MockMatrixService();
+      mockAccess = MockSpaceAccessService();
+      when(mockMatrixService.client).thenReturn(mockClient);
+      when(mockMatrixService.spaceAccess).thenReturn(mockAccess);
+    });
 
-    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
-    await tester.pumpAndSettle();
+    test('reports restricted unavailable when server lacks knock support',
+        () async {
+      when(
+        mockAccess.pickRestrictedRoomVersion(
+          wantKnock: anyNamed('wantKnock'),
+        ),
+      ).thenAnswer((_) async => null);
 
-    expect(find.text('Create subspace'), findsNothing);
+      final caps = await loadSubspaceCapabilities(mockMatrixService);
+
+      expect(caps.restrictedRoomVersion, isNull);
+      expect(caps.disabledModes[JoinMode.knockRestricted], isNotNull);
+    });
+
+    test('reports restricted available with room version', () async {
+      when(mockAccess.pickRestrictedRoomVersion(wantKnock: true))
+          .thenAnswer((_) async => '10');
+      when(mockAccess.pickRestrictedRoomVersion(wantKnock: false))
+          .thenAnswer((_) async => '10');
+
+      final caps = await loadSubspaceCapabilities(mockMatrixService);
+
+      expect(caps.restrictedRoomVersion, '10');
+      expect(caps.disabledModes, isEmpty);
+    });
   });
 }

--- a/test/widgets/invite_dialog_test.dart
+++ b/test/widgets/invite_dialog_test.dart
@@ -1,61 +1,55 @@
-﻿import 'dart:async';
+import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/matrix_service.dart';
-import 'package:kohera/core/services/sub_services/selection_service.dart';
+import 'package:kohera/features/rooms/models/kohera_room_summary.dart';
 import 'package:kohera/features/rooms/widgets/invite_dialog.dart';
-import 'package:matrix/matrix.dart';
-import 'package:matrix/src/utils/cached_stream_controller.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
 
-@GenerateNiceMocks([
-  MockSpec<MatrixService>(),
-  MockSpec<Room>(),
-  MockSpec<Client>(),
-])
+@GenerateNiceMocks([MockSpec<MatrixService>()])
 import 'invite_dialog_test.mocks.dart';
 
 void main() {
   late MockMatrixService mockMatrix;
-  late MockRoom mockRoom;
-  late MockClient mockClient;
-  late SelectionService selectionService;
 
   setUp(() {
     mockMatrix = MockMatrixService();
-    mockRoom = MockRoom();
-    mockClient = MockClient();
-    when(mockMatrix.client).thenReturn(mockClient);
-    when(mockClient.userID).thenReturn('@me:example.com');
-    when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
-    when(mockClient.rooms).thenReturn([]);
-    when(mockRoom.getLocalizedDisplayname()).thenReturn('Test Room');
-    when(mockRoom.isSpace).thenReturn(false);
-    when(mockRoom.client).thenReturn(mockClient);
-    when(mockRoom.getState(EventTypes.RoomMember, '@me:example.com'))
-        .thenReturn(Event(
-      type: EventTypes.RoomMember,
-      content: {'membership': 'invite'},
-      senderId: '@alice:example.com',
-      eventId: r'$inv',
-      room: mockRoom,
-      originServerTs: DateTime.now(),
-    ),);
-    when(mockRoom.unsafeGetUserFromMemoryOrFallback('@alice:example.com'))
-        .thenReturn(User('@alice:example.com',
-            room: mockRoom, displayName: 'Alice',),);
-    selectionService = SelectionService(client: mockClient);
-    when(mockMatrix.selection).thenReturn(selectionService);
+    when(mockMatrix.avatarResolver).thenReturn(const _NullAvatarResolver());
   });
 
-  Widget buildTestWidget() {
+  KoheraRoomSummary makeSummary({
+    String displayname = 'Test Room',
+    bool isSpace = false,
+  }) =>
+      KoheraRoomSummary(
+        roomId: '!room:example.com',
+        displayname: displayname,
+        isDirectChat: false,
+        isEncrypted: false,
+        isSpace: isSpace,
+        notificationCount: 0,
+        highlightCount: 0,
+        typingDisplayNames: const [],
+        pinnedEventIds: const [],
+        spaceChildCount: 0,
+        isFavourite: false,
+        lastEventPreview: '',
+        lastEventIsThreadReply: false,
+      );
+
+  Widget buildTestWidget({
+    required KoheraRoomSummary summary,
+    required Future<void> Function() onAccept,
+    required Future<void> Function() onDecline,
+    String? inviterName = 'Alice',
+  }) {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider<MatrixService>.value(value: mockMatrix),
-        ChangeNotifierProvider<SelectionService>.value(value: selectionService),
       ],
       child: MaterialApp(
         theme: ThemeData(splashFactory: InkRipple.splashFactory),
@@ -63,7 +57,14 @@ void main() {
           body: Builder(
             builder: (context) => Center(
               child: ElevatedButton(
-                onPressed: () => InviteDialog.show(context, room: mockRoom),
+                onPressed: () => InviteDialog.show(
+                  context,
+                  roomId: summary.roomId,
+                  summary: summary,
+                  inviterName: inviterName,
+                  onAccept: onAccept,
+                  onDecline: onDecline,
+                ),
                 child: const Text('Open'),
               ),
             ),
@@ -73,15 +74,33 @@ void main() {
     );
   }
 
-  Future<void> openDialog(WidgetTester tester) async {
-    await tester.pumpWidget(buildTestWidget());
+  Future<void> openDialog(
+    WidgetTester tester, {
+    required KoheraRoomSummary summary,
+    required Future<void> Function() onAccept,
+    required Future<void> Function() onDecline,
+    String? inviterName = 'Alice',
+  }) async {
+    await tester.pumpWidget(
+      buildTestWidget(
+        summary: summary,
+        inviterName: inviterName,
+        onAccept: onAccept,
+        onDecline: onDecline,
+      ),
+    );
     await tester.tap(find.text('Open'));
     await tester.pumpAndSettle();
   }
 
   group('InviteDialog', () {
     testWidgets('shows room name and inviter', (tester) async {
-      await openDialog(tester);
+      await openDialog(
+        tester,
+        summary: makeSummary(),
+        onAccept: () async {},
+        onDecline: () async {},
+      );
 
       expect(find.text('Room invite'), findsOneWidget);
       expect(find.text('Test Room'), findsOneWidget);
@@ -89,73 +108,102 @@ void main() {
     });
 
     testWidgets('shows "Space invite" title for spaces', (tester) async {
-      when(mockRoom.isSpace).thenReturn(true);
-      await openDialog(tester);
+      await openDialog(
+        tester,
+        summary: makeSummary(isSpace: true),
+        onAccept: () async {},
+        onDecline: () async {},
+      );
 
       expect(find.text('Space invite'), findsOneWidget);
     });
 
-    testWidgets('accept calls join and closes dialog', (tester) async {
-      when(mockRoom.join()).thenAnswer((_) async => '');
-      await openDialog(tester);
+    testWidgets('accept calls onAccept and closes dialog', (tester) async {
+      var accepted = false;
+      await openDialog(
+        tester,
+        summary: makeSummary(),
+        onAccept: () async {
+          accepted = true;
+        },
+        onDecline: () async {},
+      );
 
       await tester.tap(find.text('Accept'));
       await tester.pumpAndSettle();
 
-      verify(mockRoom.join()).called(1);
-      // Dialog should be closed
+      expect(accepted, isTrue);
       expect(find.text('Room invite'), findsNothing);
     });
 
     testWidgets('accept shows error on failure', (tester) async {
-      when(mockRoom.join()).thenThrow(Exception('Server error'));
-      await openDialog(tester);
+      await openDialog(
+        tester,
+        summary: makeSummary(),
+        onAccept: () async => throw Exception('Server error'),
+        onDecline: () async {},
+      );
 
       await tester.tap(find.text('Accept'));
       await tester.pumpAndSettle();
 
-      // Dialog should still be open with error
       expect(find.text('Room invite'), findsOneWidget);
       expect(find.textContaining('Server error'), findsOneWidget);
     });
 
-    testWidgets('decline shows confirmation then calls leave', (tester) async {
-      when(mockRoom.leave()).thenAnswer((_) async {});
-      await openDialog(tester);
+    testWidgets('decline shows confirmation then calls onDecline',
+        (tester) async {
+      var declined = false;
+      await openDialog(
+        tester,
+        summary: makeSummary(),
+        onAccept: () async {},
+        onDecline: () async {
+          declined = true;
+        },
+      );
 
       await tester.tap(find.text('Decline'));
       await tester.pumpAndSettle();
 
-      // Confirmation dialog should appear
       expect(find.text('Decline invite'), findsOneWidget);
       expect(find.text('Decline invite to Test Room?'), findsOneWidget);
 
       await tester.tap(find.widgetWithText(FilledButton, 'Decline'));
       await tester.pumpAndSettle();
 
-      verify(mockRoom.leave()).called(1);
-      // Both dialogs should be closed
+      expect(declined, isTrue);
       expect(find.text('Room invite'), findsNothing);
     });
 
     testWidgets('decline cancellation keeps dialog open', (tester) async {
-      await openDialog(tester);
+      var declined = false;
+      await openDialog(
+        tester,
+        summary: makeSummary(),
+        onAccept: () async {},
+        onDecline: () async {
+          declined = true;
+        },
+      );
 
       await tester.tap(find.text('Decline'));
       await tester.pumpAndSettle();
 
-      // Cancel the confirmation
       await tester.tap(find.text('Cancel'));
       await tester.pumpAndSettle();
 
-      // Original dialog should still be open
       expect(find.text('Room invite'), findsOneWidget);
-      verifyNever(mockRoom.leave());
+      expect(declined, isFalse);
     });
 
     testWidgets('decline shows error on failure', (tester) async {
-      when(mockRoom.leave()).thenThrow(Exception('Network error'));
-      await openDialog(tester);
+      await openDialog(
+        tester,
+        summary: makeSummary(),
+        onAccept: () async {},
+        onDecline: () async => throw Exception('Network error'),
+      );
 
       await tester.tap(find.text('Decline'));
       await tester.pumpAndSettle();
@@ -163,31 +211,38 @@ void main() {
       await tester.tap(find.widgetWithText(FilledButton, 'Decline'));
       await tester.pumpAndSettle();
 
-      // Dialog should still be open with error
       expect(find.text('Room invite'), findsOneWidget);
       expect(find.textContaining('Network error'), findsOneWidget);
     });
 
     testWidgets('buttons are disabled during accept', (tester) async {
-      final completer = Completer<String>();
-      when(mockRoom.join()).thenAnswer((_) => completer.future);
-      await openDialog(tester);
+      final completer = Completer<void>();
+      await openDialog(
+        tester,
+        summary: makeSummary(),
+        onAccept: () => completer.future,
+        onDecline: () async {},
+      );
 
       await tester.tap(find.text('Accept'));
       await tester.pump();
 
-      // Progress indicator should show
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
-      // Decline button should be disabled
       final declineButton = tester.widget<TextButton>(
         find.widgetWithText(TextButton, 'Decline'),
       );
       expect(declineButton.onPressed, isNull);
 
-      // Complete the future to avoid pending timers
-      completer.complete('');
+      completer.complete();
       await tester.pumpAndSettle();
     });
   });
+}
+
+class _NullAvatarResolver implements AvatarResolver {
+  const _NullAvatarResolver();
+  @override
+  Future<AvatarThumbnail?> resolve(String? mxc, {required double size}) async =>
+      null;
 }

--- a/test/widgets/invite_user_dialog_test.dart
+++ b/test/widgets/invite_user_dialog_test.dart
@@ -1,40 +1,32 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/features/rooms/widgets/invite_user_dialog.dart';
-import 'package:matrix/matrix.dart';
-import 'package:mockito/annotations.dart';
-import 'package:mockito/mockito.dart';
+import 'package:kohera/shared/models/kohera_user_summary.dart';
 
-@GenerateNiceMocks([MockSpec<Room>(), MockSpec<Client>(), MockSpec<User>()])
-import 'invite_user_dialog_test.mocks.dart';
+InviteUserDialogParams _params({
+  Set<String> existingMemberIds = const {},
+  List<KoheraUserSummary> knownContacts = const [],
+  List<KoheraUserSummary> roomContacts = const [],
+  Future<List<KoheraUserSummary>> Function(String query)? onSearchUserDirectory,
+}) =>
+    InviteUserDialogParams(
+      roomId: '!room:example.com',
+      existingMemberIds: existingMemberIds,
+      knownContacts: knownContacts,
+      roomContacts: roomContacts,
+      onSearchUserDirectory: onSearchUserDirectory ?? (_) async => const [],
+    );
 
-MockRoom _makeGroupRoom(List<MockUser> participants, {int memberCount = 0}) {
-  final room = MockRoom();
-  when(room.isDirectChat).thenReturn(false);
-  when(room.getParticipants()).thenReturn(participants);
-  when(room.summary).thenReturn(RoomSummary.fromJson({
-    'm.joined_member_count': memberCount,
-    'm.invited_member_count': 0,
-  }),);
-  return room;
-}
-
-MockUser _makeUser(String id, {String? displayName}) {
-  final user = MockUser();
-  when(user.id).thenReturn(id);
-  when(user.displayName).thenReturn(displayName);
-  when(user.avatarUrl).thenReturn(null);
-  return user;
-}
+KoheraUserSummary _user(String id, {String? displayName}) => KoheraUserSummary(
+      userId: id,
+      displayname: displayName ?? id,
+    );
 
 void main() {
-  late MockRoom mockRoom;
-
-  setUp(() {
-    mockRoom = MockRoom();
-  });
-
-  Widget buildTestWidget({ValueChanged<String?>? onResult}) {
+  Widget buildTestWidget(
+    InviteUserDialogParams params, {
+    ValueChanged<String?>? onResult,
+  }) {
     return MaterialApp(
       theme: ThemeData(splashFactory: InkRipple.splashFactory),
       home: Scaffold(
@@ -43,7 +35,7 @@ void main() {
             child: ElevatedButton(
               onPressed: () async {
                 final result =
-                    await InviteUserDialog.show(context, room: mockRoom);
+                    await InviteUserDialog.show(context, params: params);
                 onResult?.call(result);
               },
               child: const Text('Open'),
@@ -55,17 +47,18 @@ void main() {
   }
 
   Future<void> openDialog(
-    WidgetTester tester, {
+    WidgetTester tester,
+    InviteUserDialogParams params, {
     ValueChanged<String?>? onResult,
   }) async {
-    await tester.pumpWidget(buildTestWidget(onResult: onResult));
+    await tester.pumpWidget(buildTestWidget(params, onResult: onResult));
     await tester.tap(find.text('Open'));
     await tester.pumpAndSettle();
   }
 
   group('InviteUserDialog', () {
     testWidgets('shows title and text field', (tester) async {
-      await openDialog(tester);
+      await openDialog(tester, _params());
 
       expect(find.text('Invite user'), findsOneWidget);
       expect(find.byType(TextField), findsOneWidget);
@@ -74,7 +67,7 @@ void main() {
     });
 
     testWidgets('empty input shows validation error', (tester) async {
-      await openDialog(tester);
+      await openDialog(tester, _params());
 
       await tester.tap(find.text('Invite'));
       await tester.pumpAndSettle();
@@ -83,7 +76,7 @@ void main() {
     });
 
     testWidgets('invalid format shows error', (tester) async {
-      await openDialog(tester);
+      await openDialog(tester, _params());
 
       await tester.enterText(find.byType(TextField), 'alice');
       await tester.tap(find.text('Invite'));
@@ -96,7 +89,7 @@ void main() {
     });
 
     testWidgets('@alice without server shows error', (tester) async {
-      await openDialog(tester);
+      await openDialog(tester, _params());
 
       await tester.enterText(find.byType(TextField), '@alice');
       await tester.tap(find.text('Invite'));
@@ -109,7 +102,7 @@ void main() {
     });
 
     testWidgets('alice@server (missing @) shows error', (tester) async {
-      await openDialog(tester);
+      await openDialog(tester, _params());
 
       await tester.enterText(find.byType(TextField), 'alice@server');
       await tester.tap(find.text('Invite'));
@@ -124,12 +117,11 @@ void main() {
     testWidgets('valid MXID pops dialog with value', (tester) async {
       String? result;
 
-      // Suppress controller-disposed errors from whenComplete in show()
       final original = FlutterError.onError;
       FlutterError.onError = (d) {};
       addTearDown(() => FlutterError.onError = original);
 
-      await openDialog(tester, onResult: (v) => result = v);
+      await openDialog(tester, _params(), onResult: (v) => result = v);
 
       await tester.enterText(find.byType(TextField), '@alice:matrix.org');
       await tester.tap(find.text('Invite'));
@@ -146,7 +138,7 @@ void main() {
       FlutterError.onError = (d) {};
       addTearDown(() => FlutterError.onError = original);
 
-      await openDialog(tester, onResult: (v) => result = v);
+      await openDialog(tester, _params(), onResult: (v) => result = v);
 
       await tester.tap(find.text('Cancel'));
       await tester.pump();
@@ -160,7 +152,7 @@ void main() {
       FlutterError.onError = (d) {};
       addTearDown(() => FlutterError.onError = original);
 
-      await openDialog(tester);
+      await openDialog(tester, _params());
 
       await tester.enterText(find.byType(TextField), '');
       await tester.testTextInput.receiveAction(TextInputAction.done);
@@ -172,16 +164,12 @@ void main() {
     group('room contact suggestions', () {
       testWidgets('shows member from another room when not in current room',
           (tester) async {
-        final client = MockClient();
-        final alice = _makeUser('@alice:example.com', displayName: 'Alice');
-        final otherRoom = _makeGroupRoom([alice], memberCount: 1);
-
-        when(mockRoom.client).thenReturn(client);
-        when(mockRoom.getParticipants()).thenReturn([]);
-        when(client.userID).thenReturn('@me:example.com');
-        when(client.rooms).thenReturn([otherRoom]);
-
-        await openDialog(tester);
+        await openDialog(
+          tester,
+          _params(
+            roomContacts: [_user('@alice:example.com', displayName: 'Alice')],
+          ),
+        );
 
         expect(find.text('From other rooms'), findsOneWidget);
         expect(find.text('Alice'), findsOneWidget);
@@ -189,19 +177,34 @@ void main() {
 
       testWidgets('does not show current room members in suggestions',
           (tester) async {
-        final client = MockClient();
-        final alice = _makeUser('@alice:example.com', displayName: 'Alice');
-        final otherRoom = _makeGroupRoom([alice], memberCount: 1);
-
-        when(mockRoom.client).thenReturn(client);
-        when(mockRoom.getParticipants()).thenReturn([alice]);
-        when(client.userID).thenReturn('@me:example.com');
-        when(client.rooms).thenReturn([otherRoom]);
-
-        await openDialog(tester);
+        await openDialog(
+          tester,
+          _params(
+            existingMemberIds: {'@alice:example.com'},
+            roomContacts: [_user('@alice:example.com', displayName: 'Alice')],
+          ),
+        );
 
         expect(find.text('From other rooms'), findsNothing);
         expect(find.text('Alice'), findsNothing);
+      });
+
+      testWidgets('search invokes onSearchUserDirectory and shows results',
+          (tester) async {
+        await openDialog(
+          tester,
+          _params(
+            onSearchUserDirectory: (q) async =>
+                [_user('@bob:example.com', displayName: 'Bob')],
+          ),
+        );
+
+        await tester.enterText(find.byType(TextField), 'bob');
+        // Debounce is 400ms.
+        await tester.pump(const Duration(milliseconds: 500));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Bob'), findsOneWidget);
       });
     });
   });

--- a/test/widgets/room_details_panel_test.dart
+++ b/test/widgets/room_details_panel_test.dart
@@ -5,6 +5,7 @@ import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/services/sub_services/space_access_service.dart';
 import 'package:kohera/features/rooms/widgets/room_details_panel.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/annotations.dart';
@@ -67,6 +68,8 @@ void main() {
     when(mockClient.rooms).thenReturn([]);
     selectionService = SelectionService(client: mockClient);
     when(mockMatrixService.selection).thenReturn(selectionService);
+    when(mockMatrixService.avatarResolver)
+        .thenReturn(const _NullAvatarResolver());
   });
 
   Widget buildTestWidget({bool isFullPage = false}) {
@@ -309,4 +312,11 @@ void main() {
       expect(find.text('DEVICE1'), findsOneWidget);
     });
   });
+}
+
+class _NullAvatarResolver implements AvatarResolver {
+  const _NullAvatarResolver();
+  @override
+  Future<AvatarThumbnail?> resolve(String? mxc, {required double size}) async =>
+      null;
 }

--- a/test/widgets/space_details_panel_test.dart
+++ b/test/widgets/space_details_panel_test.dart
@@ -5,6 +5,7 @@ import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/services/sub_services/space_access_service.dart';
 import 'package:kohera/features/spaces/widgets/space_details_panel.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/annotations.dart';
@@ -39,6 +40,8 @@ void main() {
     when(mockMatrixService.client).thenReturn(mockClient);
     when(mockMatrixService.spaceAccess).thenReturn(mockAccess);
     when(mockMatrixService.selection).thenReturn(selection);
+    when(mockMatrixService.avatarResolver)
+        .thenReturn(const _NullAvatarResolver());
     when(mockAccess.getJoinMode(mockSpace)).thenReturn(JoinMode.invite);
     when(mockAccess.allowedSpaceIds(mockSpace)).thenReturn(const []);
     when(mockAccess.needsUpgradeForRestricted(
@@ -213,4 +216,11 @@ void main() {
       expect(find.text('You will leave "Test Space".'), findsOneWidget);
     });
   });
+}
+
+class _NullAvatarResolver implements AvatarResolver {
+  const _NullAvatarResolver();
+  @override
+  Future<AvatarThumbnail?> resolve(String? mxc, {required double size}) async =>
+      null;
 }


### PR DESCRIPTION
## Summary

Eliminates `matrix_sdk.Room` from the 7 action-oriented widget dialogs listed in #708. Each dialog now takes `roomId`/`spaceId` + SDK-free display models + parent-supplied callbacks, and none imports `package:matrix/matrix.dart`.

## Approach

- **Parent-provided callbacks over a new service** — `MatrixService` has no room-action methods today, and the issue emphasizes callbacks. Callers retain `Room` access and supply closures for join/invite/add/create/avatar actions.
- **`JoinAccessSection.refs()` overload** — a SDK-free `List<SpaceRef>` variant (`typedef SpaceRef = ({String id, String displayname})`) was added alongside the existing Room constructor, which stays 100% identical (still `const`). Existing consumers (`join_access_controller`, `new_room_dialog`) are untouched.
- **`CreateSubspaceDialog`** extracts the SDK create flow into a testable `createSubspace` / `loadSubspaceCapabilities` helper (`create_subspace_action.dart`, matrix-using). The dialog keeps its join-mode UI via `.refs()`.
- **`RoomDetailsPanel`** introduces `RoomDetailsController` (a `ChangeNotifier` owning the `Room`) as the sole matrix import boundary. It exposes summary/permissions/member list/device keys + action callbacks and builds the 3 still-Room-typed child widgets (`JoinAccessController`, `SharedMediaSection`, member sheet) which are out of #708's scope. The panel's external API (router/wide_layout) is unchanged.
- New SDK-free DTOs: `KoheraPushRuleState` enum, `KoheraDeviceKey`, plus `KoheraRoomMemberList` inside `kohera_room_member.dart`. `KoheraRoomSummary` / `KoheraUserSummary` are reused as-is.

## The 7 files (verified: no `^import 'package:matrix/matrix.dart'`)

- `lib/features/rooms/widgets/invite_dialog.dart`
- `lib/features/rooms/widgets/invite_user_dialog.dart`
- `lib/features/rooms/widgets/add_existing_rooms_dialog.dart`
- `lib/features/rooms/widgets/add_room_to_space_dialog.dart`
- `lib/features/spaces/widgets/create_subspace_dialog.dart`
- `lib/shared/widgets/avatar_edit_overlay.dart`
- `lib/features/rooms/widgets/room_details_panel.dart`

## New matrix-using helper files (kept minimal, parent-side)

- `lib/features/rooms/widgets/invite_user_dialog_params.dart` — `inviteUserDialogParams(Room)`
- `lib/features/spaces/widgets/create_subspace_action.dart` — `createSubspace(...)` / `loadSubspaceCapabilities(...)`
- `lib/features/rooms/services/room_details_controller.dart` — the boundary for `room_details_panel.dart`

## Follow-up simplifications (commit 2)

- Replaced nested ternary in `_buildDeviceKeyTile` with if/else
- Removed unused `tt` param from `_buildActionsRow` and unused local in `resolveMemberCount`
- Collapsed duplicated try/catch `setState` in `_runSearch`; map/addAll over imperative loops
- Removed dead `size` test helper param

## Verification

- `flutter analyze` — no issues
- 122 affected widget tests pass
- `grep "^import 'package:matrix/matrix.dart"` returns 0 for all 7 target files; no `Room` params on any of them

## Out of scope / future

`RoomDetailsController` still holds a `Room` and builds `JoinAccessController`/`SharedMediaSection`/the member sheet (all still take `Room`). The #697/#707 service layer can later absorb the remaining client access (device-key verification, etc.).

Closes #708