### PR TITLE
refactor(#710): wrap Device in KoheraDevice domain model for device list item

### DIFF
--- a/lib/features/settings/models/kohera_device.dart
+++ b/lib/features/settings/models/kohera_device.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/widgets.dart';
+
+/// A Kohera-owned domain model representing a Matrix device with pre-computed
+/// display fields.
+///
+/// This is the device model for the device settings screen. It carries no
+/// `package:matrix/matrix.dart` dependency — the SDK `Device` (and optional
+/// `DeviceKeys`) is converted to this type at the boundary in
+/// `DevicesScreen` via [toKoheraDevice]. The device list item widget only
+/// ever sees this SDK-free type, so it needs no Matrix SDK import.
+///
+/// The display fields ([displayNameOrId], [platformLabel], [deviceIcon],
+/// [lastActiveString]) are pre-computed once at the conversion boundary
+/// rather than on every widget build.
+@immutable
+class KoheraDevice {
+  const KoheraDevice({
+    required this.deviceId,
+    required this.displayName,
+    required this.isOwnDevice,
+    required this.isVerified,
+    required this.isBlocked,
+    required this.keys,
+    required this.lastSeenTs,
+    required this.displayNameOrId,
+    required this.platformLabel,
+    required this.deviceIcon,
+    required this.lastActiveString,
+  });
+
+  /// The Matrix device ID (e.g. `ABCD12`).
+  final String deviceId;
+
+  /// The user-set device display name, or `null`.
+  final String? displayName;
+
+  /// Whether this is the current account's own device.
+  final bool isOwnDevice;
+
+  /// Whether the device is verified via the SDK's cross-signing trust chain.
+  final bool isVerified;
+
+  /// Whether the device is blocked from receiving encryption keys.
+  final bool isBlocked;
+
+  /// The device's key fingerprints as a `keyId → fingerprint` map
+  /// (e.g. `{'ed25519:ABCD12': '...', 'curve25519:ABCD12': '...'}`), or
+  /// `null` when no encryption keys are loaded for the device.
+  final Map<String, String>? keys;
+
+  /// The last-seen timestamp, or `null`.
+  final DateTime? lastSeenTs;
+
+  /// The user-friendly display name, falling back to the device ID.
+  final String displayNameOrId;
+
+  /// A platform label inferred from the display name, or `null`.
+  final String? platformLabel;
+
+  /// An appropriate icon based on the device display name.
+  final IconData deviceIcon;
+
+  /// A human-readable "last active" string (e.g. `Active now`, `5h ago`).
+  final String lastActiveString;
+
+  /// Whether encryption keys are loaded for this device.
+  ///
+  /// Used to gate the Verify/Block menu items. `true` when [keys] is non-null,
+  /// mirroring the previous `deviceKeys != null` check.
+  bool get hasDeviceKeys => keys != null;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is KoheraDevice && deviceId == other.deviceId;
+
+  @override
+  int get hashCode => deviceId.hashCode;
+
+  @override
+  String toString() =>
+      'KoheraDevice(deviceId: $deviceId, displayName: $displayName, '
+      'isOwnDevice: $isOwnDevice, isVerified: $isVerified, '
+      'isBlocked: $isBlocked)';
+}

--- a/lib/features/settings/models/kohera_device_mapper.dart
+++ b/lib/features/settings/models/kohera_device_mapper.dart
@@ -1,0 +1,37 @@
+import 'package:kohera/core/extensions/device_extension.dart';
+import 'package:kohera/features/settings/models/kohera_device.dart';
+import 'package:matrix/matrix.dart';
+
+/// Converts a Matrix SDK [Device] (with optional [DeviceKeys]) into a
+/// UI-ready, SDK-free [KoheraDevice].
+///
+/// This mapper is the conversion boundary: it is the only place that imports
+/// both the SDK-coupled [Device]/[DeviceKeys] and the SDK-free [KoheraDevice].
+/// [DevicesScreen] calls it where it builds `DeviceListItem`s, so the widget
+/// never touches a Matrix SDK type.
+///
+/// The display fields ([displayNameOrId], [platformLabel], [deviceIcon],
+/// [lastActiveString]) are computed here via the existing [DeviceExtension]
+/// helpers, so the platform/icon/last-active logic is not duplicated.
+///
+/// [isOwnDevice] is supplied by the screen depending on whether the device's
+/// ID matches the active client's device ID.
+KoheraDevice toKoheraDevice(
+  Device device, {
+  required bool isOwnDevice,
+  DeviceKeys? deviceKeys,
+}) {
+  return KoheraDevice(
+    deviceId: device.deviceId,
+    displayName: device.displayName,
+    isOwnDevice: isOwnDevice,
+    isVerified: deviceKeys?.verified ?? false,
+    isBlocked: deviceKeys?.blocked ?? false,
+    keys: deviceKeys?.keys,
+    lastSeenTs: device.lastSeenDate,
+    displayNameOrId: device.displayNameOrId,
+    platformLabel: device.platformLabel,
+    deviceIcon: device.deviceIcon,
+    lastActiveString: device.lastActiveString,
+  );
+}

--- a/lib/features/settings/screens/devices_screen.dart
+++ b/lib/features/settings/screens/devices_screen.dart
@@ -8,6 +8,7 @@ import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:kohera/features/e2ee/widgets/key_verification_dialog.dart';
+import 'package:kohera/features/settings/models/kohera_device_mapper.dart';
 import 'package:kohera/features/settings/widgets/device_list_item.dart';
 import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:kohera/shared/widgets/section_header.dart';
@@ -119,7 +120,10 @@ class _DevicesScreenState extends State<DevicesScreen> {
       },
     );
     if (password != null && password.isNotEmpty && mounted) {
-      context.read<MatrixService>().uia.completeUiaWithPassword(request, password);
+      context
+          .read<MatrixService>()
+          .uia
+          .completeUiaWithPassword(request, password);
     } else {
       request.cancel();
     }
