### PR TITLE
refactor(e2ee): restructure E2EE setup screen as progressive page

### DIFF
--- a/lib/features/e2ee/screens/e2ee_setup_screen.dart
+++ b/lib/features/e2ee/screens/e2ee_setup_screen.dart
@@ -6,18 +6,20 @@ import 'package:go_router/go_router.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart';
+import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:kohera/features/e2ee/services/bootstrap_controller.dart';
-import 'package:kohera/features/e2ee/widgets/key_verification_inline.dart';
+import 'package:kohera/features/e2ee/widgets/setup/setup_actions_bar.dart';
+import 'package:kohera/features/e2ee/widgets/setup/setup_custody_gate.dart';
+import 'package:kohera/features/e2ee/widgets/setup/setup_done_banner.dart';
+import 'package:kohera/features/e2ee/widgets/setup/setup_error_section.dart';
+import 'package:kohera/features/e2ee/widgets/setup/setup_explainer.dart';
+import 'package:kohera/features/e2ee/widgets/setup/setup_key_card.dart';
+import 'package:kohera/features/e2ee/widgets/setup/setup_management_panel.dart';
+import 'package:kohera/features/e2ee/widgets/setup/setup_status_line.dart';
+import 'package:kohera/features/e2ee/widgets/setup/setup_unlock_section.dart';
+import 'package:kohera/features/e2ee/widgets/setup/setup_verify_section.dart';
 import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:provider/provider.dart';
-import 'package:url_launcher/url_launcher.dart';
-
-const String _recoveryKeyDocsUrl =
-    'https://github.com/Quantumheart/Kohera/blob/master/docs/recovery-key-storage.md';
-
-// ── Screen-local steps (outside bootstrap lifecycle) ───────────
-
-enum _ScreenStep { skipConfirm, createNewKey, management, disableConfirm }
 
 class E2eeSetupScreen extends StatefulWidget {
   const E2eeSetupScreen({super.key});
@@ -32,8 +34,8 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
   final _recoveryKeyController = TextEditingController();
   bool _uiaPromptShowing = false;
   bool _autoStarted = false;
+  bool _showManagement = false;
   Timer? _doneTimer;
-  _ScreenStep? _localStep;
 
   @override
   void initState() {
@@ -42,7 +44,7 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
     _matrixService.uia.passwordPromptBuilder = _showPasswordPrompt;
 
     if (_matrixService.chatBackup.chatBackupEnabled) {
-      _localStep = _ScreenStep.management;
+      _showManagement = true;
     }
   }
 
@@ -59,12 +61,13 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
 
   void _startBootstrap({bool wipeExisting = false}) {
     _cleanupController();
+    _showManagement = false;
     _controller = BootstrapController(
       matrixService: _matrixService,
       wipeExisting: wipeExisting,
     );
     _controller!.addListener(_onControllerChanged);
-    setState(() => _localStep = null);
+    if (mounted) setState(() {});
     unawaited(_controller!.startBootstrap());
   }
 
@@ -143,6 +146,61 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
     return password != null && password.isNotEmpty ? password : null;
   }
 
+  // ── Confirmations ─────────────────────────────────────────────
+
+  Future<void> _confirmSkip() async {
+    final confirmed = await confirmDialog(
+      context,
+      title: 'Skip chat backup setup?',
+      message:
+          'Without key backup:\n'
+          '• Message history is lost\n'
+          "• Cross-device verification won't work\n"
+          '• Some features may not work\n\n'
+          'You can set this up later in Settings > Chat backup.',
+      confirmLabel: 'Skip anyway',
+      cancelLabel: 'Go back',
+      barrierDismissible: false,
+    );
+    if (confirmed) _skip();
+  }
+
+  Future<void> _confirmCreateNewKey() async {
+    final confirmed = await confirmDialog(
+      context,
+      title: 'Create new backup?',
+      message:
+          'This will create a new recovery key. If you had a previous '
+          'backup, that encrypted message history may be lost.',
+      confirmLabel: 'Create new backup',
+      cancelLabel: 'Go back',
+    );
+    if (confirmed) {
+      _recoveryKeyController.clear();
+      _controller?.restartWithWipe();
+      if (mounted) setState(() {});
+    }
+  }
+
+  Future<void> _confirmDisable() async {
+    final confirmed = await confirmDialog(
+      context,
+      title: 'Disable backup?',
+      message:
+          'Your recovery key and server-side backup will be deleted. '
+          'You will lose access to your encrypted message history on '
+          'other devices.',
+      confirmLabel: 'Disable backup',
+      cancelLabel: 'Go back',
+      destructive: true,
+    );
+    if (confirmed) {
+      await _matrixService.chatBackup.disableChatBackup();
+      _matrixService.skipSetup();
+      if (mounted) context.go(RoutePaths.home);
+    }
+  }
+
   // ── Finish / Skip ─────────────────────────────────────────────
 
   Future<void> _finishSetup() async {
@@ -163,17 +221,6 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
 
   // ── Build ─────────────────────────────────────────────────────
 
-  int get _currentDot {
-    if (_localStep != null) {
-      return _localStep == _ScreenStep.skipConfirm ? 0 : 1;
-    }
-    return _controller?.phase == SetupPhase.done ? 2 : 1;
-  }
-
-  bool get _showDots =>
-      _localStep != _ScreenStep.management &&
-      _localStep != _ScreenStep.disableConfirm;
-
   @override
   Widget build(BuildContext context) {
     final backupNeeded = context.select<ChatBackupService, bool?>(
@@ -186,18 +233,18 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
       );
     }
 
-    if (backupNeeded &&
-        _localStep == null &&
-        _controller == null &&
-        !_autoStarted) {
+    if (backupNeeded && _controller == null && !_autoStarted) {
       _autoStarted = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _startBootstrap();
       });
     }
 
