### PR TITLE
refactor(#709): wrap StickerPack in KoheraStickerPack for sticker settings screen

### DIFF
--- a/lib/core/models/sticker_pack.dart
+++ b/lib/core/models/sticker_pack.dart
@@ -9,6 +9,8 @@ class PackImage {
     required this.isEmoji,
     this.body,
     this.emoji,
+    this.width,
+    this.height,
   });
 
   final String shortcode;
@@ -21,6 +23,14 @@ class PackImage {
   /// the image renders as a local OpenMoji asset and inserts this grapheme;
   /// when null it is a remote (mxc/http) custom emoji.
   final String? emoji;
+
+  /// Native image width in pixels, or `null` when the source pack content
+  /// carries no `info.w`. Extracted from the MSC2545 image `info` map.
+  final int? width;
+
+  /// Native image height in pixels, or `null` when the source pack content
+  /// carries no `info.h`. Extracted from the MSC2545 image `info` map.
+  final int? height;
 
   String get altText => body ?? ':$shortcode:';
 }
@@ -76,12 +86,19 @@ class StickerPack {
 
       if (!isSticker && !isEmoji) continue;
 
+      // Extract native dimensions from the MSC2545 image `info` map.
+      final info = entry.value.info;
+      final width = info == null ? null : _toInt(info['w']);
+      final height = info == null ? null : _toInt(info['h']);
+
       final image = PackImage(
         shortcode: entry.key,
         url: entry.value.url,
         body: entry.value.body,
         isSticker: isSticker,
         isEmoji: isEmoji,
+        width: width,
+        height: height,
       );
       if (isSticker) stickers.add(image);
       if (isEmoji) emoji.add(image);
@@ -101,5 +118,12 @@ class StickerPack {
       stickers: stickers,
       emoji: emoji,
     );
+  }
+
+  /// Safely coerces an MSC2545 `info` dimension value to [int].
+  static int? _toInt(Object? value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    return null;
   }
 }

--- a/lib/core/services/sticker_pack_service.dart
+++ b/lib/core/services/sticker_pack_service.dart
@@ -5,6 +5,8 @@ import 'package:kohera/core/models/emoji_gg_pack.dart';
 import 'package:kohera/core/models/sticker_pack.dart';
 import 'package:kohera/core/services/emoji_gg_service.dart';
 import 'package:kohera/core/utils/openmoji_catalog.dart';