@@ -365,9 +369,12 @@ class _DevicesScreenState extends State<DevicesScreen> {
             const SectionHeader(label: 'THIS DEVICE'),
             Card(
               child: DeviceListItem(
-                device: thisDevice.first,
+                device: toKoheraDevice(
+                  thisDevice.first,
+                  isOwnDevice: true,
+                  deviceKeys: _getDeviceKeys(thisDevice.first),
+                ),
                 isCurrentDevice: true,
-                deviceKeys: _getDeviceKeys(thisDevice.first),
                 onRename: () => _renameDevice(thisDevice.first),
               ),
             ),
@@ -395,9 +402,12 @@ class _DevicesScreenState extends State<DevicesScreen> {
                   for (var i = 0; i < otherDevices.length; i++) ...[
                     if (i > 0) const Divider(height: 1, indent: 56),
                     DeviceListItem(
-                      device: otherDevices[i],
+                      device: toKoheraDevice(
+                        otherDevices[i],
+                        isOwnDevice: false,
+                        deviceKeys: _getDeviceKeys(otherDevices[i]),
+                      ),
                       isCurrentDevice: false,
-                      deviceKeys: _getDeviceKeys(otherDevices[i]),
                       onRename: () => _renameDevice(otherDevices[i]),
                       onVerify: () => _verifyDevice(otherDevices[i]),
                       onToggleBlock: () => _toggleBlockDevice(otherDevices[i]),

--- a/lib/features/settings/widgets/device_list_item.dart
+++ b/lib/features/settings/widgets/device_list_item.dart
@@ -1,21 +1,20 @@
 import 'package:flutter/material.dart';
-import 'package:kohera/core/extensions/device_extension.dart';
-import 'package:matrix/matrix.dart';
+import 'package:kohera/features/settings/models/kohera_device.dart';
 
 /// A list tile displaying a single Matrix device with its verification status.
 class DeviceListItem extends StatelessWidget {
   const DeviceListItem({
-    required this.device, required this.isCurrentDevice, super.key,
-    this.deviceKeys,
+    required this.device,
+    required this.isCurrentDevice,
+    super.key,
     this.onRename,
     this.onVerify,
     this.onToggleBlock,
     this.onRemove,
   });
 
-  final Device device;
+  final KoheraDevice device;
   final bool isCurrentDevice;
-  final DeviceKeys? deviceKeys;
   final VoidCallback? onRename;
   final VoidCallback? onVerify;
   final VoidCallback? onToggleBlock;
@@ -26,7 +25,9 @@ class DeviceListItem extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
 
     return ListTile(
-      mouseCursor: (isCurrentDevice && onRename != null) ? SystemMouseCursors.click : null,
+      mouseCursor: (isCurrentDevice && onRename != null)
+          ? SystemMouseCursors.click
+          : null,
       leading: Icon(device.deviceIcon, color: cs.onSurfaceVariant),
       title: Text(
         device.displayNameOrId,
@@ -36,14 +37,16 @@ class DeviceListItem extends StatelessWidget {
       subtitle: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text([
-            device.lastActiveString,
-            if (device.platformLabel != null) device.platformLabel!,
-          ].join(' · '),),
+          Text(
+            [
+              device.lastActiveString,
+              if (device.platformLabel != null) device.platformLabel!,
+            ].join(' · '),
+          ),
           const SizedBox(height: 2),
           _VerificationBadge(
-            isVerified: deviceKeys?.verified ?? false,
-            isBlocked: deviceKeys?.blocked ?? false,
+            isVerified: device.isVerified,
+            isBlocked: device.isBlocked,
           ),
         ],
       ),
@@ -72,7 +75,7 @@ class DeviceListItem extends StatelessWidget {
                     dense: true,
                   ),
                 ),
-                if (deviceKeys != null && !deviceKeys!.blocked)
+                if (device.hasDeviceKeys && !device.isBlocked)
                   const PopupMenuItem(
                     value: _DeviceAction.verify,
                     child: ListTile(
@@ -81,16 +84,16 @@ class DeviceListItem extends StatelessWidget {
                       dense: true,
                     ),
                   ),
-                if (deviceKeys != null)
+                if (device.hasDeviceKeys)
                   PopupMenuItem(
                     value: _DeviceAction.block,
                     child: ListTile(
                       leading: Icon(
-                        deviceKeys!.blocked
+                        device.isBlocked
                             ? Icons.shield_outlined
                             : Icons.block_outlined,
                       ),
-                      title: Text(deviceKeys!.blocked ? 'Unblock' : 'Block'),
+                      title: Text(device.isBlocked ? 'Unblock' : 'Block'),
                       dense: true,
                     ),
                   ),

--- a/test/features/settings/models/kohera_device_mapper_test.dart
+++ b/test/features/settings/models/kohera_device_mapper_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/features/settings/models/kohera_device_mapper.dart';
+import 'package:matrix/matrix.dart';
+
+void main() {
+  group('toKoheraDevice', () {
+    test('maps deviceId and displayName', () {
+      final device = Device(
+        deviceId: 'ABCD12',
+        displayName: 'Kohera Android',
+      );
+      final kohera = toKoheraDevice(device, isOwnDevice: true);
+
+      expect(kohera.deviceId, 'ABCD12');
+      expect(kohera.displayName, 'Kohera Android');
+      expect(kohera.isOwnDevice, isTrue);
+    });
+
+    group('displayNameOrId', () {
+      test('returns displayName when available', () {
+        final device = Device(deviceId: 'ABCD12', displayName: 'My Phone');
+        expect(
+          toKoheraDevice(device, isOwnDevice: false).displayNameOrId,
+          'My Phone',
+        );
+      });
+
+      test('falls back to deviceId when displayName is null', () {
+        final device = Device(deviceId: 'ABCD12');
+        expect(
+          toKoheraDevice(device, isOwnDevice: false).displayNameOrId,
+          'ABCD12',
+        );
+      });
+    });
+
+    group('platformLabel', () {
+      test('infers Android', () {
+        final device = Device(deviceId: 'id', displayName: 'Kohera Android');
+        expect(
+          toKoheraDevice(device, isOwnDevice: false).platformLabel,
+          'Android',
+        );
+      });
+
+      test('infers iOS', () {
+        final device = Device(deviceId: 'id', displayName: 'Element iOS');
+        expect(
+          toKoheraDevice(device, isOwnDevice: false).platformLabel,
+          'iOS',
+        );
+      });
+
+      test('returns null for an unrecognized name', () {
+        final device = Device(deviceId: 'id', displayName: 'My Custom Client');
+        expect(
+          toKoheraDevice(device, isOwnDevice: false).platformLabel,
+          isNull,
+        );
+      });
+    });
+
+    group('deviceIcon', () {
+      test('returns phone icon for Android', () {
+        final device = Device(deviceId: 'id', displayName: 'Kohera Android');
+        expect(
+          toKoheraDevice(device, isOwnDevice: false).deviceIcon,
+          Icons.phone_android_outlined,
+        );
+      });
+
+      test('returns web icon for Chrome', () {
+        final device = Device(deviceId: 'id', displayName: 'Chrome on Windows');
+        expect(
+          toKoheraDevice(device, isOwnDevice: false).deviceIcon,
+          Icons.web_outlined,
+        );
+      });
+
+      test('returns desktop icon for Linux', () {
+        final device = Device(
+          deviceId: 'id',
+          displayName: 'Element Desktop Linux',
+        );
+        expect(
+          toKoheraDevice(device, isOwnDevice: false).deviceIcon,
+          Icons.desktop_mac_outlined,
+        );
+      });
+
+      test('returns unknown icon for unrecognized name', () {
+        final device = Device(deviceId: 'id', displayName: 'Mystery Box');
+        expect(
+          toKoheraDevice(device, isOwnDevice: false).deviceIcon,
+          Icons.devices_other_outlined,
+        );
+      });
+    });
+
+    group('lastSeenTs', () {
+      test('returns DateTime from lastSeenTs', () {
+        final ts = DateTime(2025, 6, 15, 10, 30).millisecondsSinceEpoch;
+        final device = Device(deviceId: 'id', lastSeenTs: ts);
+        expect(
+          toKoheraDevice(device, isOwnDevice: false).lastSeenTs,
+          DateTime(2025, 6, 15, 10, 30),
+        );
+      });
+
+      test('returns null when lastSeenTs is null', () {
+        final device = Device(deviceId: 'id');
+        expect(
+          toKoheraDevice(device, isOwnDevice: false).lastSeenTs,
+          isNull,
+        );
+      });
+    });
+
+    group('lastActiveString', () {
+      test('returns "Unknown" when lastSeenTs is null', () {
+        final device = Device(deviceId: 'id');
+        expect(
+          toKoheraDevice(device, isOwnDevice: false).lastActiveString,
+          'Unknown',
+        );
+      });
+
+      test('returns "Active now" for recent activity', () {
+        final ts = DateTime.now()
+            .subtract(const Duration(minutes: 2))
+            .millisecondsSinceEpoch;
+        final device = Device(deviceId: 'id', lastSeenTs: ts);
+        expect(
+          toKoheraDevice(device, isOwnDevice: false).lastActiveString,
+          'Active now',
+        );
+      });
+    });
+
+    group('verification state (no deviceKeys)', () {
+      final device = Device(deviceId: 'ABCD12', displayName: 'My Phone');
+
+      test('isVerified is false when deviceKeys is null', () {
+        expect(toKoheraDevice(device, isOwnDevice: false).isVerified, isFalse);
+      });
+
+      test('isBlocked is false when deviceKeys is null', () {
+        expect(toKoheraDevice(device, isOwnDevice: false).isBlocked, isFalse);
+      });
+
+      test('keys is null when deviceKeys is null', () {
+        expect(toKoheraDevice(device, isOwnDevice: false).keys, isNull);
+      });
+
+      test('hasDeviceKeys is false when deviceKeys is null', () {
+        expect(
+          toKoheraDevice(device, isOwnDevice: false).hasDeviceKeys,
+          isFalse,
+        );
+      });
+    });
+
+    test('isOwnDevice is passed through', () {
+      final device = Device(deviceId: 'id', displayName: 'Mine');
+      expect(toKoheraDevice(device, isOwnDevice: true).isOwnDevice, isTrue);
+      expect(toKoheraDevice(device, isOwnDevice: false).isOwnDevice, isFalse);
+    });
+  });
+}

--- a/test/features/settings/models/kohera_device_test.dart
+++ b/test/features/settings/models/kohera_device_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/features/settings/models/kohera_device.dart';
+
+void main() {
+  group('KoheraDevice', () {
+    KoheraDevice build({
+      String? displayName,
+      Map<String, String>? keys,
+      bool isVerified = false,
+      bool isBlocked = false,
+    }) =>
+        KoheraDevice(
+          deviceId: 'ABCD12',
+          displayName: displayName,
+          isOwnDevice: false,
+          isVerified: isVerified,
+          isBlocked: isBlocked,
+          keys: keys,
+          lastSeenTs: null,
+          displayNameOrId: displayName ?? 'ABCD12',
+          platformLabel: null,
+          deviceIcon: Icons.devices_other_outlined,
+          lastActiveString: 'Unknown',
+        );
+
+    test('stores all fields', () {
+      final device = KoheraDevice(
+        deviceId: 'XYZ',
+        displayName: 'My Phone',
+        isOwnDevice: true,
+        isVerified: true,
+        isBlocked: false,
+        keys: const {'ed25519:XYZ': 'fp'},
+        lastSeenTs: DateTime(2025),
+        displayNameOrId: 'My Phone',
+        platformLabel: 'Android',
+        deviceIcon: Icons.phone_android_outlined,
+        lastActiveString: 'Active now',
+      );
+
+      expect(device.deviceId, 'XYZ');
+      expect(device.displayName, 'My Phone');
+      expect(device.isOwnDevice, isTrue);
+      expect(device.isVerified, isTrue);
+      expect(device.isBlocked, isFalse);
+      expect(device.keys, {'ed25519:XYZ': 'fp'});
+      expect(device.lastSeenTs, DateTime(2025));
+      expect(device.displayNameOrId, 'My Phone');
+      expect(device.platformLabel, 'Android');
+      expect(device.deviceIcon, Icons.phone_android_outlined);
+      expect(device.lastActiveString, 'Active now');
+    });
+
+    test('displayName is nullable', () {
+      expect(build().displayName, isNull);
+    });
+
+    group('hasDeviceKeys', () {
+      test('is false when keys is null', () {
+        expect(build().hasDeviceKeys, isFalse);
+      });
+
+      test('is true when keys is present', () {
+        expect(
+          build(keys: {'ed25519:ABC': 'fp'}).hasDeviceKeys,
+          isTrue,
+        );
+      });
+    });
+
+    group('equality', () {
+      test('is keyed on deviceId', () {
+        final a = build();
+        final b = KoheraDevice(
+          deviceId: 'ABCD12',
+          displayName: 'Completely Different Name',
+          isOwnDevice: true,
+          isVerified: true,
+          isBlocked: true,
+          keys: const {'k': 'v'},
+          lastSeenTs: DateTime(2025, 6),
+          displayNameOrId: 'Completely Different Name',
+          platformLabel: 'iOS',
+          deviceIcon: Icons.phone_iphone_outlined,
+          lastActiveString: '1m ago',
+        );
+
+        expect(a, equals(b));
+        expect(a.hashCode, b.hashCode);
+      });
+
+      test('differs for a different deviceId', () {
+        final a = build();
+
+        const other = KoheraDevice(
+          deviceId: 'OTHER',
+          displayName: null,
+          isOwnDevice: false,
+          isVerified: false,
+          isBlocked: false,
+          keys: null,
+          lastSeenTs: null,
+          displayNameOrId: 'OTHER',
+          platformLabel: null,
+          deviceIcon: Icons.devices_other_outlined,
+          lastActiveString: 'Unknown',
+        );
+
+        expect(a, isNot(equals(other)));
+      });
+    });
+
+    test('toString includes identifying fields', () {
+      final device = build(displayName: 'My Phone', isVerified: true);
+      final str = device.toString();
+      expect(str, contains('ABCD12'));
+      expect(str, contains('My Phone'));
+      expect(str, contains('isVerified: true'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Eliminates `matrix_sdk.Device` / `DeviceKeys` coupling from the device list item widget by introducing an SDK-free `KoheraDevice` domain model with pre-computed display fields. Part of the epic #697 anti-corruption-layer effort (sibling of #709).

## Changes

- **New** `lib/features/settings/models/kohera_device.dart` — SDK-free `KoheraDevice` carrying `deviceId`, `displayName`, `isOwnDevice`, `isVerified`, `isBlocked`, `keys` (`Map<String,String>?` keyId→fingerprint), `lastSeenTs`, plus pre-computed display fields (`displayNameOrId`, `platformLabel`, `deviceIcon`, `lastActiveString`) and a `hasDeviceKeys` getter. `==`/`hashCode` keyed on `deviceId`.
- **New** `lib/features/settings/models/kohera_device_mapper.dart` — `toKoheraDevice()` is the conversion boundary: the only file importing both the matrix SDK and the model. Reuses the existing `DeviceExtension` helpers so platform/icon/last-active logic is not duplicated.
- **Modified** `lib/features/settings/widgets/device_list_item.dart` — now takes `KoheraDevice`; **no** `package:matrix/matrix.dart` import and **no** `Device`/`DeviceKeys` parameter. Verification badge and Verify/Block menu gating read from the model (`device.hasDeviceKeys`, `device.isVerified`, `device.isBlocked`).
- **Modified** `lib/features/settings/screens/devices_screen.dart` — converts each `Device`→`KoheraDevice` at its boundary where it builds the list items. The rename/verify/block/remove actions keep operating on the SDK `Device` since they need `device.deviceId` for the SDK calls.
- **New** tests: `kohera_device_test.dart` (model) and `kohera_device_mapper_test.dart` (mapper), under `test/features/settings/models/`.

The device-extension helpers and `device_extension_test.dart` are untouched — `DevicesScreen` still uses `displayNameOrId` in its confirm dialogs, and the mapper reuses the extension.

## Testing

- [x] `flutter analyze` is clean (0 issues)
- [x] `flutter test` passes — full suite: 2312 tests, including new model/mapper tests and the unchanged `test/screens/devices_screen_test.dart` (the screen converts `Device` internally with `userDeviceKeys` stubbed to `{}`, so existing assertions stay green)

No `@GenerateNiceMocks` annotations changed, so no `build_runner` regeneration was needed.

## Screenshots / recordings

N/A — no UI change; rendering paths are unchanged, sourced from the new model.

## Linked issues

Closes #710
Refs #697

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master` (not another feature branch, unless an explicitly requested stacked PR)