### PR TITLE
Remove dead dynamic avatarResolver param from IrcMessageTile

### DIFF
--- a/lib/features/chat/widgets/irc_message_tile.dart
+++ b/lib/features/chat/widgets/irc_message_tile.dart
@@ -42,7 +42,6 @@ class IrcMessageTile extends StatelessWidget {
     required this.threadUnreadCount,
     required this.inThread,
     required this.highlightedEventId,
-    required this.avatarResolver,
     required this.mentionResolver,
     required this.onToggleReaction,
     this.replyPreviewText,
@@ -74,7 +73,6 @@ class IrcMessageTile extends StatelessWidget {
   final int threadUnreadCount;
   final bool inThread;
   final String? highlightedEventId;
-  final dynamic avatarResolver; // AvatarResolver — kept dynamic to avoid SDK import
   final String? Function(String identifier)? mentionResolver;
 
   /// One-line reply preview text (already resolved), or null.

--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -398,7 +398,6 @@ class MessageListViewState extends State<MessageListView> {
       threadUnreadCount: data.threadUnreadCount,
       inThread: controller.isThread,
       highlightedEventId: widget.highlightedEventId,
-      avatarResolver: null,
       mentionResolver: widget.mentionResolver,
       onToggleReaction: (emoji) => widget.onToggleReaction(data.eventId, emoji),
       onReply: () => widget.onReply(data.eventId),

--- a/test/widgets/chat/irc_message_tile_test.dart
+++ b/test/widgets/chat/irc_message_tile_test.dart
@@ -54,7 +54,6 @@ void main() {
         threadUnreadCount: 0,
         inThread: false,
         highlightedEventId: null,
-        avatarResolver: null,
         mentionResolver: null,
         onToggleReaction: null,
       )));
@@ -84,7 +83,6 @@ void main() {
         threadUnreadCount: 0,
         inThread: false,
         highlightedEventId: null,
-        avatarResolver: null,
         mentionResolver: null,
         onToggleReaction: null,
       )));
@@ -112,7 +110,6 @@ void main() {
         threadUnreadCount: 0,
         inThread: false,
         highlightedEventId: null,
-        avatarResolver: null,
         mentionResolver: null,
         onToggleReaction: null,
       )));
@@ -141,7 +138,6 @@ void main() {
         threadUnreadCount: 0,
         inThread: false,
         highlightedEventId: null,
-        avatarResolver: null,
         mentionResolver: null,
         onToggleReaction: null,
       )));
@@ -169,7 +165,6 @@ void main() {
         threadUnreadCount: 0,
         inThread: false,
         highlightedEventId: null,
-        avatarResolver: null,
         mentionResolver: null,
         onToggleReaction: null,
       )));


### PR DESCRIPTION
Cleanup follow-up to #760 (PR #766).

## Problem

IrcMessageTile declared an avatarResolver parameter typed as dynamic (with a comment "kept dynamic to avoid SDK import"). This was wrong on two counts:

1. It was typed dynamic to sidestep importing AvatarResolver — defeating type safety and risking leaking Matrix SDK types through an untyped seam, exactly the boundary discipline the codebase enforces.
2. The parameter was entirely dead — IRC logs render no avatars, so IrcMessageTile never references it. MessageListView passed avatarResolver: null, and the tests passed avatarResolver: null.

This landed on master because PR #766 was merged at its pre-fix commit (the avatarResolver removal had not synced to the PR head before the merge).

## Fix

Drop the avatarResolver parameter from IrcMessageTile entirely, and remove the null argument at the call site in MessageListView and in irc_message_tile_test.dart.

The remaining avatarResolver references in MessageListView are the legitimate bubble-path ones (unchanged).

## Verification

- dart analyze: 0 issues
- flutter test: 2346 passing
