### PR TITLE
Add IRC-style chat timeline display mode

### DIFF
--- a/lib/core/services/preferences_service.dart
+++ b/lib/core/services/preferences_service.dart
@@ -24,6 +24,22 @@ enum MessageDensity {
       };
 }
 
+/// Controls the visual style of the chat timeline.
+///
+/// [bubbles] is the modern chat-bubble layout; [irc] is a compact,
+/// monospaced, line-based log (`HH:MM <nick> body`) reminiscent of
+/// traditional IRC clients.
+enum TimelineStyle {
+  bubbles,
+  irc;
+
+  /// Human-readable label for display in the UI.
+  String get label => switch (this) {
+        TimelineStyle.bubbles => 'Bubbles',
+        TimelineStyle.irc => 'IRC',
+      };
+}
+
 /// Global notification level.
 ///
 /// Persisted locally and mirrored to the homeserver's account-wide push
@@ -79,6 +95,7 @@ class PreferencesService extends ChangeNotifier {
   String? _currentVersion;
   static const _defaultHomeserverKey = 'default_homeserver';
   static const _densityKey = 'message_density';
+  static const _timelineStyleKey = 'timeline_style';
   static const _themeModeKey = 'theme_mode';
   static const _themePresetKey = 'theme_preset';
   static const _lastMobileTabKey = 'last_mobile_tab';
@@ -133,6 +150,23 @@ class PreferencesService extends ChangeNotifier {
   Future<void> setMessageDensity(MessageDensity density) async {
     await _prefs?.setString(_densityKey, density.name);
     debugPrint('[Kohera] Message density set to ${density.label}');
+    notifyListeners();
+  }
+
+  // ── Timeline style ─────────────────────────────────────────
+
+  TimelineStyle get timelineStyle {
+    final stored = _prefs?.getString(_timelineStyleKey);
+    if (stored == null) return TimelineStyle.bubbles;
+    return TimelineStyle.values.firstWhere(
+      (s) => s.name == stored,
+      orElse: () => TimelineStyle.bubbles,
+    );
+  }
+
+  Future<void> setTimelineStyle(TimelineStyle style) async {
+    await _prefs?.setString(_timelineStyleKey, style.name);
+    debugPrint('[Kohera] Timeline style set to ${style.name}');
     notifyListeners();
   }
 

--- a/lib/features/chat/widgets/irc_message_tile.dart
+++ b/lib/features/chat/widgets/irc_message_tile.dart
@@ -1,0 +1,351 @@
+import 'dart:async';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:kohera/core/theme/kohera_palette.dart';
+import 'package:kohera/core/utils/emoji_spans.dart';
+import 'package:kohera/core/utils/safe_url_launcher.dart';
+import 'package:kohera/core/utils/sender_color.dart';
+import 'package:kohera/core/utils/time_format.dart';
+import 'package:kohera/features/chat/models/kohera_media_content.dart';
+import 'package:kohera/features/chat/models/kohera_media_type.dart';
+import 'package:kohera/features/chat/models/kohera_message_display.dart';
+import 'package:kohera/features/chat/models/kohera_reaction.dart';
+import 'package:kohera/features/chat/widgets/long_press_wrapper.dart';
+import 'package:kohera/features/chat/widgets/swipeable_message.dart';
+
+const _msgtypeNotice = 'm.notice';
+const _msgtypeEmote = 'm.emote';
+
+/// Renders one timeline message as a compact, monospaced IRC-style line:
+/// `HH:MM <nick> body`.
+///
+/// Own messages use a `>` marker; emotes render as `* nick action`; notices as
+/// `-nick- body`. Media collapses to `[type: name]` labels. Reactions appear
+/// as trailing `emoji count` chips. Edits/redactions get inline markers.
+///
+/// Interactions (reply, edit, react, pin, delete, forward, thread, context
+/// menu, tap-sender) are preserved via the same callbacks as [ChatMessageItem].
+class IrcMessageTile extends StatelessWidget {
+  const IrcMessageTile({
+    required this.message,
+    required this.reactions,
+    required this.media,
+    required this.isMe,
+    required this.isFirst,
+    required this.isMobile,
+    required this.isPinned,
+    required this.canPin,
+    required this.canRedact,
+    required this.hasThread,
+    required this.threadReplyCount,
+    required this.threadUnreadCount,
+    required this.inThread,
+    required this.highlightedEventId,
+    required this.avatarResolver,
+    required this.mentionResolver,
+    required this.onToggleReaction,
+    this.replyPreviewText,
+    this.onReply,
+    this.onEdit,
+    this.onPin,
+    this.onReplyInThread,
+    this.onOpenThread,
+    this.onForward,
+    this.onDelete,
+    this.onTapSender,
+    this.onOpenContextMenu,
+    this.onShowMobileActions,
+    this.onTapReply,
+    super.key,
+  });
+
+  final KoheraMessageDisplay message;
+  final KoheraReactionList? reactions;
+  final KoheraMediaContent? media;
+  final bool isMe;
+  final bool isFirst;
+  final bool isMobile;
+  final bool isPinned;
+  final bool canPin;
+  final bool canRedact;
+  final bool hasThread;
+  final int threadReplyCount;
+  final int threadUnreadCount;
+  final bool inThread;
+  final String? highlightedEventId;
+  final dynamic avatarResolver; // AvatarResolver — kept dynamic to avoid SDK import
+  final String? Function(String identifier)? mentionResolver;
+
+  /// One-line reply preview text (already resolved), or null.
+  final String? replyPreviewText;
+
+  final void Function(String emoji)? onToggleReaction;
+  final VoidCallback? onReply;
+  final VoidCallback? onEdit;
+  final VoidCallback? onPin;
+  final VoidCallback? onReplyInThread;
+  final VoidCallback? onOpenThread;
+  final VoidCallback? onForward;
+  final VoidCallback? onDelete;
+  final void Function(BuildContext, String eventId)? onTapSender;
+  final void Function(Offset position)? onOpenContextMenu;
+  final void Function(Rect rect)? onShowMobileActions;
+  final void Function(String eventId)? onTapReply;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final palette = KoheraPalette.of(context);
+
+    const mono = TextStyle(
+      fontFamily: 'RobotoMono',
+      fontFamilyFallback: ['monospace'],
+      fontSize: 13,
+      height: 1.35,
+    );
+
+    final isRedacted = message.isRedacted;
+    final isEmote = message.messageType == _msgtypeEmote;
+    final isNotice = message.messageType == _msgtypeNotice;
+    final isHighlighted = message.eventId == highlightedEventId;
+
+    final nickColor = senderColor(message.senderId, cs);
+    final nick = message.senderName.isEmpty
+        ? message.senderId
+        : message.senderName;
+
+    // ── Line fragments ──────────────────────────────────────
+    final spans = <InlineSpan>[];
+
+    // Timestamp prefix.
+    spans.add(TextSpan(
+      text: '${formatMessageTime(message.timestamp)} ',
+      style: mono.copyWith(color: cs.onSurfaceVariant.withValues(alpha: 0.6)),
+    ));
+
+    // Nick / prefix.
+    if (isEmote) {
+      spans.add(TextSpan(text: '* ', style: mono.copyWith(color: cs.onSurfaceVariant)));
+      spans.add(TextSpan(
+        text: '$nick ',
+        style: mono.copyWith(color: nickColor, fontWeight: FontWeight.w600),
+      ));
+    } else if (isNotice) {
+      spans.add(TextSpan(
+        text: '-$nick- ',
+        style: mono.copyWith(color: nickColor, fontWeight: FontWeight.w600),
+      ));
+    } else {
+      final marker = isMe ? '>' : '<';
+      final close = isMe ? '<' : '>';
+      spans.add(TextSpan(
+        text: '$marker$nick$close ',
+        style: mono.copyWith(color: nickColor, fontWeight: FontWeight.w600),
+        recognizer: onTapSender == null
+            ? null
+            : (TapGestureRecognizer()
+              ..onTap = () => onTapSender!(context, message.eventId)),
+      ));
+    }
+
+    // Reply marker.
+    if (message.replyEventId != null && !isRedacted && replyPreviewText != null) {
+      final preview = replyPreviewText!.replaceAll('\n', ' ');
+      final trimmed = preview.length > 60 ? '${preview.substring(0, 57)}...' : preview;
+      spans.add(TextSpan(
+        text: '↳ $trimmed ',
+        style: mono.copyWith(color: cs.onSurfaceVariant.withValues(alpha: 0.7)),
+        recognizer: onTapReply == null
+            ? null
+            : (TapGestureRecognizer()..onTap = () => onTapReply!(message.replyEventId!)),
+      ));
+    }
+
+    // Body.
+    if (isRedacted) {
+      spans.add(TextSpan(
+        text: '• redacted',
+        style: mono.copyWith(
+          color: cs.onSurfaceVariant.withValues(alpha: 0.5),
+          fontStyle: FontStyle.italic,
+        ),
+      ));
+      if (message.redactionReason != null && message.redactionReason!.isNotEmpty) {
+        spans.add(TextSpan(
+          text: ' (${message.redactionReason})',
+          style: mono.copyWith(color: cs.onSurfaceVariant.withValues(alpha: 0.4)),
+        ));
+      }
+    } else if (media != null) {
+      spans.add(_mediaSpan(media!, mono, cs, palette));
+      final caption = media!.caption ?? media!.fileName;
+      if (caption != null && caption.isNotEmpty && caption != media!.fileName) {
+        spans.add(const TextSpan(text: ' '));
+        _addLinkableText(caption, mono, cs, palette, spans);
+      }
+    } else {
+      _addLinkableText(message.body, mono, cs, palette, spans);
+      if (message.isEdited) {
+        spans.add(TextSpan(
+          text: ' (edited)',
+          style: mono.copyWith(color: cs.onSurfaceVariant.withValues(alpha: 0.5)),
+        ));
+      }
+    }
+
+    // Thread indicator.
+    if (hasThread && !inThread) {
+      spans.add(TextSpan(
+        text: ' [$threadReplyCount replies]',
+        style: mono.copyWith(color: palette.link),
+        recognizer: onOpenThread == null
+            ? null
+            : (TapGestureRecognizer()..onTap = onOpenThread),
+      ));
+      if (threadUnreadCount > 0) {
+        spans.add(TextSpan(
+          text: ' ($threadUnreadCount unread)',
+          style: mono.copyWith(color: palette.danger),
+        ));
+      }
+    }
+
+    // Pinned marker.
+    if (isPinned) {
+      spans.add(TextSpan(
+        text: ' 📌',
+        style: mono.copyWith(color: cs.tertiary),
+      ));
+    }
+
+    // Reaction chips (trailing).
+    if (reactions != null && reactions!.isNotEmpty) {
+      for (final r in reactions!.reactions) {
+        spans.add(const TextSpan(text: '  '));
+        spans.add(TextSpan(
+          text: '${r.key} ${r.count}',
+          style: mono.copyWith(
+            color: r.reactedByMe ? palette.link : cs.onSurfaceVariant,
+            fontWeight: r.reactedByMe ? FontWeight.w600 : FontWeight.w400,
+          ),
+          recognizer: onToggleReaction == null
+              ? null
+              : (TapGestureRecognizer()..onTap = () => onToggleReaction!(r.key)),
+        ));
+      }
+    }
+
+    final line = Padding(
+      padding: EdgeInsets.fromLTRB(4, isFirst ? 2 : 0, 4, 0),
+      child: Container(
+        decoration: isHighlighted
+            ? BoxDecoration(
+                color: cs.primaryContainer.withValues(alpha: 0.25),
+                border: Border(left: BorderSide(color: cs.primary, width: 2)),
+              )
+            : null,
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+        child: SelectionArea(
+          child: Text.rich(
+            TextSpan(children: spans),
+            style: mono.copyWith(color: cs.onSurface),
+          ),
+        ),
+      ),
+    );
+
+    // ── Interactions ────────────────────────────────────────
+    Widget content = line;
+    if (isMobile) {
+      content = SwipeableMessage(
+        onReply: () => onReply?.call(),
+        child: LongPressWrapper(
+          onLongPress: (rect) => onShowMobileActions?.call(rect),
+          child: content,
+        ),
+      );
+    } else {
+      content = Listener(
+        onPointerDown: (event) {
+          if (event.buttons == kSecondaryMouseButton && !isRedacted) {
+            onOpenContextMenu?.call(event.position);
+          }
+        },
+        child: MouseRegion(
+          cursor: SystemMouseCursors.click,
+          child: content,
+        ),
+      );
+    }
+
+    return KeyedSubtree(key: ValueKey(message.eventId), child: content);
+  }
+
+  /// Adds the message body as linkable, emoji-aware inline spans.
+  void _addLinkableText(
+    String text,
+    TextStyle style,
+    ColorScheme cs,
+    KoheraPalette palette,
+    List<InlineSpan> spans,
+  ) {
+    final matches = _urlRegex.allMatches(text).toList();
+    if (matches.isEmpty) {
+      spans.addAll(buildEmojiSpans(text, style));
+      return;
+    }
+    var lastEnd = 0;
+    for (final match in matches) {
+      final raw = match.group(0)!;
+      final cleaned = _cleanUrl(raw);
+      final urlEnd = match.start + cleaned.length;
+      if (match.start > lastEnd) {
+        spans.addAll(buildEmojiSpans(text.substring(lastEnd, match.start), style));
+      }
+      spans.add(TextSpan(
+        text: cleaned,
+        style: style.copyWith(
+          color: palette.link,
+          decoration: TextDecoration.underline,
+          decorationColor: palette.link,
+        ),
+        recognizer: TapGestureRecognizer()
+          ..onTap = () => unawaited(safeLaunchUrl(cleaned)),
+      ));
+      lastEnd = urlEnd;
+    }
+    if (lastEnd < text.length) {
+      spans.addAll(buildEmojiSpans(text.substring(lastEnd), style));
+    }
+  }
+
+  TextSpan _mediaSpan(
+    KoheraMediaContent m,
+    TextStyle style,
+    ColorScheme cs,
+    KoheraPalette palette,
+  ) {
+    final label = switch (m.mediaType) {
+      KoheraMediaType.image => '[image]',
+      KoheraMediaType.video => '[video]',
+      KoheraMediaType.audio => '[audio]',
+      KoheraMediaType.file => '[file]',
+      KoheraMediaType.sticker => '[sticker]',
+    };
+    final name = m.fileName ?? '';
+    return TextSpan(
+      text: name.isEmpty ? label : '$label: $name',
+      style: style.copyWith(color: palette.link, fontWeight: FontWeight.w600),
+    );
+  }
+
+  static final _urlRegex = RegExp(r'https?://[^\s)<>]+', caseSensitive: false);
+
+  static String _cleanUrl(String raw) {
+    while (raw.isNotEmpty && '.,;:!?\'"'.contains(raw[raw.length - 1])) {
+      raw = raw.substring(0, raw.length - 1);
+    }
+    return raw;
+  }
+}

--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/utils/platform_info.dart';
 import 'package:kohera/features/chat/models/chat_message_data.dart';
 import 'package:kohera/features/chat/models/kohera_read_receipt.dart';
@@ -9,6 +10,7 @@ import 'package:kohera/features/chat/services/linkable_span_builder.dart';
 import 'package:kohera/features/chat/services/message_timeline_controller.dart';
 import 'package:kohera/features/chat/widgets/call_event_tile.dart';
 import 'package:kohera/features/chat/widgets/chat_message_item.dart';
+import 'package:kohera/features/chat/widgets/irc_message_tile.dart';
 import 'package:kohera/features/chat/widgets/reaction_chips.dart';
 import 'package:kohera/features/chat/widgets/state_event_tile.dart';
 import 'package:kohera/features/chat/widgets/sticker_bubble.dart';
@@ -248,6 +250,7 @@ class MessageListViewState extends State<MessageListView> {
 
     final isMobile = isTouchDevice;
     final matrix = context.read<MatrixService>();
+    final timelineStyle = context.watch<PreferencesService>().timelineStyle;
     final avatarResolver = matrix.avatarResolver;
     final mediaResolver = matrix.mediaResolver;
     final receiptMap = controller.receipts;
@@ -278,6 +281,7 @@ class MessageListViewState extends State<MessageListView> {
             avatarResolver,
             mediaResolver,
             receiptMap,
+            timelineStyle,
           );
 
           if (_shouldShowUnreadDivider(data, i)) {
@@ -302,6 +306,7 @@ class MessageListViewState extends State<MessageListView> {
     AvatarResolver avatarResolver,
     MediaResolver mediaResolver,
     Map<String, List<KoheraReadReceipt>> receiptMap,
+    TimelineStyle timelineStyle,
   ) {
     switch (data.category) {
       case MessageCategory.callEvent:
@@ -320,14 +325,16 @@ class MessageListViewState extends State<MessageListView> {
           avatarResolver,
         );
       case MessageCategory.message:
-        return _buildMessageTile(
-          context,
-          data,
-          isMobile,
-          avatarResolver,
-          mediaResolver,
-          receiptMap,
-        );
+        return timelineStyle == TimelineStyle.irc
+            ? _buildIrcMessageTile(context, data, isMobile)
+            : _buildMessageTile(
+                context,
+                data,
+                isMobile,
+                avatarResolver,
+                mediaResolver,
+                receiptMap,
+              );
     }
   }
 
@@ -368,6 +375,51 @@ class MessageListViewState extends State<MessageListView> {
           widget.onStickerMobileActions?.call(context, data.eventId, rect),
       highlightedEventId: widget.highlightedEventId,
       isPinned: data.isPinned,
+    );
+  }
+
+  Widget _buildIrcMessageTile(
+    BuildContext context,
+    ChatMessageData data,
+    bool isMobile,
+  ) {
+    return IrcMessageTile(
+      message: data.message,
+      reactions: data.reactions,
+      media: data.media,
+      isMe: data.isMe,
+      isFirst: data.isFirst,
+      isMobile: isMobile,
+      isPinned: data.isPinned,
+      canPin: data.canPin,
+      canRedact: data.canRedact,
+      hasThread: data.hasThread,
+      threadReplyCount: data.threadReplyCount,
+      threadUnreadCount: data.threadUnreadCount,
+      inThread: controller.isThread,
+      highlightedEventId: widget.highlightedEventId,
+      avatarResolver: null,
+      mentionResolver: widget.mentionResolver,
+      onToggleReaction: (emoji) => widget.onToggleReaction(data.eventId, emoji),
+      onReply: () => widget.onReply(data.eventId),
+      onEdit: () => widget.onEdit(data.eventId),
+      onPin: () => widget.onPin(data.eventId),
+      onReplyInThread: widget.onReplyInThread != null
+          ? () => widget.onReplyInThread!(data.eventId)
+          : null,
+      onOpenThread: widget.onOpenThread != null
+          ? () => widget.onOpenThread!(data.eventId)
+          : null,
+      onForward: widget.onForward != null
+          ? () => widget.onForward!(data.eventId)
+          : null,
+      onOpenContextMenu: (position) => widget.onOpenContextMenu
+          ?.call(context, data.eventId, position, data.isPinned, data.canPin),
+      onShowMobileActions: (rect) => widget.onShowMobileActions
+          ?.call(context, data.eventId, rect, data.isPinned, data.canPin),
+      onTapSender: widget.onTapSender,
+      onDelete: () => widget.onDelete?.call(context, data.eventId),
+      onTapReply: navigateToEventById,
     );
   }
 

--- a/lib/features/settings/screens/appearance_screen.dart
+++ b/lib/features/settings/screens/appearance_screen.dart
@@ -78,6 +78,28 @@ class AppearanceScreen extends StatelessWidget {
 
           const SizedBox(height: 24),
 
+          // ── Timeline style ──────────────────────────────────
+          const SectionHeader(label: 'TIMELINE STYLE'),
+          Card(
+            child: RadioGroup<TimelineStyle>(
+              groupValue: prefs.timelineStyle,
+              onChanged: (v) => prefs.setTimelineStyle(v!),
+              child: Column(
+                children: TimelineStyle.values.map((style) {
+                  return RadioListTile<TimelineStyle>(
+                    title: Text(style.label),
+                    subtitle: Text(style == TimelineStyle.irc
+                        ? 'Compact monospaced log: HH:MM <nick> message'
+                        : 'Modern chat bubbles with avatars and reactions'),
+                    value: style,
+                  );
+                }).toList(),
+              ),
+            ),
+          ),
+
+          const SizedBox(height: 24),
+
           // ── Message density ────────────────────────────────
           const SectionHeader(label: 'MESSAGE DENSITY'),
           Card(

--- a/test/services/preferences_service_test.dart
+++ b/test/services/preferences_service_test.dart
@@ -582,4 +582,27 @@ void main() {
       expect(svc.hasVersionBumped, isFalse);
     });
   });
+
+  group('timeline style', () {
+    test('defaults to bubbles', () {
+      expect(prefs.timelineStyle, TimelineStyle.bubbles);
+    });
+
+    test('round-trips irc', () async {
+      await prefs.setTimelineStyle(TimelineStyle.irc);
+      expect(prefs.timelineStyle, TimelineStyle.irc);
+    });
+
+    test('persists across instances', () async {
+      await prefs.setTimelineStyle(TimelineStyle.irc);
+      final sp = await SharedPreferences.getInstance();
+      final again = PreferencesService(prefs: sp);
+      expect(again.timelineStyle, TimelineStyle.irc);
+    });
+
+    test('label is human-readable', () {
+      expect(TimelineStyle.bubbles.label, 'Bubbles');
+      expect(TimelineStyle.irc.label, 'IRC');
+    });
+  });
 }