+import 'package:kohera/features/settings/models/kohera_sticker_pack.dart';
+import 'package:kohera/features/settings/models/kohera_sticker_pack_mapper.dart';
 import 'package:matrix/matrix.dart';
 
 class ImportProgress {
@@ -46,6 +48,25 @@ class StickerPackService extends ChangeNotifier {
 
   /// The built-in OpenMoji emoji pack, or null until the catalog has loaded.
   StickerPack? get openMojiPack => _openMojiPack;
+
+  // ── Kohera domain-model getters (SDK-free) ─────────────────────
+
+  /// Account packs (personal + imported + subscribed) as SDK-free
+  /// [KoheraStickerPack]s, all marked installed.
+  List<KoheraStickerPack> get koheraAccountPacks =>
+      accountPacks.map((p) => toKoheraStickerPack(p, isInstalled: true)).toList();
+
+  /// The built-in OpenMoji pack as an SDK-free [KoheraStickerPack], or null
+  /// until the catalog has loaded. Marked installed (always available).
+  KoheraStickerPack? get koheraOpenMojiPack {
+    final p = _openMojiPack;
+    return p == null ? null : toKoheraStickerPack(p, isInstalled: true);
+  }
+
+  /// Room/space packs from joined rooms not yet subscribed at account level,
+  /// as SDK-free [KoheraStickerPack]s marked not installed.
+  List<KoheraStickerPack> koheraAvailableRoomPacks() =>
+      availableRoomPacks().map((p) => toKoheraStickerPack(p, isInstalled: false)).toList();
 
   Future<void> _loadOpenMojiPack() async {
     try {

--- a/lib/features/settings/models/kohera_sticker_pack.dart
+++ b/lib/features/settings/models/kohera_sticker_pack.dart
@@ -1,0 +1,83 @@
+/// A single image entry within a sticker/emoji pack.
+///
+/// SDK-free representation of a pack image. The [mxcUrl] is the raw `mxc://`
+/// URI as a string; [width]/[height] are the native image dimensions when
+/// available from the source pack content (otherwise `null`).
+class KoheraSticker {
+  const KoheraSticker({
+    required this.shortCode,
+    required this.mxcUrl,
+    this.width,
+    this.height,
+  });
+
+  /// The shortcode (without surrounding colons), e.g. `wave`.
+  final String shortCode;
+
+  /// The `mxc://` (or `openmoji://` for built-in) media URI as a string.
+  final String mxcUrl;
+
+  /// Native image width in pixels, or `null` when the source has no `info`.
+  final int? width;
+
+  /// Native image height in pixels, or `null` when the source has no `info`.
+  final int? height;
+
+  String get altText => ':$shortCode:';
+}
+
+/// A resolved, UI-ready sticker/emoji pack with no Matrix SDK dependency.
+///
+/// This is the Kohera-owned domain model consumed by the sticker settings
+/// screen. Conversion from the SDK-coupled [StickerPack] (which imports
+/// `package:matrix/matrix.dart`) happens inside [StickerPackService] via
+/// [toKoheraStickerPack] — the screen only ever sees this SDK-free type.
+class KoheraStickerPack {
+  const KoheraStickerPack({
+    required this.id,
+    required this.name,
+    required this.displayName,
+    required this.iconUrl,
+    required this.isInstalled,
+    required this.stickers,
+    required this.emoji,
+  });
+
+  /// Stable identifier. For the user's own pack: `im.ponies.user_emotes`.
+  /// For room/space packs: the room id. For emoji.gg imports: `emojigg_<id>`.
+  /// For the built-in pack: `openmoji_builtin`.
+  final String id;
+
+  /// The machine/identifier name of the pack. Today this mirrors [id]; it is
+  /// reserved for the MSC2545 state-key distinction if pack sourcing is
+  /// generalized later (packs may share a room but differ by state key).
+  final String name;
+
+  /// Human-readable display name shown in the UI.
+  final String displayName;
+
+  /// The pack icon `mxc://` URI as a string, or `null` when the pack has no
+  /// avatar. Already filtered to `mxc` scheme at the conversion boundary.
+  final String? iconUrl;
+
+  /// Whether the pack is installed/subscribed for the current account.
+  /// `true` for account packs (personal/imported/subscribed) and the built-in
+  /// OpenMoji pack; `false` for packs merely available from joined rooms.
+  final bool isInstalled;
+
+  /// Sticker images in the pack (rendered at a larger size).
+  final List<KoheraSticker> stickers;
+
+  /// Emoji images in the pack (rendered inline at a smaller size).
+  ///
+  /// This list is beyond the issue #709 literal field spec, which lists only
+  /// `stickers`. It is included because the sticker settings screen renders a
+  /// subtitle of "X stickers, Y emoji" from `stickers.length`/`emoji.length`,
+  /// and changing the management UI is explicitly out of scope. Each entry is
+  /// the same [KoheraSticker] shape; no SDK type is involved.
+  final List<KoheraSticker> emoji;
+
+  bool get isEmpty => stickers.isEmpty && emoji.isEmpty;
+  int get stickerCount => stickers.length;
+  int get emojiCount => emoji.length;
+}

--- a/lib/features/settings/models/kohera_sticker_pack_mapper.dart
+++ b/lib/features/settings/models/kohera_sticker_pack_mapper.dart
@@ -1,0 +1,33 @@
+import 'package:kohera/core/models/sticker_pack.dart';
+import 'package:kohera/features/settings/models/kohera_sticker_pack.dart';
+
+/// Converts an SDK-coupled [StickerPack] into a UI-ready, SDK-free
+/// [KoheraStickerPack].
+///
+/// This mapper is the conversion boundary: it is the only place that imports
+/// both the SDK-coupled `StickerPack` and the SDK-free `KoheraStickerPack`.
+/// [StickerPackService] calls it internally and exposes only `KoheraStickerPack`
+/// to the sticker settings screen, so the screen never touches a Matrix SDK
+/// type.
+///
+/// [isInstalled] is supplied by the service depending on the pack's source:
+/// `true` for account packs (personal/imported/subscribed) and the built-in
+/// OpenMoji pack, `false` for packs merely available from joined rooms.
+KoheraStickerPack toKoheraStickerPack(StickerPack pack, {required bool isInstalled}) {
+  return KoheraStickerPack(
+    id: pack.id,
+    name: pack.id,
+    displayName: pack.displayName,
+    iconUrl: pack.avatarUrl?.toString(),
+    isInstalled: isInstalled,
+    stickers: pack.stickers.map(_toKoheraSticker).toList(),
+    emoji: pack.emoji.map(_toKoheraSticker).toList(),
+  );
+}
+
+KoheraSticker _toKoheraSticker(PackImage img) => KoheraSticker(
+      shortCode: img.shortcode,
+      mxcUrl: img.url.toString(),
+      width: img.width,
+      height: img.height,
+    );

--- a/lib/features/settings/screens/sticker_packs_screen.dart
+++ b/lib/features/settings/screens/sticker_packs_screen.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:kohera/core/models/sticker_pack.dart';
 import 'package:kohera/core/routing/nav_helper.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sticker_pack_service.dart';
+import 'package:kohera/features/settings/models/kohera_sticker_pack.dart';
 import 'package:kohera/shared/services/media_resolver.dart';
 import 'package:kohera/shared/widgets/mxc_image.dart';
 import 'package:provider/provider.dart';
@@ -29,8 +29,8 @@ class StickerPacksScreen extends StatelessWidget {
       ),
       body: Consumer<StickerPackService>(
         builder: (context, service, _) {
-          final accountPacks = service.accountPacks;
-          final availablePacks = service.availableRoomPacks();
+          final accountPacks = service.koheraAccountPacks;
+          final availablePacks = service.koheraAvailableRoomPacks();
 
           final personalPack = accountPacks.where((p) => p.id == _kPersonalPackId).firstOrNull;
           final importedPacks = accountPacks.where((p) => p.id.startsWith('emojigg_')).toList();
@@ -39,7 +39,7 @@ class StickerPacksScreen extends StatelessWidget {
                 (p) => p.id != _kPersonalPackId && !p.id.startsWith('emojigg_'),
               )
               .toList();
-          final openMojiPack = service.openMojiPack;
+          final openMojiPack = service.koheraOpenMojiPack;
           final myPackCount = accountPacks.length + (openMojiPack != null ? 1 : 0);
 
           return ListView(
@@ -188,7 +188,7 @@ class _ReorderablePackList extends StatelessWidget {
     required this.hasLeadingPack,
   });
 
-  final List<StickerPack> packs;
+  final List<KoheraStickerPack> packs;
   final MediaResolver mediaResolver;
   final StickerPackService service;
   final bool hasLeadingPack;
@@ -244,7 +244,7 @@ class _PackTile extends StatelessWidget {
     this.trailing,
   });
 
-  final StickerPack pack;
+  final KoheraStickerPack pack;
   final MediaResolver mediaResolver;
   final Widget? leading;
   final Widget? trailing;
@@ -287,18 +287,18 @@ class _PackTile extends StatelessWidget {
 class _PackAvatar extends StatelessWidget {
   const _PackAvatar({required this.pack, required this.mediaResolver});
 
-  final StickerPack pack;
+  final KoheraStickerPack pack;
   final MediaResolver mediaResolver;
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
 
-    if (pack.avatarUrl != null) {
+    if (pack.iconUrl != null) {
       return ClipRRect(
         borderRadius: BorderRadius.circular(8),
         child: MxcImage(
-          mxcUrl: pack.avatarUrl.toString(),
+          mxcUrl: pack.iconUrl!,
           mediaResolver: mediaResolver,
           width: 40,
           height: 40,

--- a/test/features/settings/models/kohera_sticker_pack_mapper_test.dart
+++ b/test/features/settings/models/kohera_sticker_pack_mapper_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/models/sticker_pack.dart';
+import 'package:kohera/features/settings/models/kohera_sticker_pack_mapper.dart';
+
+void main() {
+  group('toKoheraStickerPack', () {
+    final source = StickerPack(
+      id: 'im.ponies.user_emotes',
+      displayName: 'My Emotes',
+      avatarUrl: Uri.parse('mxc://example.com/avatar123'),
+      stickers: [
+        PackImage(
+          shortcode: 'wave',
+          url: Uri.parse('mxc://example.com/wave'),
+          body: 'Wave sticker',
+          isSticker: true,
+          isEmoji: false,
+          width: 256,
+          height: 256,
+        ),
+      ],
+      emoji: [
+        PackImage(
+          shortcode: 'smile',
+          url: Uri.parse('mxc://example.com/smile'),
+          body: 'Smile emoji',
+          isSticker: false,
+          isEmoji: true,
+        ),
+      ],
+    );
+
+    test('maps id, name (=id), displayName', () {
+      final kohera = toKoheraStickerPack(source, isInstalled: true);
+      expect(kohera.id, 'im.ponies.user_emotes');
+      expect(kohera.name, 'im.ponies.user_emotes');
+      expect(kohera.displayName, 'My Emotes');
+    });
+
+    test('converts avatarUrl Uri to iconUrl string', () {
+      final kohera = toKoheraStickerPack(source, isInstalled: true);
+      expect(kohera.iconUrl, 'mxc://example.com/avatar123');
+    });
+
+    test('iconUrl is null when source has no avatar', () {
+      const noAvatar = StickerPack(
+        id: 'p',
+        displayName: 'No Avatar',
+        stickers: [],
+        emoji: [],
+      );
+      expect(toKoheraStickerPack(noAvatar, isInstalled: true).iconUrl, isNull);
+    });
+
+    test('sets isInstalled from the parameter', () {
+      expect(toKoheraStickerPack(source, isInstalled: true).isInstalled, isTrue);
+      expect(toKoheraStickerPack(source, isInstalled: false).isInstalled, isFalse);
+    });
+
+    test('maps stickers and emoji to KoheraSticker with url string + dims', () {
+      final kohera = toKoheraStickerPack(source, isInstalled: true);
+      expect(kohera.stickers, hasLength(1));
+      expect(kohera.stickers.first.shortCode, 'wave');
+      expect(kohera.stickers.first.mxcUrl, 'mxc://example.com/wave');
+      expect(kohera.stickers.first.width, 256);
+      expect(kohera.stickers.first.height, 256);
+
+      expect(kohera.emoji, hasLength(1));
+      expect(kohera.emoji.first.shortCode, 'smile');
+      expect(kohera.emoji.first.mxcUrl, 'mxc://example.com/smile');
+      // Emoji had no info → dimensions null.
+      expect(kohera.emoji.first.width, isNull);
+      expect(kohera.emoji.first.height, isNull);
+    });
+
+    test('preserves counts used by the settings subtitle', () {
+      final kohera = toKoheraStickerPack(source, isInstalled: true);
+      expect(kohera.stickerCount, 1);
+      expect(kohera.emojiCount, 1);
+      expect(kohera.isEmpty, isFalse);
+    });
+  });
+
+  group('StickerPack.fromContent dimension extraction', () {
+    test('extracts width/height from image info', () {
+      final pack = StickerPack.fromContent(
+        id: 'test',
+        content: {
+          'pack': {'display_name': 'Dim Pack'},
+          'images': {
+            'big': {
+              'url': 'mxc://example.com/big',
+              'info': {'w': 512, 'h': 384},
+            },
+            'small': {
+              'url': 'mxc://example.com/small',
+            },
+          },
+        },
+      )!;
+
+      final big = pack.allImages.firstWhere((i) => i.shortcode == 'big');
+      expect(big.width, 512);
+      expect(big.height, 384);
+
+      final small = pack.allImages.firstWhere((i) => i.shortcode == 'small');
+      expect(small.width, isNull);
+      expect(small.height, isNull);
+    });
+
+    test('coerces numeric (non-int) dimension values to int', () {
+      final pack = StickerPack.fromContent(
+        id: 'test',
+        content: {
+          'pack': {'display_name': 'Num Pack'},
+          'images': {
+            'x': {
+              'url': 'mxc://example.com/x',
+              'info': {'w': 200.0, 'h': 100.5},
+            },
+          },
+        },
+      )!;
+      final img = pack.stickers.first;
+      expect(img.width, 200);
+      expect(img.height, 100);
+    });
+  });
+}

--- a/test/features/settings/models/kohera_sticker_pack_test.dart
+++ b/test/features/settings/models/kohera_sticker_pack_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/features/settings/models/kohera_sticker_pack.dart';
+
+void main() {
+  group('KoheraSticker', () {
+    test('stores shortcode, mxcUrl and optional dimensions', () {
+      const sticker = KoheraSticker(shortCode: 'wave', mxcUrl: 'mxc://x/wave');
+      expect(sticker.shortCode, 'wave');
+      expect(sticker.mxcUrl, 'mxc://x/wave');
+      expect(sticker.width, isNull);
+      expect(sticker.height, isNull);
+      expect(sticker.altText, ':wave:');
+    });
+
+    test('carries native dimensions when provided', () {
+      const sticker = KoheraSticker(
+        shortCode: 'blob',
+        mxcUrl: 'mxc://x/blob',
+        width: 256,
+        height: 256,
+      );
+      expect(sticker.width, 256);
+      expect(sticker.height, 256);
+    });
+  });
+
+  group('KoheraStickerPack', () {
+    const pack = KoheraStickerPack(
+      id: 'im.ponies.user_emotes',
+      name: 'im.ponies.user_emotes',
+      displayName: 'My Pack',
+      iconUrl: 'mxc://example.com/avatar',
+      isInstalled: true,
+      stickers: [
+        KoheraSticker(shortCode: 'wave', mxcUrl: 'mxc://x/wave'),
+        KoheraSticker(shortCode: 'party', mxcUrl: 'mxc://x/party'),
+      ],
+      emoji: [KoheraSticker(shortCode: 'smile', mxcUrl: 'mxc://x/smile')],
+    );
+
+    test('exposes sticker/emoji counts', () {
+      expect(pack.stickerCount, 2);
+      expect(pack.emojiCount, 1);
+    });
+
+    test('isEmpty is false when any image is present', () {
+      expect(pack.isEmpty, isFalse);
+    });
+
+    test('isEmpty is true for an empty pack', () {
+      const empty = KoheraStickerPack(
+        id: 'empty',
+        name: 'empty',
+        displayName: 'Empty',
+        iconUrl: null,
+        isInstalled: false,
+        stickers: [],
+        emoji: [],
+      );
+      expect(empty.isEmpty, isTrue);
+    });
+
+    test('isInstalled flag is preserved', () {
+      expect(pack.isInstalled, isTrue);
+      const available = KoheraStickerPack(
+        id: '!room:example.com',
+        name: '!room:example.com',
+        displayName: 'Room Pack',
+        iconUrl: null,
+        isInstalled: false,
+        stickers: [],
+        emoji: [],
+      );
+      expect(available.isInstalled, isFalse);
+    });
+  });
+}

--- a/test/services/sticker_pack_service_test.dart
+++ b/test/services/sticker_pack_service_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/models/sticker_pack.dart';
 import 'package:kohera/core/services/sticker_pack_service.dart';
 import 'package:kohera/core/utils/openmoji_catalog.dart';
+import 'package:kohera/features/settings/models/kohera_sticker_pack.dart';
 import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:matrix/src/utils/space_child.dart';
@@ -404,6 +405,62 @@ void main() {
           {'room_ids': ordered},
         ),
       ).called(1);
+    });
+  });
+
+  // ── Kohera domain-model getters ──────────────────────────────
+
+  group('koheraAccountPacks', () {
+    test('returns KoheraStickerPack instances marked installed', () {
+      when(mockClient.accountData).thenReturn({
+        _kUserEmotesType: _accountDataEvent(_kUserEmotesType, _packContent()),
+      });
+      final packs = service.koheraAccountPacks;
+      expect(packs, hasLength(1));
+      expect(packs.first, isA<KoheraStickerPack>());
+      expect(packs.first.id, _kUserEmotesType);
+      expect(packs.first.isInstalled, isTrue);
+      expect(packs.first.iconUrl, isNull);
+      expect(packs.first.stickerCount + packs.first.emojiCount, greaterThan(0));
+    });
+
+    test('maps avatarUrl to iconUrl string', () {
+      when(mockClient.accountData).thenReturn({
+        _kUserEmotesType: _accountDataEvent(
+          _kUserEmotesType,
+          {
+            'pack': {
+              'display_name': 'With Avatar',
+              'avatar_url': 'mxc://example.com/avatar',
+            },
+            'images': {
+              'x': {'url': 'mxc://example.com/x'},
+            },
+          },
+        ),
+      });
+      expect(service.koheraAccountPacks.first.iconUrl, 'mxc://example.com/avatar');
+    });
+
+    test('returns empty when no account data', () {
+      expect(service.koheraAccountPacks, isEmpty);
+    });
+  });
+
+  group('koheraAvailableRoomPacks', () {
+    test('returns packs marked not installed', () {
+      final mockRoom = MockRoom();
+      when(mockRoom.id).thenReturn('!room:example.com');
+      when(mockRoom.getState(_kRoomEmotesType)).thenReturn(
+        _stateEvent(_packContent(displayName: 'Room Pack')),
+      );
+      when(mockClient.rooms).thenReturn([mockRoom]);
+      final packs = service.koheraAvailableRoomPacks();
+      expect(packs, hasLength(1));
+      expect(packs.first, isA<KoheraStickerPack>());
+      expect(packs.first.id, '!room:example.com');
+      expect(packs.first.isInstalled, isFalse);
+      expect(packs.first.displayName, 'Room Pack');
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #709 — wraps the SDK-coupled `StickerPack` model in a new SDK-free `KoheraStickerPack` domain model for the sticker packs settings screen, eliminating `matrix_sdk.StickerPack`/`matrix_sdk.Client` coupling from the screen and its private widgets. Conversion happens inside `StickerPackService` (the existing service — #707's HANDOFF established that `StickerPackService` fills the `StickerService` role, so no new service is needed).

Part of epic #697.

## What changed

### New SDK-free model
- `lib/features/settings/models/kohera_sticker_pack.dart` — `KoheraStickerPack` + `KoheraSticker`, **no** `package:matrix/matrix.dart` import. Fields per the issue spec (`id`, `name`, `displayName`, `iconUrl`, `isInstalled`, `stickers`).
  - **Deviation (documented):** an `emoji` list (`List<KoheraSticker>`) is included beyond the issue's literal field list, because the existing settings-screen subtitle renders "X stickers, Y emoji" from `stickers.length`/`emoji.length` and changing the management UI is explicitly out of scope. Additive and SDK-free.
  - `name` mirrors `id` (the stable machine identifier); reserved for a future MSC2545 state-key distinction.

### Conversion boundary
- `lib/features/settings/models/kohera_sticker_pack_mapper.dart` — `toKoheraStickerPack(StickerPack pack, {required bool isInstalled})`. The only file importing both the SDK-coupled `StickerPack` and the SDK-free `KoheraStickerPack`.

### Additive dimension enhancement
- `PackImage` (`lib/core/models/sticker_pack.dart`) gains nullable `width`/`height`, extracted from the MSC2545 image `info` map (`info.w`/`info.h`) in `StickerPack.fromContent`. **Additive** — the chat sticker picker overlay (out of scope) doesn't read dimensions, so it's unaffected.

### Service
- `StickerPackService` exposes three SDK-free getters: `koheraAccountPacks` (installed), `koheraOpenMojiPack` (installed), `koheraAvailableRoomPacks()` (not installed). The existing `StickerPack`-typed getters stay for the chat sticker picker overlay (out of scope).

### Screen
- `sticker_packs_screen.dart` + its private widgets (`_PackTile`, `_PackAvatar`, `_ReorderablePackList`) now consume `KoheraStickerPack`. `_PackAvatar` uses `iconUrl` (`String?`) instead of `avatarUrl` (`Uri?`). The `package:kohera/core/models/sticker_pack.dart` import is removed. All categorization, reorder, add/remove behavior is preserved.

## Out of scope (per issue)
- The chat **sticker picker overlay** (`sticker_picker_overlay.dart`) — still uses the SDK-coupled `StickerPack`/`PackImage`; left untouched.
- Changing sticker pack management **UI** — behavior preserved.

## Acceptance criteria
- [x] `lib/features/settings/screens/sticker_packs_screen.dart` has no `import 'package:matrix/matrix.dart'` (and no longer imports the SDK-coupled `sticker_pack.dart`)
- [x] Pack display widgets take `KoheraStickerPack` and no `StickerPack` or `Client` parameter
- [x] Sticker pack listing, install, and uninstall work via `StickerPackService`
- [x] Sticker pack icons, names, and sticker thumbnails render correctly (no UI change)
- [x] `flutter analyze` passes with no new warnings (zero issues project-wide)
- [x] `flutter test` passes for affected tests (56 passing: model, mapper, service, e2e settings)

## Tests
- New: `kohera_sticker_pack_test.dart` (model), `kohera_sticker_pack_mapper_test.dart` (mapper + dimension extraction)
- Extended: `sticker_pack_service_test.dart` with `koheraAccountPacks` / `koheraAvailableRoomPacks` assertions
- Verified: `test/e2e/settings_screen_test.dart` still green

Refs #697