### PR TITLE
fix(#771): respect top safe-area inset on call and key-backup banners

### DIFF
--- a/lib/features/calling/widgets/voice_banner.dart
+++ b/lib/features/calling/widgets/voice_banner.dart
@@ -6,7 +6,6 @@ import 'package:kohera/features/calling/widgets/call_state_views.dart'
     show formatCallElapsed;
 import 'package:provider/provider.dart';
 
-
 class VoiceBanner extends StatefulWidget {
   const VoiceBanner({required this.currentViewingRoomId, super.key});
 
@@ -61,27 +60,34 @@ class _VoiceBannerState extends State<VoiceBanner> {
     final elapsedText = elapsed != null ? formatCallElapsed(elapsed) : '';
     final cs = Theme.of(context).colorScheme;
 
-    return Material(
-      color: cs.primaryContainer,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
-        child: Row(
-          children: [
-            Icon(Icons.headset_mic_rounded, size: 16, color: cs.onPrimaryContainer),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                '$roomName \u2014 $elapsedText',
-                style: TextStyle(color: cs.onPrimaryContainer, fontSize: 13),
-                overflow: TextOverflow.ellipsis,
+    return SafeArea(
+      bottom: false,
+      child: Material(
+        color: cs.primaryContainer,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+          child: Row(
+            children: [
+              Icon(
+                Icons.headset_mic_rounded,
+                size: 16,
+                color: cs.onPrimaryContainer,
               ),
-            ),
-            TextButton(
-              onPressed: () => CallNavigator.endCall(context),
-              style: TextButton.styleFrom(foregroundColor: cs.error),
-              child: const Text('Disconnect'),
-            ),
-          ],
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '$roomName \u2014 $elapsedText',
+                  style: TextStyle(color: cs.onPrimaryContainer, fontSize: 13),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              TextButton(
+                onPressed: () => CallNavigator.endCall(context),
+                style: TextButton.styleFrom(foregroundColor: cs.error),
+                child: const Text('Disconnect'),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/e2ee/widgets/key_backup_banner.dart
+++ b/lib/features/e2ee/widgets/key_backup_banner.dart
@@ -35,75 +35,79 @@ class _KeyBackupBannerContent extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
 
-    return Material(
-      color: Colors.transparent,
-      child: Semantics(
-        label: 'Key backup not set up. Tap to configure.',
-        button: true,
-        child: InkWell(
-          onTap: () => context.go(RoutePaths.e2eeSetup),
-          child: Container(
-          constraints: const BoxConstraints(minHeight: 48),
-          padding: const EdgeInsets.only(left: 12, right: 4),
-          decoration: BoxDecoration(
-            border: Border(
-              left: BorderSide(color: cs.onTertiaryContainer, width: 3),
+    return SafeArea(
+      bottom: false,
+      child: Material(
+        color: Colors.transparent,
+        child: Semantics(
+          label: 'Key backup not set up. Tap to configure.',
+          button: true,
+          child: InkWell(
+            onTap: () => context.go(RoutePaths.e2eeSetup),
+            child: Container(
+              constraints: const BoxConstraints(minHeight: 48),
+              padding: const EdgeInsets.only(left: 12, right: 4),
+              decoration: BoxDecoration(
+                border: Border(
+                  left: BorderSide(color: cs.onTertiaryContainer, width: 3),
+                ),
+                color: cs.tertiaryContainer,
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.shield_outlined,
+                    size: 18,
+                    color: cs.onTertiaryContainer,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Protect your messages',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: tt.titleSmall?.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: cs.onTertiaryContainer,
+                          ),
+                        ),
+                        Text(
+                          'Without key backup, you may lose message history '
+                          'and some features will not work',
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: tt.bodySmall?.copyWith(
+                            color: cs.onTertiaryContainer
+                                .withValues(alpha: 0.85),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () => context.go(RoutePaths.e2eeSetup),
+                    style: TextButton.styleFrom(
+                      foregroundColor: cs.onTertiaryContainer,
+                    ),
+                    child: const Text('Set up'),
+                  ),
+                  IconButton(
+                    onPressed: () =>
+                        context.read<ChatBackupService>().dismissBanner(),
+                    icon: const Icon(Icons.close, size: 18),
+                    color: cs.onTertiaryContainer,
+                    tooltip: 'Dismiss',
+                    visualDensity: VisualDensity.compact,
+                  ),
+                ],
+              ),
             ),
-            color: cs.tertiaryContainer,
-          ),
-          child: Row(
-            children: [
-              Icon(
-                Icons.shield_outlined,
-                size: 18,
-                color: cs.onTertiaryContainer,
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'Protect your messages',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: tt.titleSmall?.copyWith(
-                        fontWeight: FontWeight.w600,
-                        color: cs.onTertiaryContainer,
-                      ),
-                    ),
-                    Text(
-                      'Without key backup, you may lose message history '
-                      'and some features will not work',
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: tt.bodySmall?.copyWith(
-                        color: cs.onTertiaryContainer.withValues(alpha: 0.85),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              TextButton(
-                onPressed: () => context.go(RoutePaths.e2eeSetup),
-                style: TextButton.styleFrom(
-                  foregroundColor: cs.onTertiaryContainer,
-                ),
-                child: const Text('Set up'),
-              ),
-              IconButton(
-                onPressed: () =>
-                    context.read<ChatBackupService>().dismissBanner(),
-                icon: const Icon(Icons.close, size: 18),
-                color: cs.onTertiaryContainer,
-                tooltip: 'Dismiss',
-                visualDensity: VisualDensity.compact,
-              ),
-            ],
           ),
         ),
-      ),
       ),
     );
   }

--- a/test/widgets/key_backup_banner_test.dart
+++ b/test/widgets/key_backup_banner_test.dart
@@ -141,6 +141,21 @@ void main() {
 
       expect(find.text('Protect your messages'), findsOneWidget);
     });
+
+    testWidgets('content wrapped in SafeArea to avoid status-bar overlap',
+        (tester) async {
+      when(mockChatBackup.chatBackupNeeded).thenReturn(true);
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(
+        find.ancestor(
+          of: find.byIcon(Icons.shield_outlined),
+          matching: find.byType(SafeArea),
+        ),
+        findsOneWidget,
+      );
+    });
   });
 }
 

--- a/test/widgets/voice_banner_test.dart
+++ b/test/widgets/voice_banner_test.dart
@@ -84,5 +84,29 @@ void main() {
       expect(find.textContaining('Call Room'), findsOneWidget);
       expect(find.textContaining('01:30'), findsOneWidget);
     });
+
+    testWidgets('wrapped in SafeArea to avoid status-bar overlap',
+        (tester) async {
+      when(mockCallService.callState).thenReturn(KoheraCallState.connected);
+      when(mockCallService.activeCallRoomId).thenReturn('!call-room:example.com');
+      when(mockCallService.callElapsed)
+          .thenReturn(const Duration(minutes: 1));
+      when(mockClient.getRoomById('!call-room:example.com'))
+          .thenReturn(mockRoom);
+      when(mockRoom.getLocalizedDisplayname()).thenReturn('Call Room');
+
+      await tester.pumpWidget(
+        buildTestWidget(currentViewingRoomId: '!other:example.com'),
+      );
+      await tester.pump();
+
+      expect(
+        find.ancestor(
+          of: find.byIcon(Icons.headset_mic_rounded),
+          matching: find.byType(SafeArea),
+        ),
+        findsOneWidget,
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

The persistent voice-call banner and key-backup banner render as the first children of the top-level `Column` in `HomeShell`, which has no `Scaffold`/`SafeArea` ancestor. On iPhone they drew into the status-bar / notch / Dynamic Island region. This wraps each banner's visible content in `SafeArea(bottom: false)` so the top inset applies only while the banner is shown.

## Changes

- `lib/features/calling/widgets/voice_banner.dart` — wrapped the visible `Material` in `SafeArea(bottom: false)` *after* the hidden `SizedBox.shrink` early-return, so the inset applies only when the banner is visible.
- `lib/features/e2ee/widgets/key_backup_banner.dart` — wrapped `_KeyBackupBannerContent`'s `Material` in `SafeArea(bottom: false)`; the empty `SizedBox.shrink` branch stays zero-height (no gap when hidden). Shares the same latent issue noted in the bug report.
- `JoinCallBanner` left untouched — it renders inside the chat `Scaffold` body, so its `AppBar` insets already apply.

## Testing

- [x] `flutter analyze` is clean (changed files)
- [x] `flutter test` passes — `test/widgets/voice_banner_test.dart`, `test/widgets/key_backup_banner_test.dart` (all 12 tests)
- Added regression tests asserting each banner's content is wrapped in `SafeArea` (`find.ancestor` checks).

## Screenshots / recordings

N/A — inset behavior; verified via widget tests.

## Linked issues

Closes #771

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master`