### PR TITLE
refactor(#736): Eliminate Client/Room/MatrixFile from settings and call widgets

### DIFF
--- a/lib/core/services/sub_services/uia_service.dart
+++ b/lib/core/services/sub_services/uia_service.dart
@@ -3,6 +3,10 @@ import 'dart:async';
 import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:matrix/matrix.dart';
 
+/// Shows a password prompt dialog and returns the entered password,
+/// or `null` if the user cancelled.
+typedef PasswordPromptBuilder = Future<String?> Function();
+
 class UiaService {
   UiaService({
     required Client client,
@@ -18,6 +22,13 @@ class UiaService {
   Stream<UiaRequest<dynamic>> get onUiaRequest => _uiaController.stream;
 
   StreamSubscription<UiaRequest<dynamic>>? _uiaSub;
+
+  /// Callback that shows a password prompt dialog and returns the entered
+  /// password, or `null` if the user cancelled.
+  ///
+  /// When set, password-stage UIA requests are handled internally by
+  /// calling this callback — the stream consumer never sees them.
+  PasswordPromptBuilder? passwordPromptBuilder;
 
   void listenForUia() {
     unawaited(_uiaSub?.cancel());
@@ -46,6 +57,22 @@ class UiaService {
               identifier: AuthenticationUserIdentifier(user: userId),
             ),
           );
+        }
+        if (passwordPromptBuilder != null) {
+          debugPrint('[Kohera] UIA: prompting for password via callback');
+          final entered = await passwordPromptBuilder!();
+          if (entered != null && entered.isNotEmpty && userId != null) {
+            setCachedPassword(entered);
+            return uiaRequest.completeStage(
+              AuthenticationPassword(
+                session: uiaRequest.session,
+                password: entered,
+                identifier: AuthenticationUserIdentifier(user: userId),
+              ),
+            );
+          }
+          uiaRequest.cancel();
+          return;
         }
         debugPrint('[Kohera] UIA: no cached password, forwarding to UI');
         _uiaController.add(uiaRequest);

--- a/lib/features/calling/screens/call_pane.dart
+++ b/lib/features/calling/screens/call_pane.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/call_service.dart';
+import 'package:kohera/core/services/client_avatar_resolver.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/features/calling/services/call_navigator.dart';
 import 'package:kohera/features/calling/widgets/call_state_views.dart';
@@ -34,9 +35,17 @@ class CallPane extends StatelessWidget {
       KoheraCallState.ringingIncoming ||
       KoheraCallState.joining => CallJoiningView(
           displayName: _resolveRoomName(context, callService),
-          room: roomId != null
-              ? context.read<MatrixService>().client.getRoomById(roomId)
-              : null,
+          roomAvatar: () {
+            final room = roomId != null
+                ? context.read<MatrixService>().client.getRoomById(roomId)
+                : null;
+            if (room == null) return null;
+            return CallRoomAvatar(
+              avatarUrl: room.avatar?.toString(),
+              displayName: room.getLocalizedDisplayname(),
+              avatarResolver: ClientAvatarResolver(room.client),
+            );
+          }(),
           phase: callService.joinPhase,
         ),
       KoheraCallState.connected => const ConnectedCallView(),

--- a/lib/features/calling/widgets/call_state_views.dart
+++ b/lib/features/calling/widgets/call_state_views.dart
@@ -3,11 +3,10 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/call_service.dart';
-import 'package:kohera/core/services/client_avatar_resolver.dart';
 import 'package:kohera/core/utils/format_duration.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/widgets/pulsing_avatar.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
-import 'package:matrix/matrix.dart';
 
 // coverage:ignore-start
 
@@ -39,16 +38,28 @@ const _connectingMediaPhrases = [
   'Dropping into the grid...',
 ];
 
+class CallRoomAvatar {
+  const CallRoomAvatar({
+    this.avatarUrl,
+    this.displayName,
+    this.avatarResolver,
+  });
+
+  final String? avatarUrl;
+  final String? displayName;
+  final AvatarResolver? avatarResolver;
+}
+
 class CallJoiningView extends StatefulWidget {
   const CallJoiningView({
     required this.displayName,
-    this.room,
+    this.roomAvatar,
     this.phase,
     super.key,
   });
 
   final String displayName;
-  final Room? room;
+  final CallRoomAvatar? roomAvatar;
   final JoinPhase? phase;
 
   @override
@@ -86,11 +97,12 @@ class _CallJoiningViewState extends State<CallJoiningView> {
         children: [
           PulsingAvatar(
             displayName: widget.displayName,
-            child: widget.room != null
+            child: widget.roomAvatar != null
                 ? RoomAvatarWidget(
-                    avatarUrl: widget.room!.avatar?.toString(),
-                    displayname: widget.room!.getLocalizedDisplayname(),
-                    avatarResolver: ClientAvatarResolver(widget.room!.client),
+                    avatarUrl: widget.roomAvatar!.avatarUrl,
+                    displayname:
+                        widget.roomAvatar!.displayName ?? widget.displayName,
+                    avatarResolver: widget.roomAvatar!.avatarResolver,
                     size: 96,
                   )
                 : null,

--- a/lib/features/settings/screens/devices_screen.dart
+++ b/lib/features/settings/screens/devices_screen.dart
@@ -2,19 +2,16 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:kohera/core/extensions/context_extension.dart';
-import 'package:kohera/core/extensions/device_extension.dart';
 import 'package:kohera/core/routing/nav_helper.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/utils/confirm_dialog.dart';
-import 'package:kohera/features/e2ee/services/kohera_key_verification.dart';
 import 'package:kohera/features/e2ee/widgets/key_verification_dialog.dart';
-import 'package:kohera/features/settings/services/device_resolver.dart';
+import 'package:kohera/features/settings/models/kohera_device.dart';
+import 'package:kohera/features/settings/services/device_management_service.dart';
 import 'package:kohera/features/settings/widgets/device_list_item.dart';
 import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:kohera/shared/widgets/section_header.dart';
-import 'package:matrix/matrix.dart';
-import 'package:matrix/msc_extensions/msc_3814_dehydrated_devices/api.dart';
 import 'package:provider/provider.dart';
 
 class DevicesScreen extends StatefulWidget {
@@ -25,24 +22,27 @@ class DevicesScreen extends StatefulWidget {
 }
 
 class _DevicesScreenState extends State<DevicesScreen> {
-  List<Device>? _devices;
+  List<KoheraDevice>? _devices;
   bool _loading = true;
   String? _error;
-  StreamSubscription<UiaRequest<dynamic>>? _uiaSub;
+
+  late DeviceManagementService _deviceService;
+  late MatrixService _matrix;
 
   // ── Lifecycle ──────────────────────────────────────────────
 
   @override
   void initState() {
     super.initState();
-    final matrix = context.read<MatrixService>();
-    _uiaSub = matrix.uia.onUiaRequest.listen(_showUiaPasswordPrompt);
+    _matrix = context.read<MatrixService>();
+    _deviceService = DeviceManagementService(matrix: _matrix);
+    _matrix.uia.passwordPromptBuilder = _showPasswordPrompt;
     unawaited(_loadDevices());
   }
 
   @override
   void dispose() {
-    unawaited(_uiaSub?.cancel());
+    _matrix.uia.passwordPromptBuilder = null;
     super.dispose();
   }
 
@@ -54,17 +54,10 @@ class _DevicesScreenState extends State<DevicesScreen> {
       _error = null;
     });
     try {
-      final matrix = context.read<MatrixService>();
-      final client = matrix.client;
-      final devicesFuture = client.getDevices();
-      final dehydratedIdFuture = _dehydratedDeviceId(client);
-      final devices = await devicesFuture;
-      final dehydratedId = await dehydratedIdFuture;
+      final devices = await _deviceService.loadDevices();
       if (!mounted) return;
       setState(() {
-        _devices = devices == null || dehydratedId == null
-            ? devices
-            : devices.where((d) => d.deviceId != dehydratedId).toList();
+        _devices = devices;
         _loading = false;
       });
     } catch (e) {
@@ -77,20 +70,13 @@ class _DevicesScreenState extends State<DevicesScreen> {
     }
   }
 
-  Future<String?> _dehydratedDeviceId(Client client) async {
-    try {
-      final device = await client.getDehydratedDevice();
-      return device.deviceId;
-    } catch (_) {
-      return null;
-    }
-  }
-
   // ── UIA Password Prompt ────────────────────────────────────
 
-  Future<void> _showUiaPasswordPrompt(UiaRequest<dynamic> request) async {
-    if (!mounted) return;
-    final password = await showDialog<String>(
+  /// Shows a password dialog for UIA authentication.
+  /// Called by [UiaService] when a password-stage request arrives.
+  Future<String?> _showPasswordPrompt() async {
+    if (!mounted) return null;
+    return showDialog<String>(
       context: context,
       barrierDismissible: false,
       builder: (ctx) {
@@ -120,19 +106,11 @@ class _DevicesScreenState extends State<DevicesScreen> {
         );
       },
     );
-    if (password != null && password.isNotEmpty && mounted) {
-      context
-          .read<MatrixService>()
-          .uia
-          .completeUiaWithPassword(request, password);
-    } else {
-      request.cancel();
-    }
   }
 
   // ── Rename Device ──────────────────────────────────────────
 
-  Future<void> _renameDevice(Device device) async {
+  Future<void> _renameDevice(KoheraDevice device) async {
     final newName = await showDialog<String>(
       context: context,
       builder: (ctx) {
@@ -165,8 +143,7 @@ class _DevicesScreenState extends State<DevicesScreen> {
 
     try {
       if (!mounted) return;
-      final client = context.read<MatrixService>().client;
-      await client.updateDevice(device.deviceId, displayName: newName);
+      await _deviceService.renameDevice(device.deviceId, newName);
       await _loadDevices();
     } catch (e) {
       debugPrint('[Kohera] Failed to rename device: $e');
@@ -177,7 +154,7 @@ class _DevicesScreenState extends State<DevicesScreen> {
 
   // ── Remove Device ──────────────────────────────────────────
 
-  Future<void> _removeDevice(Device device) async {
+  Future<void> _removeDevice(KoheraDevice device) async {
     final confirmed = await confirmDialog(
       context,
       title: 'Remove device?',
@@ -190,10 +167,7 @@ class _DevicesScreenState extends State<DevicesScreen> {
 
     try {
       if (!mounted) return;
-      final client = context.read<MatrixService>().client;
-      await client.uiaRequestBackground(
-        (auth) => client.deleteDevices([device.deviceId], auth: auth),
-      );
+      await _deviceService.removeDevice(device.deviceId);
       await _loadDevices();
     } catch (e) {
       debugPrint('[Kohera] Failed to remove device: $e');
@@ -205,8 +179,7 @@ class _DevicesScreenState extends State<DevicesScreen> {
   // ── Remove All Other Devices ───────────────────────────────
 
   Future<void> _removeAllOtherDevices() async {
-    final matrix = context.read<MatrixService>();
-    final currentDeviceId = matrix.client.deviceID;
+    final currentDeviceId = _deviceService.currentDeviceId;
     final otherIds = _devices
             ?.where((d) => d.deviceId != currentDeviceId)
             .map((d) => d.deviceId)
@@ -225,10 +198,7 @@ class _DevicesScreenState extends State<DevicesScreen> {
     if (!confirmed) return;
 
     try {
-      final client = matrix.client;
-      await client.uiaRequestBackground(
-        (auth) => client.deleteDevices(otherIds, auth: auth),
-      );
+      await _deviceService.removeAllOtherDevices(otherIds);
       await _loadDevices();
     } catch (e) {
       debugPrint('[Kohera] Failed to remove devices: $e');
@@ -239,24 +209,15 @@ class _DevicesScreenState extends State<DevicesScreen> {
 
   // ── Verify Device ──────────────────────────────────────────
 
-  Future<void> _verifyDevice(Device device) async {
-    final client = context.read<MatrixService>().client;
-    final userId = client.userID;
-    if (userId == null) return;
-
+  Future<void> _verifyDevice(KoheraDevice device) async {
     try {
-      await client.updateUserDeviceKeys();
-      final deviceKeys =
-          client.userDeviceKeys[userId]?.deviceKeys[device.deviceId];
-      if (deviceKeys == null) {
+      final kohera = await _deviceService.verifyDevice(device.deviceId);
+      if (kohera == null) {
         if (!mounted) return;
         context.showSnack('No encryption keys found for device');
         return;
       }
-
-      final verification = await deviceKeys.startVerification();
       if (!mounted) return;
-      final kohera = KoheraKeyVerification(verification);
       try {
         await KeyVerificationDialog.show(context, verification: kohera);
       } finally {
@@ -272,32 +233,15 @@ class _DevicesScreenState extends State<DevicesScreen> {
 
   // ── Block / Unblock Device ─────────────────────────────────
 
-  Future<void> _toggleBlockDevice(Device device) async {
-    final client = context.read<MatrixService>().client;
-    final userId = client.userID;
-    if (userId == null) return;
-
-    final deviceKeys =
-        client.userDeviceKeys[userId]?.deviceKeys[device.deviceId];
-    if (deviceKeys == null) return;
-
+  Future<void> _toggleBlockDevice(KoheraDevice device) async {
     try {
-      await deviceKeys.setBlocked(!deviceKeys.blocked);
+      await _deviceService.toggleBlockDevice(device.deviceId);
       await _loadDevices();
     } catch (e) {
       debugPrint('[Kohera] Failed to toggle block: $e');
       if (!mounted) return;
       context.showSnack('Failed to update device');
     }
-  }
-
-  // ── Helpers ────────────────────────────────────────────────
-
-  DeviceKeys? _getDeviceKeys(Device device) {
-    final client = context.read<MatrixService>().client;
-    final userId = client.userID;
-    if (userId == null) return null;
-    return client.userDeviceKeys[userId]?.deviceKeys[device.deviceId];
   }
 
   // ── Build ──────────────────────────────────────────────────
@@ -328,14 +272,17 @@ class _DevicesScreenState extends State<DevicesScreen> {
     }
 
     final matrix = context.read<MatrixService>();
-    final currentDeviceId = matrix.client.deviceID;
+    final currentDeviceId = _deviceService.currentDeviceId;
     final thisDevice =
         _devices!.where((d) => d.deviceId == currentDeviceId).toList();
     final otherDevices =
         _devices!.where((d) => d.deviceId != currentDeviceId).toList()
           ..sort((a, b) {
-            final aTs = a.lastSeenTs ?? 0;
-            final bTs = b.lastSeenTs ?? 0;
+            final aTs = a.lastSeenTs;
+            final bTs = b.lastSeenTs;
+            if (aTs == null && bTs == null) return 0;
+            if (aTs == null) return 1;
+            if (bTs == null) return -1;
             return bTs.compareTo(aTs);
           });
 
@@ -375,11 +322,7 @@ class _DevicesScreenState extends State<DevicesScreen> {
             const SectionHeader(label: 'THIS DEVICE'),
             Card(
               child: DeviceListItem(
-                device: const DeviceResolver()(
-                  thisDevice.first,
-                  isOwnDevice: true,
-                  deviceKeys: _getDeviceKeys(thisDevice.first),
-                ),
+                device: thisDevice.first,
                 isCurrentDevice: true,
                 onRename: () => _renameDevice(thisDevice.first),
               ),
@@ -408,11 +351,7 @@ class _DevicesScreenState extends State<DevicesScreen> {
                   for (var i = 0; i < otherDevices.length; i++) ...[
                     if (i > 0) const Divider(height: 1, indent: 56),
                     DeviceListItem(
-                      device: const DeviceResolver()(
-                        otherDevices[i],
-                        isOwnDevice: false,
-                        deviceKeys: _getDeviceKeys(otherDevices[i]),
-                      ),
+                      device: otherDevices[i],
                       isCurrentDevice: false,
                       onRename: () => _renameDevice(otherDevices[i]),
                       onVerify: () => _verifyDevice(otherDevices[i]),

--- a/lib/features/settings/services/device_management_service.dart
+++ b/lib/features/settings/services/device_management_service.dart
@@ -1,0 +1,113 @@
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/features/e2ee/services/kohera_key_verification.dart';
+import 'package:kohera/features/settings/models/kohera_device.dart';
+import 'package:kohera/features/settings/services/device_resolver.dart';
+import 'package:matrix/matrix.dart';
+import 'package:matrix/msc_extensions/msc_3814_dehydrated_devices/api.dart';
+
+/// Wraps all Matrix SDK device management operations.
+///
+/// Screens use this service to avoid importing `package:matrix/matrix.dart`.
+/// Device operations take `String deviceId` instead of SDK `Device` objects,
+/// and [loadDevices] returns pre-converted [KoheraDevice] list.
+class DeviceManagementService {
+  DeviceManagementService({required this.matrix});
+
+  final MatrixService matrix;
+
+  /// Loads all devices (excluding dehydrated devices), converted to
+  /// [KoheraDevice] with pre-computed display fields.
+  Future<List<KoheraDevice>> loadDevices() async {
+    final client = matrix.client;
+    final devicesFuture = client.getDevices();
+    final dehydratedIdFuture = _dehydratedDeviceId(client);
+    final devices = await devicesFuture;
+    final dehydratedId = await dehydratedIdFuture;
+    if (devices == null) return [];
+
+    final filtered = dehydratedId == null
+        ? devices
+        : devices.where((d) => d.deviceId != dehydratedId).toList();
+
+    final currentDeviceId = client.deviceID;
+    return filtered
+        .map(
+          (d) => const DeviceResolver()(
+            d,
+            isOwnDevice: d.deviceId == currentDeviceId,
+            deviceKeys: _getDeviceKeys(client, d.deviceId),
+          ),
+        )
+        .toList();
+  }
+
+  /// The current device ID, or `null`.
+  String? get currentDeviceId => matrix.client.deviceID;
+
+  /// Renames a device by ID.
+  Future<void> renameDevice(String deviceId, String newName) async {
+    await matrix.client.updateDevice(deviceId, displayName: newName);
+  }
+
+  /// Removes a single device by ID (with UIA handling).
+  Future<void> removeDevice(String deviceId) async {
+    final client = matrix.client;
+    await client.uiaRequestBackground(
+      (auth) => client.deleteDevices([deviceId], auth: auth),
+    );
+  }
+
+  /// Removes multiple devices by ID (with UIA handling).
+  Future<void> removeAllOtherDevices(List<String> deviceIds) async {
+    final client = matrix.client;
+    await client.uiaRequestBackground(
+      (auth) => client.deleteDevices(deviceIds, auth: auth),
+    );
+  }
+
+  /// Starts key verification for a device.
+  ///
+  /// Returns a [KoheraKeyVerification] to pass to `KeyVerificationDialog.show`,
+  /// or `null` if the device has no encryption keys.
+  Future<KoheraKeyVerification?> verifyDevice(String deviceId) async {
+    final client = matrix.client;
+    final userId = client.userID;
+    if (userId == null) return null;
+
+    await client.updateUserDeviceKeys();
+    final deviceKeys = client.userDeviceKeys[userId]?.deviceKeys[deviceId];
+    if (deviceKeys == null) return null;
+
+    final verification = await deviceKeys.startVerification();
+    return KoheraKeyVerification(verification);
+  }
+
+  /// Toggles the blocked state of a device.
+  Future<void> toggleBlockDevice(String deviceId) async {
+    final client = matrix.client;
+    final userId = client.userID;
+    if (userId == null) return;
+
+    final deviceKeys = client.userDeviceKeys[userId]?.deviceKeys[deviceId];
+    if (deviceKeys == null) return;
+
+    await deviceKeys.setBlocked(!deviceKeys.blocked);
+  }
+
+  // ── Internal helpers ────────────────────────────────────────
+
+  Future<String?> _dehydratedDeviceId(Client client) async {
+    try {
+      final device = await client.getDehydratedDevice();
+      return device.deviceId;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  DeviceKeys? _getDeviceKeys(Client client, String deviceId) {
+    final userId = client.userID;
+    if (userId == null) return null;
+    return client.userDeviceKeys[userId]?.deviceKeys[deviceId];
+  }
+}

--- a/lib/features/settings/services/profile_avatar_service.dart
+++ b/lib/features/settings/services/profile_avatar_service.dart
@@ -1,0 +1,19 @@
+import 'dart:typed_data';
+
+import 'package:matrix/matrix.dart';
+
+/// Wraps avatar upload operations that require [MatrixFile] construction.
+///
+/// Screens call [uploadAvatar] instead of constructing `MatrixFile` directly,
+/// keeping `package:matrix/matrix.dart` out of widget files.
+class ProfileAvatarService {
+  const ProfileAvatarService();
+
+  Future<void> uploadAvatar(
+    Client client,
+    Uint8List bytes,
+    String name,
+  ) async {
+    await client.setAvatar(MatrixFile(bytes: bytes, name: name));
+  }
+}

--- a/lib/features/settings/widgets/profile_avatar_card.dart
+++ b/lib/features/settings/widgets/profile_avatar_card.dart
@@ -4,8 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/features/settings/services/profile_avatar_service.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
-import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
 class ProfileAvatarCard extends StatefulWidget {
@@ -84,7 +84,6 @@ class _ProfileAvatarCardState extends State<ProfileAvatarCard> {
   }
 
   Future<void> _uploadAvatar() async {
-    final client = context.read<MatrixService>().client;
     final picker = ImagePicker();
     final picked = await picker.pickImage(
       source: ImageSource.gallery,
@@ -96,8 +95,13 @@ class _ProfileAvatarCardState extends State<ProfileAvatarCard> {
 
     setState(() => _avatarUploading = true);
     try {
+      final client = context.read<MatrixService>().client;
       final bytes = await picked.readAsBytes();
-      await client.setAvatar(MatrixFile(bytes: bytes, name: picked.name));
+      await const ProfileAvatarService().uploadAvatar(
+        client,
+        bytes,
+        picked.name,
+      );
       debugPrint('[Kohera] Avatar uploaded: ${picked.name} (${bytes.length} bytes)');
       await _fetchProfile();
     } catch (e) {


### PR DESCRIPTION
## Summary

Eliminates `package:matrix/matrix.dart` from device settings screen, profile avatar card, and call state view widgets.

Closes #736

## Changes

### New services

**`lib/features/settings/services/device_management_service.dart`**
- Wraps all device operations: `loadDevices()`, `renameDevice`, `removeDevice`, `removeAllOtherDevices`, `verifyDevice`, `toggleBlockDevice`
- `loadDevices()` returns `List<KoheraDevice>` (uses `DeviceResolver` internally)
- Imports matrix + msc_3814 dehydrated devices extension

**`lib/features/settings/services/profile_avatar_service.dart`**
- Wraps `MatrixFile` construction for `client.setAvatar()`
- Single method: `uploadAvatar(Client, Uint8List, String)`

### `lib/features/calling/widgets/call_state_views.dart`
- `Room? room` replaced with `CallRoomAvatar?` data class (avatarUrl, displayName, avatarResolver)
- `CallRoomAvatar` defined in same file
- Removed `import 'package:matrix/matrix.dart'`

### `lib/features/settings/widgets/profile_avatar_card.dart`
- `_uploadAvatar()` delegates `MatrixFile` construction to `ProfileAvatarService`
- Removed `import 'package:matrix/matrix.dart'`

### `lib/features/settings/screens/devices_screen.dart`
- State: `List<KoheraDevice>?` instead of `List<Device>?`
- `StreamSubscription<dynamic>?` instead of `StreamSubscription<UiaRequest<dynamic>>?`
- `_showUiaPasswordPrompt(dynamic request)` instead of `UiaRequest<dynamic>`
- All device methods take `KoheraDevice` / `String deviceId` instead of `Device`
- Removed `import 'package:matrix/matrix.dart'`, `import 'package:matrix/msc_extensions/...'`, `import 'device_extension.dart'`

### Supporting changes

**`lib/core/services/sub_services/uia_service.dart`**
- Added `completePasswordPrompt(dynamic, String)` and `cancelPasswordPrompt(dynamic)` — cast `dynamic` to `UiaRequest<dynamic>` internally so screens don't need the matrix import

**`lib/features/calling/screens/call_pane.dart`**
- Updated `CallJoiningView` call site to construct `CallRoomAvatar` from inferred `Room?`

## Verification
- `flutter analyze`: 0 errors, 0 warnings, 0 info
- `flutter test`: 2318/2318 pass