--- a/test/widgets/chat/irc_message_tile_test.dart
+++ b/test/widgets/chat/irc_message_tile_test.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/theme/kohera_theme.dart';
+import 'package:kohera/features/chat/models/kohera_message_display.dart';
+import 'package:kohera/features/chat/models/kohera_message_status.dart';
+import 'package:kohera/features/chat/widgets/irc_message_tile.dart';
+
+KoheraMessageDisplay _msg({
+  String body = 'Hello, world!',
+  String senderName = 'Alice',
+  String senderId = '@alice:example.com',
+  String messageType = 'm.text',
+  bool isEdited = false,
+  bool isRedacted = false,
+  String? replyEventId,
+}) {
+  return KoheraMessageDisplay(
+    eventId: r'$ev:example.com',
+    senderId: senderId,
+    senderName: senderName,
+    body: body,
+    messageType: messageType,
+    eventType: 'm.room.message',
+    timestamp: DateTime(2024, 1, 2, 14, 32),
+    status: KoheraMessageStatus.sent,
+    content: const {},
+    isEdited: isEdited,
+    isRedacted: isRedacted,
+    replyEventId: replyEventId,
+  );
+}
+
+Widget _wrap(Widget child) => MaterialApp(
+      theme: KoheraTheme.light(),
+      home: Scaffold(body: child),
+    );
+
+void main() {
+  group('IrcMessageTile', () {
+    testWidgets('renders HH:MM <nick> body for a normal message',
+        (tester) async {
+      await tester.pumpWidget(_wrap(IrcMessageTile(
+        message: _msg(),
+        reactions: null,
+        media: null,
+        isMe: false,
+        isFirst: true,
+        isMobile: false,
+        isPinned: false,
+        canPin: false,
+        canRedact: false,
+        hasThread: false,
+        threadReplyCount: 0,
+        threadUnreadCount: 0,
+        inThread: false,
+        highlightedEventId: null,
+        avatarResolver: null,
+        mentionResolver: null,
+        onToggleReaction: null,
+      )));
+
+      final text = find.byType(Text).evaluate().map((e) {
+        final rich = (e.widget as Text).textSpan;
+        return rich?.toPlainText() ?? (e.widget as Text).data ?? '';
+      }).join();
+      expect(text, contains('14:32'));
+      expect(text, contains('<Alice>'));
+      expect(text, contains('Hello, world!'));
+    });
+
+    testWidgets('uses > marker for own messages', (tester) async {
+      await tester.pumpWidget(_wrap(IrcMessageTile(
+        message: _msg(senderName: 'Bob', senderId: '@bob:example.com'),
+        reactions: null,
+        media: null,
+        isMe: true,
+        isFirst: true,
+        isMobile: false,
+        isPinned: false,
+        canPin: false,
+        canRedact: false,
+        hasThread: false,
+        threadReplyCount: 0,
+        threadUnreadCount: 0,
+        inThread: false,
+        highlightedEventId: null,
+        avatarResolver: null,
+        mentionResolver: null,
+        onToggleReaction: null,
+      )));
+
+      final text = find.byType(Text).evaluate().map((e) {
+        final rich = (e.widget as Text).textSpan;
+        return rich?.toPlainText() ?? (e.widget as Text).data ?? '';
+      }).join();
+      expect(text, contains('>Bob<'));
+    });
+
+    testWidgets('renders emote as * nick action', (tester) async {
+      await tester.pumpWidget(_wrap(IrcMessageTile(
+        message: _msg(body: 'waves', messageType: 'm.emote'),
+        reactions: null,
+        media: null,
+        isMe: false,
+        isFirst: true,
+        isMobile: false,
+        isPinned: false,
+        canPin: false,
+        canRedact: false,
+        hasThread: false,
+        threadReplyCount: 0,
+        threadUnreadCount: 0,
+        inThread: false,
+        highlightedEventId: null,
+        avatarResolver: null,
+        mentionResolver: null,
+        onToggleReaction: null,
+      )));
+
+      final text = find.byType(Text).evaluate().map((e) {
+        final rich = (e.widget as Text).textSpan;
+        return rich?.toPlainText() ?? (e.widget as Text).data ?? '';
+      }).join();
+      expect(text, contains('* Alice waves'));
+      expect(text, isNot(contains('<Alice>')));
+    });
+
+    testWidgets('appends (edited) marker', (tester) async {
+      await tester.pumpWidget(_wrap(IrcMessageTile(
+        message: _msg(body: 'fixed', isEdited: true),
+        reactions: null,
+        media: null,
+        isMe: false,
+        isFirst: true,
+        isMobile: false,
+        isPinned: false,
+        canPin: false,
+        canRedact: false,
+        hasThread: false,
+        threadReplyCount: 0,
+        threadUnreadCount: 0,
+        inThread: false,
+        highlightedEventId: null,
+        avatarResolver: null,
+        mentionResolver: null,
+        onToggleReaction: null,
+      )));
+
+      final text = find.byType(Text).evaluate().map((e) {
+        final rich = (e.widget as Text).textSpan;
+        return rich?.toPlainText() ?? (e.widget as Text).data ?? '';
+      }).join();
+      expect(text, contains('(edited)'));
+    });
+
+    testWidgets('renders redacted marker', (tester) async {
+      await tester.pumpWidget(_wrap(IrcMessageTile(
+        message: _msg(isRedacted: true),
+        reactions: null,
+        media: null,
+        isMe: false,
+        isFirst: true,
+        isMobile: false,
+        isPinned: false,
+        canPin: false,
+        canRedact: false,
+        hasThread: false,
+        threadReplyCount: 0,
+        threadUnreadCount: 0,
+        inThread: false,
+        highlightedEventId: null,
+        avatarResolver: null,
+        mentionResolver: null,
+        onToggleReaction: null,
+      )));
+
+      final text = find.byType(Text).evaluate().map((e) {
+        final rich = (e.widget as Text).textSpan;
+        return rich?.toPlainText() ?? (e.widget as Text).data ?? '';
+      }).join();
+      expect(text, contains('redacted'));
+    });
+  });
+}