-    if (!backupNeeded && _localStep == null && !_autoStarted) {
-      _localStep = _ScreenStep.management;
+    if (!backupNeeded &&
+        !_showManagement &&
+        _controller == null &&
+        !_autoStarted) {
+      _showManagement = true;
     }
 
     final isBlocking = !_matrixService.hasSkippedSetup && backupNeeded;
@@ -205,22 +252,16 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
     return PopScope(
       canPop: !isBlocking,
       onPopInvokedWithResult: (didPop, _) {
-        if (!didPop && isBlocking) {
-          setState(() => _localStep = _ScreenStep.skipConfirm);
-        }
+        if (!didPop && isBlocking) unawaited(_confirmSkip());
       },
       child: Scaffold(
         appBar: isBlocking
             ? null
             : AppBar(
                 leading: BackButton(
-                  onPressed: () {
-                    if (_localStep != null) {
-                      context.go(RoutePaths.home);
-                    } else {
-                      setState(() => _localStep = _ScreenStep.skipConfirm);
-                    }
-                  },
+                  onPressed: _showManagement
+                      ? () => context.go(RoutePaths.home)
+                      : () => unawaited(_finishSetup()),
                 ),
               ),
         body: SafeArea(
@@ -231,15 +272,9 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
                 padding: const EdgeInsets.symmetric(horizontal: 24),
                 child: Column(
                   children: [
-                    if (_showDots) ...[
-                      const SizedBox(height: 24),
-                      _StepDots(current: _currentDot, total: 3),
-                      const SizedBox(height: 32),
-                    ] else
-                      const SizedBox(height: 24),
-                    Expanded(child: _buildContent()),
+                    Expanded(child: _buildBody()),
                     const SizedBox(height: 16),
-                    _buildActions(),
+                    _buildActionsBar(),
                     const SizedBox(height: 24),
                   ],
                 ),
@@ -251,602 +286,130 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
     );
   }
 
-  Widget _buildContent() {
-    if (_localStep != null) {
-      return switch (_localStep!) {
-        _ScreenStep.skipConfirm => _buildSkipConfirm(),
-        _ScreenStep.createNewKey => _buildCreateNewKey(),
-        _ScreenStep.management => _buildManagement(),
-        _ScreenStep.disableConfirm => _buildDisableConfirm(),
-      };
-    }
-    final controller = _controller;
-    if (controller == null) {
-      return _buildLoading();
-    }
-    return switch (controller.phase) {
-      SetupPhase.loading => _buildLoading(),
-      SetupPhase.savingKey => _buildSavingKey(),
-      SetupPhase.unlock => _buildUnlock(),
-      SetupPhase.verification => _buildDeviceVerification(),
-      SetupPhase.done => _buildDone(),
-      SetupPhase.error => _buildError(),
-    };
-  }
+  // ── Body ──────────────────────────────────────────────────────
 
-  Widget _buildActions() {
-    if (_localStep != null) {
-      return switch (_localStep!) {
-        _ScreenStep.skipConfirm => Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            TextButton(
-              onPressed: () {
-                if (_controller == null) {
-                  _startBootstrap();
-                } else {
-                  setState(() => _localStep = null);
-                }
-              },
-              child: const Text('Go back'),
-            ),
-            FilledButton(
-              onPressed: _skip,
-              child: const Text('Skip anyway'),
-            ),
-          ],
-        ),
-        _ScreenStep.createNewKey => Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            TextButton(
-              onPressed: () => setState(() => _localStep = null),
-              child: const Text('Go back'),
-            ),
-            FilledButton(
-              onPressed: () {
-                _recoveryKeyController.clear();
-                _controller?.restartWithWipe();
-                setState(() => _localStep = null);
-              },
-              child: const Text('Create new backup'),
-            ),
-          ],
-        ),
-        _ScreenStep.management => const SizedBox.shrink(),
-        _ScreenStep.disableConfirm => Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            TextButton(
-              onPressed: () =>
-                  setState(() => _localStep = _ScreenStep.management),
-              child: const Text('Go back'),
-            ),
-            FilledButton(
-              onPressed: () async {
-                await _matrixService.chatBackup.disableChatBackup();
-                _matrixService.skipSetup();
-                if (mounted) context.go(RoutePaths.home);
-              },
-              style: FilledButton.styleFrom(
-                backgroundColor: Theme.of(context).colorScheme.error,
-              ),
-              child: const Text('Disable backup'),
-            ),
-          ],
-        ),
-      };
-    }
-
-    final controller = _controller;
-    if (controller == null) return const SizedBox.shrink();
-
-    return switch (controller.phase) {
-      SetupPhase.loading || SetupPhase.verification => const SizedBox.shrink(),
-      SetupPhase.savingKey => Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          TextButton(
-            onPressed: () =>
-                setState(() => _localStep = _ScreenStep.skipConfirm),
-            child: const Text('Back'),
-          ),
-          FilledButton(
-            onPressed: !controller.generatingKey && controller.canConfirmNewKey
-                ? controller.confirmNewSsss
-                : null,
-            child: const Text('Next'),
-          ),
-        ],
-      ),
-      SetupPhase.unlock => Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          TextButton(
-            onPressed: () =>
-                setState(() => _localStep = _ScreenStep.skipConfirm),
-            child: const Text('Back'),
-          ),
-          FilledButton(
-            onPressed: () => controller.unlockExistingSsss(
-              _recoveryKeyController.text.trim(),
-            ),
-            child: const Text('Unlock'),
-          ),
-        ],
-      ),
-      SetupPhase.done => FilledButton(
-        onPressed: _finishSetup,
-        child: const Text('Done'),
-      ),
-      SetupPhase.error => Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          TextButton(
-            onPressed: () => context.go(RoutePaths.home),
-            child: const Text('Close'),
-          ),
-          FilledButton(
-            onPressed: controller.retry,
-            child: const Text('Retry'),
-          ),
-        ],
-      ),
-    };
-  }
-
-  // ── Content views ─────────────────────────────────────────────
-
-  Widget _buildExplainer() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          'What is key backup?',
-          style: Theme.of(context).textTheme.headlineSmall,
-        ),
-        const SizedBox(height: 16),
-        const Text(
-          'Your messages are encrypted end-to-end. A recovery key '
-          'lets you access them on new devices or if you reinstall.',
-        ),
-        const SizedBox(height: 24),
-        const Text('Without it:'),
-        const SizedBox(height: 8),
-        ..._bulletPoints([
-          'Message history is lost',
-          "Cross-device verification won't work",
-          'Some features may not work',
-        ]),
-      ],
-    );
-  }
-
-  Widget _buildSkipConfirm() {
-    return SingleChildScrollView(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'Are you sure?',
-            style: Theme.of(context).textTheme.headlineSmall,
-          ),
-          const SizedBox(height: 16),
-          const Text('Without key backup:'),
-          const SizedBox(height: 8),
-          ..._bulletPoints([
-            'Message history is lost',
-            "Cross-device verification won't work",
-            'Some features may not work',
-          ]),
-          const SizedBox(height: 16),
-          const Text('You can set this up later in Settings > Chat backup.'),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildLoading() {
-    final showExplainer =
-        _autoStarted &&
-        (_controller?.phase ?? SetupPhase.loading) == SetupPhase.loading;
-    return Column(
-      children: [
-        if (showExplainer)
-          Expanded(
-            child: SingleChildScrollView(
-              child: Padding(
-                padding: const EdgeInsets.only(bottom: 24),
-                child: _buildExplainer(),
-              ),
-            ),
-          )
-        else
-          const Expanded(child: SizedBox.shrink()),
-        const KoheraLoader(),
-        const SizedBox(height: 16),
-        Text(_controller?.loadingMessage ?? 'Preparing...'),
-        const SizedBox(height: 24),
-      ],
-    );
-  }
-
-  Widget _buildSavingKey() {
-    final controller = _controller!;
-    if (controller.generatingKey) {
-      return _buildLoading();
-    }
-
-    final cs = Theme.of(context).colorScheme;
-    return SingleChildScrollView(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'Save your recovery key',
-            style: Theme.of(context).textTheme.headlineSmall,
-          ),
-          const SizedBox(height: 16),
-          const Text(
-            'Save this key in a password manager, or print it and store '
-            'the paper somewhere safe.',
-          ),
-          const SizedBox(height: 8),
-          Text(
-            "Don't save it in screenshots, unencrypted notes apps, or chat "
-            'messages. If you lose this key, your message history is gone '
-            "\u2014 we can't recover it for you.",
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: cs.error,
-            ),
-          ),
-          const SizedBox(height: 4),
-          Align(
-            alignment: Alignment.centerLeft,
-            child: TextButton.icon(
-              onPressed: () => unawaited(
-                launchUrl(
-                  Uri.parse(_recoveryKeyDocsUrl),
-                  mode: LaunchMode.externalApplication,
-                ),
-              ),
-              icon: const Icon(Icons.open_in_new, size: 16),
-              label: const Text('Learn more about safe storage'),
-              style: TextButton.styleFrom(
-                padding: EdgeInsets.zero,
-                minimumSize: Size.zero,
-                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              ),
-            ),
-          ),
-          const SizedBox(height: 16),
-          Container(
-            width: double.infinity,
-            padding: const EdgeInsets.all(12),
-            decoration: BoxDecoration(
-              color: cs.surfaceContainerHighest,
-              borderRadius: BorderRadius.zero,
-            ),
-            child: SelectableText(
-              controller.newRecoveryKey ?? '',
-              style: const TextStyle(fontFamily: 'monospace', fontSize: 14),
-            ),
-          ),
-          const SizedBox(height: 8),
-          Align(
-            alignment: Alignment.centerRight,
-            child: TextButton.icon(
-              onPressed: controller.keyCopied
-                  ? null
-                  : () {
-                      if (controller.newRecoveryKey != null) {
-                        unawaited(
-                          Clipboard.setData(
-                            ClipboardData(text: controller.newRecoveryKey!),
-                          ),
-                        );
-                        controller.setKeyCopied();
-                      }
-                    },
-              icon: Icon(
-                controller.keyCopied ? Icons.check : Icons.copy,
-                size: 18,
-              ),
-              label: Text(controller.keyCopied ? 'Copied' : 'Copy'),
-            ),
-          ),
-          CheckboxListTile(
-            value: controller.saveToDevice,
-            onChanged: (v) => controller.setSaveToDevice(v ?? false),
-            title: const Text('Also keep a copy on this device'),
-            subtitle: Text(
-              'Convenient for unlocking on this device. This is not a '
-              'backup — if you lose the device, this copy is gone too.',
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-            controlAffinity: ListTileControlAffinity.leading,
-            contentPadding: EdgeInsets.zero,
-            mouseCursor: SystemMouseCursors.click,
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildUnlock() {
-    final controller = _controller;
-    return SingleChildScrollView(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'Unlock your backup',
-            style: Theme.of(context).textTheme.headlineSmall,
-          ),
-          const SizedBox(height: 16),
-          const Text(
-            'Enter your recovery key to restore your message history.',
-          ),
-          const SizedBox(height: 16),
-          TextField(
-            controller: _recoveryKeyController,
-            decoration: InputDecoration(
-              labelText: 'Recovery key',
-              errorText: controller?.recoveryKeyError,
-              border: const OutlineInputBorder(),
-            ),
-            style: const TextStyle(fontFamily: 'monospace'),
-          ),
-          const SizedBox(height: 8),
-          CheckboxListTile(
-            value: controller?.saveToDevice ?? false,
-            onChanged: (v) => controller?.setSaveToDevice(v ?? false),
-            title: const Text('Also keep a copy on this device'),
-            subtitle: Text(
-              'Convenient for unlocking on this device. This is not a '
-              'backup — if you lose the device, this copy is gone too.',
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-            controlAffinity: ListTileControlAffinity.leading,
-            contentPadding: EdgeInsets.zero,
-            mouseCursor: SystemMouseCursors.click,
-          ),
-          const SizedBox(height: 4),
-          const Divider(),
-          const SizedBox(height: 4),
-          Center(
-            child: OutlinedButton.icon(
-              onPressed: () => controller?.startVerification(),
-              icon: const Icon(Icons.devices, size: 18),
-              label: const Text('Verify with another device'),
-            ),
-          ),
-          const SizedBox(height: 8),
-          TextButton(
-            onPressed: () =>
-                setState(() => _localStep = _ScreenStep.createNewKey),
-            child: const Text('Create new key'),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildCreateNewKey() {
-    return SingleChildScrollView(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'Create new backup?',
-            style: Theme.of(context).textTheme.headlineSmall,
-          ),
-          const SizedBox(height: 16),
-          const Text(
-            'This will create a new recovery key. If you had a previous '
-            'backup, that encrypted message history may be lost.',
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildDeviceVerification() {
-    final verification = _controller?.koheraVerification;
-    if (verification == null) {
-      return Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const KoheraLoader(),
-            const SizedBox(height: 16),
-            const Text('Starting verification...'),
-            const SizedBox(height: 16),
-            TextButton(
-              onPressed: () => _controller?.onVerificationCancel(),
-              child: const Text('Cancel'),
-            ),
-          ],
+  Widget _buildBody() {
+    if (_showManagement) {
+      return SingleChildScrollView(
+        child: E2eeSetupManagementPanel(
+          onShowRecoveryKey: () => context.go(RoutePaths.settingsRecoveryKey),
+          onCreateNewKey: () => _startBootstrap(wipeExisting: true),
+          onDisable: _confirmDisable,
         ),
       );
     }
 
+    final controller = _controller;
+    final sections = <Widget>[
+      const SizedBox(height: 24),
+      const E2eeSetupExplainer(),
+      const SizedBox(height: 24),
+    ];
+
+    if (controller == null) {
+      sections.add(const E2eeSetupStatusLine(message: 'Preparing...'));
+    } else {
+      switch (controller.phase) {
+        case SetupPhase.loading:
+          sections.add(E2eeSetupStatusLine(message: controller.loadingMessage));
+        case SetupPhase.savingKey:
+          if (controller.generatingKey) {
+            sections.add(
+              E2eeSetupStatusLine(message: controller.loadingMessage),
+            );
+          } else {
+            sections.add(
+              E2eeSetupKeyCard(
+                recoveryKey: controller.newRecoveryKey,
+                copied: controller.keyCopied,
+                onCopy: controller.setKeyCopied,
+              ),
+            );
+            sections.add(const SizedBox(height: 8));
+            sections.add(
+              E2eeSetupCustodyGate(
+                saveToDevice: controller.saveToDevice,
+                onChanged: controller.setSaveToDevice,
+              ),
+            );
+          }
+        case SetupPhase.unlock:
+          sections.add(
+            E2eeSetupUnlockSection(
+              recoveryKeyController: _recoveryKeyController,
+              recoveryKeyError: controller.recoveryKeyError,
+              saveToDevice: controller.saveToDevice,
+              onSaveToDeviceChanged: controller.setSaveToDevice,
+              onVerify: controller.startVerification,
+              onCreateNewKey: _confirmCreateNewKey,
+            ),
+          );
+        case SetupPhase.verification:
+          sections.add(
+            E2eeSetupVerifySection(
+              verification: controller.koheraVerification,
+              onDone: controller.onVerificationDone,
+              onCancel: controller.onVerificationCancel,
+            ),
+          );
+        case SetupPhase.done:
+          sections.add(const E2eeSetupDoneBanner());
+        case SetupPhase.error:
+          sections.add(E2eeSetupErrorSection(message: controller.error));
+      }
+    }
+
     return SingleChildScrollView(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'Verify with another device',
-            style: Theme.of(context).textTheme.headlineSmall,
-          ),
-          const SizedBox(height: 16),
-          const Text(
-            'Open Kohera on another device and confirm the emoji match.',
-          ),
-          const SizedBox(height: 24),
-          KeyVerificationInline(
-            verification: verification,
-            onDone: (success) => _controller?.onVerificationDone(success),
-            onCancel: () => _controller?.onVerificationCancel(),
-          ),
-        ],
+        children: sections,
       ),
     );
   }
 
-  Widget _buildDone() {
-    final cs = Theme.of(context).colorScheme;
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(Icons.check_circle, color: cs.primary, size: 64),
-          const SizedBox(height: 16),
-          Text(
-            "You're all set!",
-            style: Theme.of(context).textTheme.headlineSmall,
-          ),
-          const SizedBox(height: 8),
-          const Text(
-            'Your messages are backed up and will be available '
-            'across all your devices.',
-            textAlign: TextAlign.center,
-          ),
-        ],
+  // ── Actions ───────────────────────────────────────────────────
+
+  Widget _buildActionsBar() {
+    if (_showManagement) return const E2eeSetupActionsBar();
+
+    final controller = _controller;
+    if (controller == null) {
+      return E2eeSetupActionsBar(
+        secondaryLabel: 'Skip for now',
+        onSecondary: _confirmSkip,
+      );
+    }
+
+    return switch (controller.phase) {
+      SetupPhase.loading ||
+      SetupPhase.verification ||
+      SetupPhase.done => const E2eeSetupActionsBar(),
+      SetupPhase.savingKey =>
+        controller.generatingKey
+            ? E2eeSetupActionsBar(
+                secondaryLabel: 'Skip for now',
+                onSecondary: _confirmSkip,
+              )
+            : E2eeSetupActionsBar(
+                secondaryLabel: 'Skip for now',
+                onSecondary: _confirmSkip,
+                primaryLabel: 'Next',
+                onPrimary: controller.confirmNewSsss,
+                primaryEnabled: controller.canConfirmNewKey,
+              ),
+      SetupPhase.unlock => E2eeSetupActionsBar(
+        secondaryLabel: 'Skip for now',
+        onSecondary: _confirmSkip,
+        primaryLabel: 'Unlock',
+        onPrimary: () =>
+            controller.unlockExistingSsss(_recoveryKeyController.text.trim()),
       ),
-    );
-  }
-
-  Widget _buildManagement() {
-    final cs = Theme.of(context).colorScheme;
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(Icons.check_circle, color: cs.primary, size: 64),
-          const SizedBox(height: 16),
-          Text(
-            'Chat backup',
-            style: Theme.of(context).textTheme.headlineSmall,
-          ),
-          const SizedBox(height: 8),
-          const Text(
-            'Your keys are backed up. Your encrypted messages are '
-            'secure and accessible from any device.',
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 32),
-          OutlinedButton(
-            onPressed: () => context.go(RoutePaths.settingsRecoveryKey),
-            child: const Text('Show recovery key'),
-          ),
-          const SizedBox(height: 8),
-          OutlinedButton(
-            onPressed: () => _startBootstrap(wipeExisting: true),
-            child: const Text('Create new key'),
-          ),
-          const SizedBox(height: 8),
-          TextButton(
-            onPressed: () =>
-                setState(() => _localStep = _ScreenStep.disableConfirm),
-            child: Text(
-              'Disable backup',
-              style: TextStyle(color: cs.error),
-            ),
-          ),
-        ],
+      SetupPhase.error => E2eeSetupActionsBar(
+        secondaryLabel: 'Close',
+        onSecondary: () => context.go(RoutePaths.home),
+        primaryLabel: 'Retry',
+        onPrimary: controller.retry,
       ),
-    );
-  }
-
-  Widget _buildDisableConfirm() {
-    return SingleChildScrollView(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'Disable backup?',
-            style: Theme.of(context).textTheme.headlineSmall,
-          ),
-          const SizedBox(height: 16),
-          const Text(
-            'Your recovery key and server-side backup will be deleted. '
-            'You will lose access to your encrypted message history on '
-            'other devices.',
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildError() {
-    final cs = Theme.of(context).colorScheme;
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(Icons.error_outline, color: cs.error, size: 64),
-          const SizedBox(height: 16),
-          Text(
-            _controller?.error ??
-                'An unexpected error occurred during backup setup.',
-            textAlign: TextAlign.center,
-          ),
-        ],
-      ),
-    );
-  }
-
-  // ── Helpers ───────────────────────────────────────────────────
-
-  List<Widget> _bulletPoints(List<String> items) {
-    return items
-        .map(
-          (item) => Padding(
-            padding: const EdgeInsets.only(left: 8, bottom: 4),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text('\u2022  '),
-                Expanded(
-                  child: Text(item),
-                ),
-              ],
-            ),
-          ),
-        )
-        .toList();
-  }
-}
-
-// ── Step dot indicator ──────────────────────────────────────────
-
-class _StepDots extends StatelessWidget {
-  const _StepDots({required this.current, required this.total});
-
-  final int current;
-  final int total;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: List.generate(total, (i) {
-        final isActive = i <= current;
-        return Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 4),
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 200),
-            width: 8,
-            height: 8,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: isActive ? cs.primary : cs.outlineVariant,
-            ),
-          ),
-        );
-      }),
-    );
+    };
   }
 }

