### PR TITLE
refactor(#735): Create KoheraPresenceType enum and decouple presence_dot

### DIFF
--- a/lib/shared/models/kohera_presence_type.dart
+++ b/lib/shared/models/kohera_presence_type.dart
@@ -1,0 +1,17 @@
+/// Kohera-owned presence type enum, mirroring `matrix.PresenceType`
+/// without importing the Matrix SDK.
+enum KoheraPresenceType {
+  online,
+  unavailable,
+  offline;
+
+  /// Converts from the SDK enum's `.name` string value.
+  ///
+  /// Use as: `KoheraPresenceType.fromName(cached.presence.name)`
+  /// where `cached.presence` is an inferred `PresenceType`.
+  factory KoheraPresenceType.fromName(String name) => switch (name) {
+        'online' => KoheraPresenceType.online,
+        'unavailable' => KoheraPresenceType.unavailable,
+        _ => KoheraPresenceType.offline,
+      };
+}

--- a/lib/shared/widgets/presence_dot.dart
+++ b/lib/shared/widgets/presence_dot.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/sub_services/presence_service.dart';
-import 'package:matrix/matrix.dart';
+import 'package:kohera/shared/models/kohera_presence_type.dart';
 
 /// A presence status dot. Rebuilds independently when [presence] changes and
 /// renders nothing (no layout shift) for unknown presence.
@@ -27,7 +27,8 @@ class PresenceDot extends StatelessWidget {
       builder: (context, _) {
         final cached = presence.presenceFor(userId);
         if (cached == null) return const SizedBox.shrink();
-        final (color, label) = _styleFor(cached.presence, cs);
+        final (color, label) =
+            _styleFor(KoheraPresenceType.fromName(cached.presence.name), cs);
         final diameter = size * 0.3;
         return Semantics(
           label: label,
@@ -45,11 +46,14 @@ class PresenceDot extends StatelessWidget {
     );
   }
 
-  static (Color, String) _styleFor(PresenceType type, ColorScheme cs) =>
+  static (Color, String) _styleFor(
+    KoheraPresenceType type,
+    ColorScheme cs,
+  ) =>
       switch (type) {
-        PresenceType.online => (cs.primary, 'Online'),
-        PresenceType.unavailable => (cs.tertiary, 'Away'),
-        PresenceType.offline => (cs.outline, 'Offline'),
+        KoheraPresenceType.online => (cs.primary, 'Online'),
+        KoheraPresenceType.unavailable => (cs.tertiary, 'Away'),
+        KoheraPresenceType.offline => (cs.outline, 'Offline'),
       };
 }
 


### PR DESCRIPTION
## Summary

Creates `KoheraPresenceType` enum and eliminates `package:matrix/matrix.dart` from `presence_dot.dart`.

Closes #735

## Changes

### New: `lib/shared/models/kohera_presence_type.dart`
- Enum with `online`, `unavailable`, `offline` (mirrors `matrix.PresenceType`)
- `fromName(String)` factory for conversion from SDK enum's `.name` field
- No SDK imports

### `lib/shared/widgets/presence_dot.dart`
- `_styleFor(PresenceType type, ...)` -> `_styleFor(KoheraPresenceType type, ...)`
- Call site converts via `KoheraPresenceType.fromName(cached.presence.name)`
- Removed `import 'package:matrix/matrix.dart'`

## Key insight
`PresenceType` has a custom `final String name` field (not an extension method). Fields are always accessible on inferred types without importing the defining library. So `cached.presence.name` works without matrix import.

## Verification
- `flutter analyze`: 0 errors, 0 warnings, 0 info
- `flutter test`: 2318/2318 pass