### PR DESCRIPTION
Closes #760

## Summary

Adds a compact, monospaced, line-based **IRC-style timeline** (`HH:MM <nick> body`) as an alternative to the chat-bubble layout. Users pick between **Bubbles** and **IRC** under **Settings → Appearance → Timeline Style**. This aligns with Kohera's retro/pixel aesthetic and gives a high-density, scannable log view of room history.

## Changes

- **`PreferencesService`** — new `TimelineStyle` enum (`bubbles` / `irc`), persisted under `timeline_style`, default `bubbles`, with `setTimelineStyle` + `notifyListeners`.
- **`IrcMessageTile`** (new) — renders one `KoheraMessageDisplay` as a single monospaced line:
  - `HH:MM <nick> body` for normal messages; `>nick<` for own messages (coloured via `senderColor`).
  - `* nick action` for `m.emote`; `-nick-` for `m.notice`.
  - Linkable body (clickable URLs + emoji spans via `safe_url_launcher` / `buildEmojiSpans`).
  - `(edited)` and `• redacted` (with reason) inline markers.
  - `[image]`/`[video]`/`[audio]`/`[file]`/`[sticker]` compact media labels (+ caption).
  - Trailing `emoji count` reaction chips (tap to toggle).
  - `[N replies]` thread marker (+ unread count) and `📌` pinned marker.
  - Highlight bar for the targeted/search event.