--- a/lib/features/e2ee/screens/e2ee_setup_screen.dart
+++ b/lib/features/e2ee/screens/e2ee_setup_screen.dart
@@ -342,6 +342,7 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
               onSaveToDeviceChanged: controller.setSaveToDevice,
               onVerify: controller.startVerification,
               onCreateNewKey: _confirmCreateNewKey,
+              enabled: !controller.unlocking,
             ),
           );
         case SetupPhase.verification:
@@ -400,9 +401,12 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
       SetupPhase.unlock => E2eeSetupActionsBar(
         secondaryLabel: 'Skip for now',
         onSecondary: _confirmSkip,
+        secondaryEnabled: !controller.unlocking,
         primaryLabel: 'Unlock',
         onPrimary: () =>
             controller.unlockExistingSsss(_recoveryKeyController.text.trim()),
+        primaryEnabled: !controller.unlocking,
+        primaryBusy: controller.unlocking,
       ),
       SetupPhase.error => E2eeSetupActionsBar(
         secondaryLabel: 'Close',

--- a/lib/features/e2ee/services/bootstrap_controller.dart
+++ b/lib/features/e2ee/services/bootstrap_controller.dart
@@ -46,6 +46,7 @@ class BootstrapController extends ChangeNotifier {
   bool get generatingKey => _keyHandler.generatingKey;
   bool get saveToDevice => _keyHandler.saveToDevice;
   bool get keyCopied => _keyHandler.keyCopied;
+  bool get unlocking => _keyHandler.unlocking;
   bool get canConfirmNewKey => _keyHandler.canConfirmNewKey;
   String? get recoveryKeyError => _keyHandler.recoveryKeyError;
   KeyVerification? get verification => _verification;
@@ -131,8 +132,11 @@ class BootstrapController extends ChangeNotifier {
     final bootstrap = _driver.bootstrap;
     if (bootstrap == null) return;
 
+    _keyHandler.markUnlocking();
+    _notify();
     final success = await _keyHandler.unlockExisting(bootstrap, key);
-    if (!success && _keyHandler.recoveryKeyError != null &&
+    if (!success &&
+        _keyHandler.recoveryKeyError != null &&
         _keyHandler.recoveryKeyError!.startsWith('Failed to open')) {
       _phase = SetupPhase.error;
       _error = _keyHandler.recoveryKeyError;
@@ -178,7 +182,8 @@ class BootstrapController extends ChangeNotifier {
     if (encryption != null) {
       for (var i = 0; i < 10; i++) {
         if (_isDisposed) return;
-        final cached = await encryption.keyManager.isCached() &&
+        final cached =
+            await encryption.keyManager.isCached() &&
             await encryption.crossSigning.isCached();
         if (cached) break;
         await Future<void>.delayed(const Duration(seconds: 1));

--- a/lib/features/e2ee/services/kohera_key_verification.dart
+++ b/lib/features/e2ee/services/kohera_key_verification.dart
@@ -23,7 +23,8 @@ import 'package:matrix/matrix.dart';
 /// `devices_screen`, `e2ee_setup_screen`) and pass this wrapper to the
 /// verification widgets.
 class KoheraKeyVerification extends ChangeNotifier {
-  KoheraKeyVerification(KeyVerification verification) : _verification = verification {
+  KoheraKeyVerification(KeyVerification verification)
+    : _verification = verification {
     verification.onUpdate = _onUpdate;
     state = _mapState(verification.state);
     _resolveView(state);
@@ -47,6 +48,24 @@ class KoheraKeyVerification extends ChangeNotifier {
 
   /// The cancel/failure reason, if any.
   String? get canceledReason => _verification.canceledReason;
+
+  /// The cancel/failure code, if any.
+  String? get canceledCode => _verification.canceledCode;
+
+  /// Human-readable cancel reason, mapped from the Matrix cancel code.
+  /// Returns `null` when there is no cancellation or the code is unknown.
+  String? get canceledMessage {
+    final code = _verification.canceledCode ?? _verification.canceledReason;
+    return switch (code) {
+      'm.mismatched_sas' =>
+        "The emoji/numbers didn't match. Verification cancelled.",
+      'm.key_mismatch' => "The keys didn't match. Verification cancelled.",
+      'm.timeout' => 'Verification timed out.',
+      'm.user' => 'Verification was cancelled.',
+      'm.accepted' => 'Verification was cancelled.',
+      _ => null,
+    };
+  }
 
   // ── SAS data ────────────────────────────────────────────────
 
@@ -86,7 +105,8 @@ class KoheraKeyVerification extends ChangeNotifier {
       _verification.possibleMethods.contains(EventTypes.QRScan) &&
       qrScanSupported;
 
-  bool get canCompareSas => _verification.possibleMethods.contains(EventTypes.Sas);
+  bool get canCompareSas =>
+      _verification.possibleMethods.contains(EventTypes.Sas);
 
   // ── State mapping + view resolution ─────────────────────────
 

--- a/lib/features/e2ee/services/recovery_key_handler.dart
+++ b/lib/features/e2ee/services/recovery_key_handler.dart
@@ -13,6 +13,7 @@ class RecoveryKeyHandler {
   bool _generatingKey = false;
   bool _saveToDevice = false;
   bool _keyCopied = false;
+  bool _unlocking = false;
   String? _recoveryKeyError;
   OpenSSSS? _unlockedSsssKey;
   String? _storedRecoveryKey;
@@ -23,6 +24,7 @@ class RecoveryKeyHandler {
   bool get generatingKey => _generatingKey;
   bool get saveToDevice => _saveToDevice;
   bool get keyCopied => _keyCopied;
+  bool get unlocking => _unlocking;
   bool get canConfirmNewKey => _keyCopied || _saveToDevice;
   String? get recoveryKeyError => _recoveryKeyError;
   OpenSSSS? get unlockedSsssKey => _unlockedSsssKey;
@@ -35,6 +37,10 @@ class RecoveryKeyHandler {
 
   void setKeyCopied() {
     _keyCopied = true;
+  }
+
+  void markUnlocking() {
+    _unlocking = true;
   }
 
   Future<void> generateNewKey(Bootstrap bootstrap) async {
@@ -66,37 +72,42 @@ class RecoveryKeyHandler {
     final ssssKey = bootstrap.newSsssKey;
     if (ssssKey == null) return false;
 
-    if (key.isEmpty) {
-      _recoveryKeyError = 'Please enter a recovery key';
-      return false;
-    }
-
+    _unlocking = true;
     try {
-      await ssssKey.unlock(keyOrPassphrase: key);
-      _unlockedSsssKey = ssssKey;
-    } catch (e) {
-      _recoveryKeyError = 'Invalid recovery key';
-      return false;
-    }
-
-    _recoveryKeyError = null;
-    if (_saveToDevice) {
-      await matrixService.chatBackup.storeRecoveryKey(key);
-    }
-
-    try {
-      await bootstrap.openExistingSsss();
-      final encryption = matrixService.client.encryption;
-      if (encryption != null && encryption.crossSigning.enabled) {
-        debugPrint('[Bootstrap] Self-signing after SSSS unlock');
-        await encryption.crossSigning.selfSign(recoveryKey: key);
+      if (key.isEmpty) {
+        _recoveryKeyError = 'Please enter a recovery key';
+        return false;
       }
-    } catch (e) {
-      _recoveryKeyError = 'Failed to open backup: $e';
-      return false;
-    }
 
-    return true;
+      try {
+        await ssssKey.unlock(keyOrPassphrase: key);
+        _unlockedSsssKey = ssssKey;
+      } catch (e) {
+        _recoveryKeyError = 'Invalid recovery key';
+        return false;
+      }
+
+      _recoveryKeyError = null;
+      if (_saveToDevice) {
+        await matrixService.chatBackup.storeRecoveryKey(key);
+      }
+
+      try {
+        await bootstrap.openExistingSsss();
+        final encryption = matrixService.client.encryption;
+        if (encryption != null && encryption.crossSigning.enabled) {
+          debugPrint('[Bootstrap] Self-signing after SSSS unlock');
+          await encryption.crossSigning.selfSign(recoveryKey: key);
+        }
+      } catch (e) {
+        _recoveryKeyError = 'Failed to open backup: $e';
+        return false;
+      }
+
+      return true;
+    } finally {
+      _unlocking = false;
+    }
   }
 
   Future<void> storeIfNeeded() async {
@@ -109,6 +120,7 @@ class RecoveryKeyHandler {
     _newRecoveryKey = null;
     _generatingKey = false;
     _keyCopied = false;
+    _unlocking = false;
     _recoveryKeyError = null;
     _unlockedSsssKey = null;
     _storedRecoveryKey = null;

--- a/lib/features/e2ee/widgets/key_verification_content.dart
+++ b/lib/features/e2ee/widgets/key_verification_content.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/material.dart';
 import 'package:kohera/features/e2ee/models/kohera_verification_state.dart';
 import 'package:kohera/features/e2ee/models/verification_view.dart';
@@ -99,8 +98,11 @@ class KeyVerificationContent extends StatelessWidget {
         return Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.check_circle,
-                color: Theme.of(context).colorScheme.primary, size: 64,),
+            Icon(
+              Icons.check_circle,
+              color: Theme.of(context).colorScheme.primary,
+              size: 64,
+            ),
             const SizedBox(height: 16),
             const Text('QR code scanned successfully.'),
           ],
@@ -115,8 +117,11 @@ class KeyVerificationContent extends StatelessWidget {
         return Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.verified,
-                color: Theme.of(context).colorScheme.primary, size: 64,),
+            Icon(
+              Icons.verified,
+              color: Theme.of(context).colorScheme.primary,
+              size: 64,
+            ),
             const SizedBox(height: 16),
             const Text('Device verified successfully!'),
           ],
@@ -126,11 +131,14 @@ class KeyVerificationContent extends StatelessWidget {
         return Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.error_outline,
-                color: Theme.of(context).colorScheme.error, size: 64,),
+            Icon(
+              Icons.error_outline,
+              color: Theme.of(context).colorScheme.error,
+              size: 64,
+            ),
             const SizedBox(height: 16),
             Text(
-              verification.canceledReason ??
+              verification.canceledMessage ??
                   'Verification was cancelled or failed.',
               textAlign: TextAlign.center,
             ),
@@ -199,13 +207,15 @@ class KeyVerificationContent extends StatelessWidget {
           spacing: 24,
           runSpacing: 8,
           children: numbers
-              .map((n) => Text(
-                    '$n',
-                    style: const TextStyle(
-                      fontSize: 32,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),)
+              .map(
+                (n) => Text(
+                  '$n',
+                  style: const TextStyle(
+                    fontSize: 32,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              )
               .toList(),
         ),
       ],
@@ -227,21 +237,27 @@ class KeyVerificationContent extends StatelessWidget {
           spacing: 16,
           runSpacing: 8,
           children: emojis
-              .map((e) => Semantics(
-                    label: e.name,
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        ExcludeSemantics(
-                          child: Text(e.emoji,
-                              style: const TextStyle(fontSize: 32),),
+              .map(
+                (e) => Semantics(
+                  label: e.name,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      ExcludeSemantics(
+                        child: Text(
+                          e.emoji,
+                          style: const TextStyle(fontSize: 32),
                         ),
-                        const SizedBox(height: 4),
-                        Text(e.name,
-                            style: Theme.of(context).textTheme.bodySmall,),
-                      ],
-                    ),
-                  ),)
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        e.name,
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    ],
+                  ),
+                ),
+              )
               .toList(),
         ),
       ],

--- a/lib/features/e2ee/widgets/setup/setup_actions_bar.dart
+++ b/lib/features/e2ee/widgets/setup/setup_actions_bar.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+class E2eeSetupActionsBar extends StatelessWidget {
+  const E2eeSetupActionsBar({
+    this.secondaryLabel,
+    this.onSecondary,
+    this.primaryLabel,
+    this.onPrimary,
+    this.primaryEnabled = true,
+    this.primaryColor,
+    super.key,
+  });
+
+  final String? secondaryLabel;
+  final VoidCallback? onSecondary;
+  final String? primaryLabel;
+  final VoidCallback? onPrimary;
+  final bool primaryEnabled;
+  final Color? primaryColor;
+
+  @override
+  Widget build(BuildContext context) {
+    if (secondaryLabel == null && primaryLabel == null) {
+      return const SizedBox.shrink();
+    }
+
+    final secondary = secondaryLabel != null
+        ? TextButton(
+            onPressed: onSecondary,
+            child: Text(secondaryLabel!),
+          )
+        : null;
+    final primary = primaryLabel != null
+        ? FilledButton(
+            onPressed: primaryEnabled ? onPrimary : null,
+            style: primaryColor != null
+                ? FilledButton.styleFrom(backgroundColor: primaryColor)
+                : null,
+            child: Text(primaryLabel!),
+          )
+        : null;
+
+    if (secondary != null && primary != null) {
+      return Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [secondary, primary],
+      );
+    }
+    return Row(
+      mainAxisAlignment: primary != null
+          ? MainAxisAlignment.end
+          : MainAxisAlignment.start,
+      children: [(secondary ?? primary!)],
+    );
+  }
+}

--- a/lib/features/e2ee/widgets/setup/setup_actions_bar.dart
+++ b/lib/features/e2ee/widgets/setup/setup_actions_bar.dart
@@ -4,18 +4,22 @@ class E2eeSetupActionsBar extends StatelessWidget {
   const E2eeSetupActionsBar({
     this.secondaryLabel,
     this.onSecondary,
+    this.secondaryEnabled = true,
     this.primaryLabel,
     this.onPrimary,
     this.primaryEnabled = true,
+    this.primaryBusy = false,
     this.primaryColor,
     super.key,
   });
 
   final String? secondaryLabel;
   final VoidCallback? onSecondary;
+  final bool secondaryEnabled;
   final String? primaryLabel;
   final VoidCallback? onPrimary;
   final bool primaryEnabled;
+  final bool primaryBusy;
   final Color? primaryColor;
 
   @override
@@ -26,17 +30,30 @@ class E2eeSetupActionsBar extends StatelessWidget {
 
     final secondary = secondaryLabel != null
         ? TextButton(
-            onPressed: onSecondary,
+            onPressed: secondaryEnabled ? onSecondary : null,
             child: Text(secondaryLabel!),
           )
         : null;
     final primary = primaryLabel != null
         ? FilledButton(
-            onPressed: primaryEnabled ? onPrimary : null,
+            onPressed: (primaryEnabled && !primaryBusy) ? onPrimary : null,
             style: primaryColor != null
                 ? FilledButton.styleFrom(backgroundColor: primaryColor)
                 : null,
-            child: Text(primaryLabel!),
+            child: primaryBusy
+                ? Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(primaryLabel!),
+                    ],
+                  )
+                : Text(primaryLabel!),
           )
         : null;
 

--- a/lib/features/e2ee/widgets/setup/setup_bullet_points.dart
+++ b/lib/features/e2ee/widgets/setup/setup_bullet_points.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class E2eeSetupBulletPoints extends StatelessWidget {
+  const E2eeSetupBulletPoints({required this.items, super.key});
+
+  final List<String> items;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: items
+          .map(
+            (item) => Padding(
+              padding: const EdgeInsets.only(left: 8, bottom: 4),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('\u2022  '),
+                  Expanded(child: Text(item)),
+                ],
+              ),
+            ),
+          )
+          .toList(),
+    );
+  }
+}

--- a/lib/features/e2ee/widgets/setup/setup_custody_gate.dart
+++ b/lib/features/e2ee/widgets/setup/setup_custody_gate.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class E2eeSetupCustodyGate extends StatelessWidget {
+  const E2eeSetupCustodyGate({
+    required this.saveToDevice,
+    required this.onChanged,
+    super.key,
+  });
+
+  final bool saveToDevice;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return CheckboxListTile(
+      value: saveToDevice,
+      onChanged: (v) => onChanged(v ?? false),
+      title: const Text('Also keep a copy on this device'),
+      subtitle: Text(
+        'Convenient for unlocking on this device. This is not a '
+        'backup \u2014 if you lose the device, this copy is gone too.',
+        style: Theme.of(context).textTheme.bodySmall,
+      ),
+      controlAffinity: ListTileControlAffinity.leading,
+      contentPadding: EdgeInsets.zero,
+      mouseCursor: SystemMouseCursors.click,
+    );
+  }
+}

--- a/lib/features/e2ee/widgets/setup/setup_custody_gate.dart
+++ b/lib/features/e2ee/widgets/setup/setup_custody_gate.dart
@@ -3,18 +3,18 @@ import 'package:flutter/material.dart';
 class E2eeSetupCustodyGate extends StatelessWidget {
   const E2eeSetupCustodyGate({
     required this.saveToDevice,
-    required this.onChanged,
+    this.onChanged,
     super.key,
   });
 
   final bool saveToDevice;
-  final ValueChanged<bool> onChanged;
+  final ValueChanged<bool>? onChanged;
 
   @override
   Widget build(BuildContext context) {
     return CheckboxListTile(
       value: saveToDevice,
-      onChanged: (v) => onChanged(v ?? false),
+      onChanged: onChanged == null ? null : (v) => onChanged!(v ?? false),
       title: const Text('Also keep a copy on this device'),
       subtitle: Text(
         'Convenient for unlocking on this device. This is not a '

--- a/lib/features/e2ee/widgets/setup/setup_done_banner.dart
+++ b/lib/features/e2ee/widgets/setup/setup_done_banner.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class E2eeSetupDoneBanner extends StatelessWidget {
+  const E2eeSetupDoneBanner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.check_circle, color: cs.primary, size: 64),
+            const SizedBox(height: 16),
+            Text(
+              "You're all set!",
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Your messages are backed up and will be available '
+              'across all your devices.',
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/e2ee/widgets/setup/setup_error_section.dart
+++ b/lib/features/e2ee/widgets/setup/setup_error_section.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class E2eeSetupErrorSection extends StatelessWidget {
+  const E2eeSetupErrorSection({super.key, this.message});
+
+  final String? message;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline, color: cs.error, size: 64),
+            const SizedBox(height: 16),
+            Text(
+              message ?? 'An unexpected error occurred during backup setup.',
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/e2ee/widgets/setup/setup_explainer.dart
+++ b/lib/features/e2ee/widgets/setup/setup_explainer.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:kohera/features/e2ee/widgets/setup/setup_bullet_points.dart';
+
+class E2eeSetupExplainer extends StatelessWidget {
+  const E2eeSetupExplainer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'What is key backup?',
+          style: Theme.of(context).textTheme.headlineSmall,
+        ),
+        const SizedBox(height: 16),
+        const Text(
+          'Your messages are encrypted end-to-end. A recovery key '
+          'lets you access them on new devices or if you reinstall.',
+        ),
+        const SizedBox(height: 24),
+        const Text('Without it:'),
+        const SizedBox(height: 8),
+        const E2eeSetupBulletPoints(
+          items: [
+            'Message history is lost',
+            "Cross-device verification won't work",
+            'Some features may not work',
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/e2ee/widgets/setup/setup_key_card.dart
+++ b/lib/features/e2ee/widgets/setup/setup_key_card.dart
@@ -1,0 +1,99 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+const String _recoveryKeyDocsUrl =
+    'https://github.com/Quantumheart/Kohera/blob/master/docs/recovery-key-storage.md';
+
+class E2eeSetupKeyCard extends StatelessWidget {
+  const E2eeSetupKeyCard({
+    required this.recoveryKey,
+    required this.copied,
+    required this.onCopy,
+    super.key,
+  });
+
+  final String? recoveryKey;
+  final bool copied;
+  final VoidCallback onCopy;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Save your recovery key',
+          style: Theme.of(context).textTheme.headlineSmall,
+        ),
+        const SizedBox(height: 16),
+        const Text(
+          'Save this key in a password manager, or print it and store '
+          'the paper somewhere safe.',
+        ),
+        const SizedBox(height: 8),
+        Text(
+          "Don't save it in screenshots, unencrypted notes apps, or chat "
+          'messages. If you lose this key, your message history is gone '
+          "\u2014 we can't recover it for you.",
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+            color: cs.error,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: TextButton.icon(
+            onPressed: () => unawaited(
+              launchUrl(
+                Uri.parse(_recoveryKeyDocsUrl),
+                mode: LaunchMode.externalApplication,
+              ),
+            ),
+            icon: const Icon(Icons.open_in_new, size: 16),
+            label: const Text('Learn more about safe storage'),
+            style: TextButton.styleFrom(
+              padding: EdgeInsets.zero,
+              minimumSize: Size.zero,
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: cs.surfaceContainerHighest,
+            borderRadius: BorderRadius.zero,
+          ),
+          child: SelectableText(
+            recoveryKey ?? '',
+            style: const TextStyle(fontFamily: 'monospace', fontSize: 14),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Align(
+          alignment: Alignment.centerRight,
+          child: TextButton.icon(
+            onPressed: copied
+                ? null
+                : () {
+                    if (recoveryKey != null) {
+                      unawaited(
+                        Clipboard.setData(ClipboardData(text: recoveryKey!)),
+                      );
+                      onCopy();
+                    }
+                  },
+            icon: Icon(copied ? Icons.check : Icons.copy, size: 18),
+            label: Text(copied ? 'Copied' : 'Copy'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/e2ee/widgets/setup/setup_management_panel.dart
+++ b/lib/features/e2ee/widgets/setup/setup_management_panel.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+class E2eeSetupManagementPanel extends StatelessWidget {
+  const E2eeSetupManagementPanel({
+    required this.onShowRecoveryKey,
+    required this.onCreateNewKey,
+    required this.onDisable,
+    super.key,
+  });
+
+  final VoidCallback onShowRecoveryKey;
+  final VoidCallback onCreateNewKey;
+  final VoidCallback onDisable;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.check_circle, color: cs.primary, size: 64),
+          const SizedBox(height: 16),
+          Text(
+            'Chat backup',
+            style: Theme.of(context).textTheme.headlineSmall,
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Your keys are backed up. Your encrypted messages are '
+            'secure and accessible from any device.',
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 32),
+          OutlinedButton(
+            onPressed: onShowRecoveryKey,
+            child: const Text('Show recovery key'),
+          ),
+          const SizedBox(height: 8),
+          OutlinedButton(
+            onPressed: onCreateNewKey,
+            child: const Text('Create new key'),
+          ),
+          const SizedBox(height: 8),
+          TextButton(
+            onPressed: onDisable,
+            child: Text(
+              'Disable backup',
+              style: TextStyle(color: cs.error),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/e2ee/widgets/setup/setup_status_line.dart
+++ b/lib/features/e2ee/widgets/setup/setup_status_line.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
+
+class E2eeSetupStatusLine extends StatelessWidget {
+  const E2eeSetupStatusLine({required this.message, super.key});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const KoheraLoader(),
+            const SizedBox(height: 16),
+            Text(message),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/e2ee/widgets/setup/setup_unlock_section.dart
+++ b/lib/features/e2ee/widgets/setup/setup_unlock_section.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:kohera/features/e2ee/widgets/setup/setup_custody_gate.dart';
+
+class E2eeSetupUnlockSection extends StatelessWidget {
+  const E2eeSetupUnlockSection({
+    required this.recoveryKeyController,
+    required this.recoveryKeyError,
+    required this.saveToDevice,
+    required this.onSaveToDeviceChanged,
+    required this.onVerify,
+    required this.onCreateNewKey,
+    super.key,
+  });
+
+  final TextEditingController recoveryKeyController;
+  final String? recoveryKeyError;
+  final bool saveToDevice;
+  final ValueChanged<bool> onSaveToDeviceChanged;
+  final VoidCallback onVerify;
+  final VoidCallback onCreateNewKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Unlock your backup',
+          style: Theme.of(context).textTheme.headlineSmall,
+        ),
+        const SizedBox(height: 16),
+        const Text('Enter your recovery key to restore your message history.'),
+        const SizedBox(height: 16),
+        TextField(
+          controller: recoveryKeyController,
+          decoration: InputDecoration(
+            labelText: 'Recovery key',
+            errorText: recoveryKeyError,
+            border: const OutlineInputBorder(),
+          ),
+          style: const TextStyle(fontFamily: 'monospace'),
+        ),
+        const SizedBox(height: 8),
+        E2eeSetupCustodyGate(
+          saveToDevice: saveToDevice,
+          onChanged: onSaveToDeviceChanged,
+        ),
+        const SizedBox(height: 4),
+        const Divider(),
+        const SizedBox(height: 4),
+        Center(
+          child: OutlinedButton.icon(
+            onPressed: onVerify,
+            icon: const Icon(Icons.devices, size: 18),
+            label: const Text('Verify with another device'),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: TextButton(
+            onPressed: onCreateNewKey,
+            child: const Text('Create new key'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/e2ee/widgets/setup/setup_unlock_section.dart
+++ b/lib/features/e2ee/widgets/setup/setup_unlock_section.dart
@@ -9,6 +9,7 @@ class E2eeSetupUnlockSection extends StatelessWidget {
     required this.onSaveToDeviceChanged,
     required this.onVerify,
     required this.onCreateNewKey,
+    this.enabled = true,
     super.key,
   });
 
@@ -18,6 +19,7 @@ class E2eeSetupUnlockSection extends StatelessWidget {
   final ValueChanged<bool> onSaveToDeviceChanged;
   final VoidCallback onVerify;
   final VoidCallback onCreateNewKey;
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
@@ -33,6 +35,7 @@ class E2eeSetupUnlockSection extends StatelessWidget {
         const SizedBox(height: 16),
         TextField(
           controller: recoveryKeyController,
+          enabled: enabled,
           decoration: InputDecoration(
             labelText: 'Recovery key',
             errorText: recoveryKeyError,
@@ -43,14 +46,14 @@ class E2eeSetupUnlockSection extends StatelessWidget {
         const SizedBox(height: 8),
         E2eeSetupCustodyGate(
           saveToDevice: saveToDevice,
-          onChanged: onSaveToDeviceChanged,
+          onChanged: enabled ? onSaveToDeviceChanged : null,
         ),
         const SizedBox(height: 4),
         const Divider(),
         const SizedBox(height: 4),
         Center(
           child: OutlinedButton.icon(
-            onPressed: onVerify,
+            onPressed: enabled ? onVerify : null,
             icon: const Icon(Icons.devices, size: 18),
             label: const Text('Verify with another device'),
           ),
@@ -59,7 +62,7 @@ class E2eeSetupUnlockSection extends StatelessWidget {
         Align(
           alignment: Alignment.centerLeft,
           child: TextButton(
-            onPressed: onCreateNewKey,
+            onPressed: enabled ? onCreateNewKey : null,
             child: const Text('Create new key'),
           ),
         ),

--- a/lib/features/e2ee/widgets/setup/setup_verify_section.dart
+++ b/lib/features/e2ee/widgets/setup/setup_verify_section.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:kohera/features/e2ee/services/kohera_key_verification.dart';
+import 'package:kohera/features/e2ee/widgets/key_verification_inline.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
+
+class E2eeSetupVerifySection extends StatelessWidget {
+  const E2eeSetupVerifySection({
+    required this.verification,
+    required this.onDone,
+    required this.onCancel,
+    super.key,
+  });
+
+  final KoheraKeyVerification? verification;
+  final ValueChanged<bool> onDone;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final verification = this.verification;
+    if (verification == null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const KoheraLoader(),
+            const SizedBox(height: 16),
+            const Text('Starting verification...'),
+            const SizedBox(height: 16),
+            TextButton(
+              onPressed: onCancel,
+              child: const Text('Cancel'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Verify with another device',
+          style: Theme.of(context).textTheme.headlineSmall,
+        ),
+        const SizedBox(height: 16),
+        const Text(
+          'Open Kohera on another device and confirm the emoji match.',
+        ),
+        const SizedBox(height: 24),
+        KeyVerificationInline(
+          verification: verification,
+          onDone: onDone,
+          onCancel: onCancel,
+        ),
+      ],
+    );
+  }
+}

--- a/test/widgets/key_verification_dialog_test.dart
+++ b/test/widgets/key_verification_dialog_test.dart
@@ -1,4 +1,4 @@
-﻿import 'dart:async';
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -20,6 +20,9 @@ class FakeKeyVerification extends Fake implements KeyVerification {
 
   @override
   String? canceledReason;
+
+  @override
+  String? canceledCode;
 
   @override
   bool canceled;
@@ -54,6 +57,7 @@ class FakeKeyVerification extends Fake implements KeyVerification {
   FakeKeyVerification({
     this.state = KeyVerificationState.waitingAccept,
     this.canceledReason,
+    this.canceledCode,
     this.canceled = false,
   });
 
@@ -100,8 +104,10 @@ class FakeKeyVerification extends Fake implements KeyVerification {
   Future<void> acceptQRScanConfirmation() async {}
 
   @override
-  Future<void> continueVerification(String type,
-      {Uint8List? qrDataRawBytes,}) async {
+  Future<void> continueVerification(
+    String type, {
+    Uint8List? qrDataRawBytes,
+  }) async {
     continueVerificationMethod = type;
   }
 
@@ -123,14 +129,15 @@ void main() {
           builder: (context) => Center(
             child: ElevatedButton(
               onPressed: () {
-                unawaited(showDialog(
-                  context: context,
-                  barrierDismissible: false,
-                  builder: (_) =>
-                      KeyVerificationDialog(
-                        verification: KoheraKeyVerification(verification),
-                      ),
-                ),);
+                unawaited(
+                  showDialog(
+                    context: context,
+                    barrierDismissible: false,
+                    builder: (_) => KeyVerificationDialog(
+                      verification: KoheraKeyVerification(verification),
+                    ),
+                  ),
+                );
               },
               child: const Text('Open'),
             ),
@@ -140,8 +147,10 @@ void main() {
     );
   }
 
-  Future<void> openDialog(WidgetTester tester,
-      {required FakeKeyVerification verification,}) async {
+  Future<void> openDialog(
+    WidgetTester tester, {
+    required FakeKeyVerification verification,
+  }) async {
     await tester.pumpWidget(buildTestApp(verification: verification));
     await tester.tap(find.text('Open'));
     // Use pump() not pumpAndSettle() because CircularProgressIndicator
@@ -151,14 +160,14 @@ void main() {
 
   group('KeyVerificationDialog', () {
     testWidgets('shows spinner in waitingAccept state', (tester) async {
-      final verification = FakeKeyVerification(
-        
-      );
+      final verification = FakeKeyVerification();
       await openDialog(tester, verification: verification);
 
       expect(find.byType(KoheraLoader), findsOneWidget);
-      expect(find.text('Waiting for the other device to accept...'),
-          findsOneWidget,);
+      expect(
+        find.text('Waiting for the other device to accept...'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('renders SAS emoji with Semantics labels', (tester) async {
@@ -187,8 +196,9 @@ void main() {
       expect(find.text('Compare emoji'), findsOneWidget);
     });
 
-    testWidgets('renders decimal SAS when decimal is negotiated',
-        (tester) async {
+    testWidgets('renders decimal SAS when decimal is negotiated', (
+      tester,
+    ) async {
       final verification = FakeKeyVerification(
         state: KeyVerificationState.askSas,
       );
@@ -208,8 +218,9 @@ void main() {
       expect(verification.acceptSasCalled, isTrue);
     });
 
-    testWidgets('prefers numbers when both emoji and decimal are negotiated',
-        (tester) async {
+    testWidgets('prefers numbers when both emoji and decimal are negotiated', (
+      tester,
+    ) async {
       final verification = FakeKeyVerification(
         state: KeyVerificationState.askSas,
       );
@@ -223,13 +234,17 @@ void main() {
       expect(find.text('1234'), findsOneWidget);
     });
 
-    testWidgets('falls back to emoji when no numbers are available',
-        (tester) async {
+    testWidgets('falls back to emoji when no numbers are available', (
+      tester,
+    ) async {
       final verification = FakeKeyVerification(
         state: KeyVerificationState.askSas,
       );
       verification.setSasTypes(['emoji']);
-      verification.setSasEmojis([KeyVerificationEmoji(0), KeyVerificationEmoji(1)]);
+      verification.setSasEmojis([
+        KeyVerificationEmoji(0),
+        KeyVerificationEmoji(1),
+      ]);
 
       await openDialog(tester, verification: verification);
 
@@ -237,9 +252,7 @@ void main() {
     });
 
     testWidgets('cancel calls verification.cancel() and pops', (tester) async {
-      final verification = FakeKeyVerification(
-        
-      );
+      final verification = FakeKeyVerification();
       await openDialog(tester, verification: verification);
 
       await tester.tap(find.text('Cancel'));
@@ -264,14 +277,17 @@ void main() {
       expect(find.byType(KeyVerificationDialog), findsNothing);
     });
 
-    testWidgets('error state displays canceledReason', (tester) async {
+    testWidgets('error state displays mapped cancel message', (tester) async {
       final verification = FakeKeyVerification(
         state: KeyVerificationState.error,
-        canceledReason: 'User rejected the keys',
+        canceledCode: 'm.mismatched_sas',
       );
       await openDialog(tester, verification: verification);
 
-      expect(find.text('User rejected the keys'), findsOneWidget);
+      expect(
+        find.text("The emoji/numbers didn't match. Verification cancelled."),
+        findsOneWidget,
+      );
       expect(find.text('Verification failed'), findsOneWidget);
     });
 
@@ -284,8 +300,9 @@ void main() {
       expect(find.text('Unlocking encryption secrets...'), findsOneWidget);
     });
 
-    testWidgets('askChoice shows the QR/emoji chooser when QR is possible',
-        (tester) async {
+    testWidgets('askChoice shows the QR/emoji chooser when QR is possible', (
+      tester,
+    ) async {
       final verification = FakeKeyVerification();
       verification.possibleMethods = [EventTypes.Sas, EventTypes.QRScan];
 
@@ -301,7 +318,9 @@ void main() {
       expect(find.text('Compare numbers instead'), findsOneWidget);
     });
 
-    testWidgets('chooser "Compare numbers instead" selects SAS', (tester) async {
+    testWidgets('chooser "Compare numbers instead" selects SAS', (
+      tester,
+    ) async {
       final verification = FakeKeyVerification(
         state: KeyVerificationState.askChoice,
       );
@@ -316,8 +335,9 @@ void main() {
       expect(verification.continueVerificationMethod, EventTypes.Sas);
     });
 
-    testWidgets('askChoice auto-selects SAS when QR is not possible',
-        (tester) async {
+    testWidgets('askChoice auto-selects SAS when QR is not possible', (
+      tester,
+    ) async {
       final verification = FakeKeyVerification(
         state: KeyVerificationState.askChoice,
       );
@@ -331,9 +351,7 @@ void main() {
     });
 
     testWidgets('state transitions update the UI', (tester) async {
-      final verification = FakeKeyVerification(
-        
-      );
+      final verification = FakeKeyVerification();
       await openDialog(tester, verification: verification);
 
       expect(find.text('Verify device'), findsOneWidget);

--- a/test/widgets/recovery_key_handler_test.dart
+++ b/test/widgets/recovery_key_handler_test.dart
@@ -60,8 +60,9 @@ void main() {
       final mockBootstrap = MockBootstrap();
       final mockSsssKey = MockOpenSSSS();
       when(mockBootstrap.newSsssKey).thenReturn(mockSsssKey);
-      when(mockSsssKey.unlock(keyOrPassphrase: anyNamed('keyOrPassphrase')))
-          .thenThrow(Exception('bad key'));
+      when(
+        mockSsssKey.unlock(keyOrPassphrase: anyNamed('keyOrPassphrase')),
+      ).thenThrow(Exception('bad key'));
 
       final result = await handler.unlockExisting(mockBootstrap, 'bad-key');
 
@@ -73,8 +74,9 @@ void main() {
       final mockBootstrap = MockBootstrap();
       final mockSsssKey = MockOpenSSSS();
       when(mockBootstrap.newSsssKey).thenReturn(mockSsssKey);
-      when(mockSsssKey.unlock(keyOrPassphrase: anyNamed('keyOrPassphrase')))
-          .thenAnswer((_) async {});
+      when(
+        mockSsssKey.unlock(keyOrPassphrase: anyNamed('keyOrPassphrase')),
+      ).thenAnswer((_) async {});
       when(mockBootstrap.openExistingSsss()).thenAnswer((_) async {});
       when(mockChatBackup.storeRecoveryKey(any)).thenAnswer((_) async {});
       final mockClient = MockClient();
@@ -98,21 +100,40 @@ void main() {
       expect(result, isFalse);
     });
 
-    test('storeIfNeeded stores key when saveToDevice and newRecoveryKey set',
-        () async {
+    test('markUnlocking exposes busy state until unlock completes', () async {
       final mockBootstrap = MockBootstrap();
-      when(mockBootstrap.newSsss()).thenAnswer((_) async {});
       final mockSsssKey = MockOpenSSSS();
       when(mockBootstrap.newSsssKey).thenReturn(mockSsssKey);
-      when(mockSsssKey.recoveryKey).thenReturn('KEY');
-      when(mockChatBackup.storeRecoveryKey(any)).thenAnswer((_) async {});
+      when(mockSsssKey.unlock(keyOrPassphrase: anyNamed('keyOrPassphrase')))
+          .thenAnswer((_) async {});
+      when(mockBootstrap.openExistingSsss()).thenAnswer((_) async {});
+      when(mockMatrixService.client).thenReturn(MockClient());
 
-      await handler.generateNewKey(mockBootstrap);
-      handler.setSaveToDevice(true);
-      await handler.storeIfNeeded();
+      handler.markUnlocking();
+      expect(handler.unlocking, isTrue);
 
-      verify(mockChatBackup.storeRecoveryKey('KEY')).called(1);
+      await handler.unlockExisting(mockBootstrap, 'valid-key');
+
+      expect(handler.unlocking, isFalse);
     });
+
+    test(
+      'storeIfNeeded stores key when saveToDevice and newRecoveryKey set',
+      () async {
+        final mockBootstrap = MockBootstrap();
+        when(mockBootstrap.newSsss()).thenAnswer((_) async {});
+        final mockSsssKey = MockOpenSSSS();
+        when(mockBootstrap.newSsssKey).thenReturn(mockSsssKey);
+        when(mockSsssKey.recoveryKey).thenReturn('KEY');
+        when(mockChatBackup.storeRecoveryKey(any)).thenAnswer((_) async {});
+
+        await handler.generateNewKey(mockBootstrap);
+        handler.setSaveToDevice(true);
+        await handler.storeIfNeeded();
+
+        verify(mockChatBackup.storeRecoveryKey('KEY')).called(1);
+      },
+    );
 
     test('storeIfNeeded is no-op when saveToDevice is false', () async {
       final mockBootstrap = MockBootstrap();
@@ -148,8 +169,9 @@ void main() {
     });
 
     test('consumeStoredRecoveryKey returns and clears key', () async {
-      when(mockChatBackup.getStoredRecoveryKey())
-          .thenAnswer((_) async => 'stored-key');
+      when(
+        mockChatBackup.getStoredRecoveryKey(),
+      ).thenAnswer((_) async => 'stored-key');
 
       await handler.loadStoredKey();
 


### PR DESCRIPTION
## Summary

Replaces the paged wizard layout of `E2eeSetupScreen` with a single scrollable progressive page. Sections reveal as the bootstrap advances; a sticky actions bar holds the one primary action per phase. No behavior change to bootstrap logic — auto-start, custody gate, auto-dismiss, blocking back guard, and the management path are all preserved. `BootstrapController`/`BootstrapDriver`/`RecoveryKeyHandler` (state machine) untouched. Screen drops 852 → 415 lines.

Also folds in two follow-up fixes found while exercising the verification/unlock paths:
- Raw SDK cancel codes (e.g. `m.mismatched_sas`) no longer leak into the verification error view.
- Unlocking an existing backup now shows a busy state instead of silently awaiting.

## Changes

### Progressive page
- New `lib/features/e2ee/widgets/setup/` directory with presentational widgets:
  - `setup_explainer.dart`, `setup_status_line.dart`, `setup_bullet_points.dart`
  - `setup_key_card.dart` (owns the recovery-key docs URL + copy logic), `setup_custody_gate.dart`
  - `setup_unlock_section.dart`, `setup_verify_section.dart` (wraps `KeyVerificationInline`)
  - `setup_done_banner.dart`, `setup_error_section.dart`, `setup_management_panel.dart`
  - `setup_actions_bar.dart` (sticky secondary + primary; collapses to `SizedBox.shrink` when neither needed; supports `primaryBusy`/`secondaryEnabled`)
- `lib/features/e2ee/screens/e2ee_setup_screen.dart` slimmed to orchestration only:
  - `_buildBody()` returns a `Column` of conditional sections (no page swap, no `_StepDots`, no `_ScreenStep`/`_localStep`).
  - `_buildActionsBar()` returns an `E2eeSetupActionsBar` per phase.
  - Skip / create-new-key / disable confirmations are now `confirmDialog(...)` calls (`_confirmSkip`, `_confirmCreateNewKey`, `_confirmDisable`) instead of separate wizard pages. Re-added the `confirm_dialog` import.
  - Back guard (`PopScope`) during blocking state opens the skip confirm dialog instead of a skip page.
- Decisions applied: explainer always visible; status line only (no progress-timeline chips); all three confirmations as dialogs.

### Verification cancel-code mapping
- `lib/features/e2ee/services/kohera_key_verification.dart`: add `canceledCode` getter and a `canceledMessage` getter that maps known Matrix cancel codes (`m.mismatched_sas`, `m.key_mismatch`, `m.timeout`, `m.user`, `m.accepted`) to human text. Prefers `canceledCode`, which the SDK sets on both the rejecting and receiving device, so the message is correct on either side.
- `lib/features/e2ee/widgets/key_verification_content.dart`: error view shows `canceledMessage` instead of the raw `canceledReason`; unknown codes fall back to the existing message.
- `test/widgets/key_verification_dialog_test.dart`: drive a real code (`m.mismatched_sas`) and assert the mapped string; add a `canceledCode` override to the fake.

### Unlock busy state
- `lib/features/e2ee/services/recovery_key_handler.dart`: add `_unlocking` + `unlocking` getter; `markUnlocking()` sets it; `unlockExisting` clears it in a `finally`; `reset()` clears it.
- `lib/features/e2ee/services/bootstrap_controller.dart`: expose `unlocking`; call `markUnlocking()` and notify before the await in `unlockExistingSsss` so the UI updates immediately.
- `lib/features/e2ee/widgets/setup/setup_unlock_section.dart`: accept `enabled`; disables the recovery-key field, custody checkbox, and verify/create-new-key CTAs while busy.
- `lib/features/e2ee/widgets/setup/setup_custody_gate.dart`: `onChanged` is nullable so the checkbox can be disabled.
- `lib/features/e2ee/widgets/setup/setup_actions_bar.dart`: add `primaryBusy` (inline spinner + label, forces disabled) and `secondaryEnabled`.
- `lib/features/e2ee/screens/e2ee_setup_screen.dart`: unlock section passes `enabled: !controller.unlocking`; unlock actions bar passes `primaryBusy`/`primaryEnabled`/`secondaryEnabled` from `controller.unlocking`, disabling Skip too to avoid a skip/unlock race.
- `test/widgets/recovery_key_handler_test.dart`: cover `markUnlocking` and the busy flag clearing after unlock completes.

## Testing

- [x] `flutter analyze` is clean
- [x] `flutter test` passes — `e2ee_setup_screen_test.dart`, `bootstrap_controller_test.dart`, `bootstrap_driver_test.dart`, `key_verification_dialog_test.dart`, `recovery_key_handler_test.dart` green; full suite shows only the pre-existing `message_bubble_golden_test` pixel drift (0.26% / 1242px), unrelated to this change
  - No `@GenerateNiceMocks` annotations changed, so `build_runner` was not required.
- Existing `e2ee_setup_screen_test.dart` assertions still hold: no `'Next'`/`'Skip for now'`/saved-confirmation dialog in the settled error state, `Retry` present, management path renders `'Chat backup'` + `'Show recovery key'`.

## Screenshots / recordings

N/A — layout restructure of an existing flow; no new visual assets. Manual smoke run recommended on Linux/macOS to confirm section spacing on the fresh-login path, the verification mismatch message on a second device, and the unlock busy state.

## Linked issues

Refs #622
Refs #626

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master` (not another feature branch, unless an explicitly requested stacked PR)