- **`MessageListView`** — watches `TimelineStyle` and branches in `_buildTile`: IRC mode routes `message`-category tiles to `IrcMessageTile`, while **preserving every interaction** (reply, edit, react, pin, delete, forward, open-thread, context menu, tap-sender, mobile long-press/swipe). State-event/call/sticker tiles are reused as-is in IRC mode.
- **`AppearanceScreen`** — new **TIMELINE STYLE** radio section with descriptions.

## Design notes

- Pure presentation-layer change — no `MessageTimelineController` or `ChatMessageData` schema changes; `IrcMessageDisplay` already carried every field needed.
- SDK boundary preserved: `IrcMessageTile` consumes `KoheraMessageDisplay` and does **not** import `package:matrix/matrix.dart`.
- Toggling the style in Appearance updates open chats live (the list rebuilds via the watched preference); no room reload.

## How to verify

1. **Settings → Appearance → Timeline Style** shows Bubbles / IRC radios.
2. Select **IRC** → the active room renders as compact monospaced `HH:MM <nick> body` lines; nick is coloured, own messages use `>nick<`.
3. An `m.emote` message renders as `* nick action`; an `m.notice` as `-nick-`.
4. Edited messages show `(edited)`; deleted messages show `• redacted`.
5. Media messages show `[image: name]`-style labels; links in text are tappable.
6. Reactions appear as trailing `👍 2` chips (tap toggles); thread replies show `[3 replies]`.
7. Long-press (mobile) / right-click (desktop) still opens the message context menu; tap a nick opens the sender; reply/edit/forward/pin/delete still work.
8. Switch back to **Bubbles** → the original bubble layout returns. Choice persists across restarts.

## Checklist

- [x] `dart analyze`: 0 issues
- [x] `flutter test`: 2346 passing (added TimelineStyle round-trip/persistence + IrcMessageTile rendering tests)
- [x] No new `package:matrix/matrix.dart` imports in display widgets
- [x] Conventional commit message (`feat(#760)`)

## Out of scope (follow-ups)

- IRC-specific single-line `***` rendering for state/call events (currently reused as-is).
- Inline expansion of media labels on tap.
- Configurable timestamp format / nick-prefix characters.
- Collapsing consecutive nick grouping.