### PR TITLE
feat(chat): create polls from the compose attachment menu

### DIFF
--- a/lib/features/chat/models/kohera_poll_draft.dart
+++ b/lib/features/chat/models/kohera_poll_draft.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/foundation.dart';
+
+/// User-entered poll configuration captured by [CreatePollDialog] before it
+/// is sent via `Room.startPoll`.
+///
+/// Display widgets and the dialog never import `package:matrix/matrix.dart`;
+/// the send boundary ([ChatMessageActions.sendPoll]) converts this draft into
+/// SDK `PollAnswer`s with generated ids and calls `room.startPoll`.
+@immutable
+class KoheraPollDraft {
+  const KoheraPollDraft({
+    required this.question,
+    required this.answers,
+    required this.disclosed,
+    required this.maxSelections,
+  });
+
+  final String question;
+
+  /// Non-empty answer labels, in order. 2–20 entries (enforced by the dialog).
+  final List<String> answers;
+
+  /// `true` for a disclosed poll (live tallies), `false` for undisclosed.
+  final bool disclosed;
+
+  /// Maximum selections a voter may make. `1` = single-select.
+  final int maxSelections;
+}

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -43,6 +43,7 @@ import 'package:kohera/features/chat/services/web_image_paste.dart';
 import 'package:kohera/features/chat/widgets/attachment_source_sheet.dart';
 import 'package:kohera/features/chat/widgets/chat_app_bar.dart';
 import 'package:kohera/features/chat/widgets/compose_bar_section.dart';
+import 'package:kohera/features/chat/widgets/create_poll_dialog.dart';
 import 'package:kohera/features/chat/widgets/delete_event_dialog.dart';
 import 'package:kohera/features/chat/widgets/desktop_drop_wrapper.dart';
 import 'package:kohera/features/chat/widgets/emoji_picker_sheet.dart';
@@ -740,6 +741,9 @@ class _ChatScreenState extends State<ChatScreen>
         await _handleGifPressed();
       case AttachmentSource.sticker:
         _toggleStickerPicker();
+      case AttachmentSource.poll:
+        final draft = await CreatePollDialog.show(context);
+        if (draft != null && mounted) await _actions.sendPoll(draft);
       case AttachmentSource.file:
         final attachment = await pickFileAsAttachment();
         if (attachment != null && mounted) _addAttachment(attachment);

--- a/lib/features/chat/services/chat_message_actions.dart
+++ b/lib/features/chat/services/chat_message_actions.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:kohera/core/models/pending_attachment.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/features/chat/models/kohera_poll_draft.dart';
 import 'package:kohera/features/chat/services/compose_state_controller.dart';
 import 'package:kohera/features/chat/services/file_send_handler.dart';
 import 'package:matrix/matrix.dart';
@@ -161,5 +162,41 @@ class ChatMessageActions {
     return children
         .reduce((a, b) => a.originServerTs.isAfter(b.originServerTs) ? a : b)
         .eventId;
+  }
+
+  // ── Polls ────────────────────────────────────────────
+
+  Future<void> sendPoll(KoheraPollDraft draft) async {
+    final room = getRoom();
+    final scaffold = getScaffold();
+    if (room == null) return;
+
+    final client = room.client;
+    final answers = draft.answers
+        .map(
+          (label) => PollAnswer(
+            id: client.generateUniqueTransactionId(),
+            mText: label,
+          ),
+        )
+        .toList(growable: false);
+
+    try {
+      await room.startPoll(
+        question: draft.question,
+        answers: answers,
+        kind: draft.disclosed
+            ? PollKind.disclosed
+            : PollKind.undisclosed,
+        maxSelections: draft.maxSelections,
+      );
+    } catch (e) {
+      debugPrint('[Kohera] Failed to send poll: $e');
+      scaffold.showSnackBar(
+        SnackBar(
+          content: Text('Failed to send poll: ${MatrixService.friendlyAuthError(e)}'),
+        ),
+      );
+    }
   }
 }

--- a/lib/features/chat/widgets/attachment_source_sheet.dart
+++ b/lib/features/chat/widgets/attachment_source_sheet.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-enum AttachmentSource { gallery, camera, file, gif, sticker }
+enum AttachmentSource { gallery, camera, file, gif, sticker, poll }
 
 Future<AttachmentSource?> showAttachmentSourceSheet(
   BuildContext context, {
@@ -12,39 +12,49 @@ Future<AttachmentSource?> showAttachmentSourceSheet(
     showDragHandle: true,
     builder: (sheetContext) {
       return SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ListTile(
-              leading: const Icon(Icons.photo_library_outlined),
-              title: const Text('Photo or Video'),
-              onTap: () => Navigator.pop(sheetContext, AttachmentSource.gallery),
-            ),
-            ListTile(
-              leading: const Icon(Icons.camera_alt_outlined),
-              title: const Text('Take Photo'),
-              onTap: () => Navigator.pop(sheetContext, AttachmentSource.camera),
-            ),
-            ListTile(
-              leading: const Icon(Icons.folder_outlined),
-              title: const Text('File'),
-              onTap: () => Navigator.pop(sheetContext, AttachmentSource.file),
-            ),
-            if (showGif)
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
               ListTile(
-                leading: const Icon(Icons.gif_box_outlined),
-                title: const Text('GIF'),
-                onTap: () => Navigator.pop(sheetContext, AttachmentSource.gif),
-              ),
-            if (showSticker)
-              ListTile(
-                leading: const Icon(Icons.emoji_emotions_outlined),
-                title: const Text('Stickers & Emoji'),
+                leading: const Icon(Icons.photo_library_outlined),
+                title: const Text('Photo or Video'),
                 onTap: () =>
-                    Navigator.pop(sheetContext, AttachmentSource.sticker),
+                    Navigator.pop(sheetContext, AttachmentSource.gallery),
               ),
-            const SizedBox(height: 8),
-          ],
+              ListTile(
+                leading: const Icon(Icons.camera_alt_outlined),
+                title: const Text('Take Photo'),
+                onTap: () =>
+                    Navigator.pop(sheetContext, AttachmentSource.camera),
+              ),
+              ListTile(
+                leading: const Icon(Icons.folder_outlined),
+                title: const Text('File'),
+                onTap: () => Navigator.pop(sheetContext, AttachmentSource.file),
+              ),
+              if (showGif)
+                ListTile(
+                  leading: const Icon(Icons.gif_box_outlined),
+                  title: const Text('GIF'),
+                  onTap: () => Navigator.pop(sheetContext, AttachmentSource.gif),
+                ),
+              if (showSticker)
+                ListTile(
+                  leading: const Icon(Icons.emoji_emotions_outlined),
+                  title: const Text('Stickers & Emoji'),
+                  onTap: () =>
+                      Navigator.pop(sheetContext, AttachmentSource.sticker),
+                ),
+              ListTile(
+                leading: const Icon(Icons.poll_outlined),
+                title: const Text('Poll'),
+                onTap: () =>
+                    Navigator.pop(sheetContext, AttachmentSource.poll),
+              ),
+              const SizedBox(height: 8),
+            ],
+          ),
         ),
       );
     },

--- a/lib/features/chat/widgets/create_poll_dialog.dart
+++ b/lib/features/chat/widgets/create_poll_dialog.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import 'package:kohera/features/chat/models/kohera_poll_draft.dart';
+
+/// Dialog for composing an MSC3381 poll before sending it.
+///
+/// Captures the question, 2–20 answer options, disclosed/undisclosed kind,
+/// and single- vs. multi-select `maxSelections`. Returns a [KoheraPollDraft]
+/// or `null` if cancelled. Sending is handled by the caller
+/// ([ChatMessageActions.sendPoll]).
+class CreatePollDialog extends StatefulWidget {
+  const CreatePollDialog._();
+
+  static Future<KoheraPollDraft?> show(BuildContext context) {
+    return showDialog<KoheraPollDraft?>(
+      context: context,
+      builder: (_) => const CreatePollDialog._(),
+    );
+  }
+
+  @override
+  State<CreatePollDialog> createState() => _CreatePollDialogState();
+}
+
+class _CreatePollDialogState extends State<CreatePollDialog> {
+  static const _minAnswers = 2;
+  static const _maxAnswers = 20;
+
+  final _questionController = TextEditingController();
+  final List<TextEditingController> _answerControllers = [
+    TextEditingController(),
+    TextEditingController(),
+  ];
+  bool _disclosed = true;
+  bool _multiSelect = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _questionController.dispose();
+    for (final c in _answerControllers) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  bool get _canAdd => _answerControllers.length < _maxAnswers;
+
+  void _addAnswer() {
+    if (!_canAdd) return;
+    setState(() {
+      _answerControllers.add(TextEditingController());
+      _error = null;
+    });
+  }
+
+  void _removeAnswer(int index) {
+    if (_answerControllers.length <= _minAnswers) return;
+    setState(() {
+      _answerControllers[index].dispose();
+      _answerControllers.removeAt(index);
+      _error = null;
+    });
+  }
+
+  KoheraPollDraft? _validate() {
+    final question = _questionController.text.trim();
+    if (question.isEmpty) {
+      setState(() => _error = 'Enter a question.');
+      return null;
+    }
+    final answers = _answerControllers.map((c) => c.text.trim()).toList();
+    if (answers.any((a) => a.isEmpty)) {
+      setState(() => _error = 'All options must have text.');
+      return null;
+    }
+    final unique = answers.toSet();
+    if (unique.length != answers.length) {
+      setState(() => _error = 'Options must be unique.');
+      return null;
+    }
+    if (answers.length < _minAnswers) {
+      setState(() => _error = 'At least $_minAnswers options are required.');
+      return null;
+    }
+    return KoheraPollDraft(
+      question: question,
+      answers: answers,
+      disclosed: _disclosed,
+      maxSelections: _multiSelect ? answers.length : 1,
+    );
+  }
+
+  void _submit() {
+    final draft = _validate();
+    if (draft != null) Navigator.pop(context, draft);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+
+    return AlertDialog(
+      title: const Text('Create poll'),
+      content: SizedBox(
+        width: 420,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextField(
+                controller: _questionController,
+                autofocus: true,
+                textCapitalization: TextCapitalization.sentences,
+                decoration: const InputDecoration(
+                  labelText: 'Question',
+                  border: OutlineInputBorder(),
+                ),
+                onSubmitted: (_) => _submit(),
+              ),
+              const SizedBox(height: 16),
+              Text('Options', style: tt.titleSmall),
+              const SizedBox(height: 8),
+              for (var i = 0; i < _answerControllers.length; i++)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: TextField(
+                          controller: _answerControllers[i],
+                          textCapitalization: TextCapitalization.sentences,
+                          decoration: InputDecoration(
+                            labelText: 'Option ${i + 1}',
+                            border: const OutlineInputBorder(),
+                          ),
+                          onSubmitted: (_) => _submit(),
+                        ),
+                      ),
+                      IconButton(
+                        tooltip: 'Remove option',
+                        icon: const Icon(Icons.remove_circle_outline),
+                        onPressed: _answerControllers.length > _minAnswers
+                            ? () => _removeAnswer(i)
+                            : null,
+                      ),
+                    ],
+                  ),
+                ),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: TextButton.icon(
+                  onPressed: _canAdd ? _addAnswer : null,
+                  icon: const Icon(Icons.add),
+                  label: const Text('Add option'),
+                ),
+              ),
+              const Divider(),
+              SwitchListTile(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('Disclosed (show live results)'),
+                value: _disclosed,
+                onChanged: (v) => setState(() {
+                  _disclosed = v;
+                  _error = null;
+                }),
+              ),
+              SwitchListTile(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('Allow multiple selections'),
+                value: _multiSelect,
+                onChanged: _answerControllers.length > 1
+                    ? (v) => setState(() {
+                          _multiSelect = v;
+                          _error = null;
+                        })
+                    : null,
+              ),
+              if (_error != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(
+                    _error!,
+                    style: tt.bodySmall
+                        ?.copyWith(color: Theme.of(context).colorScheme.error),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _submit,
+          child: const Text('Send'),
+        ),
+      ],
+    );
+  }
+}

--- a/test/widgets/chat/attachment_source_sheet_test.dart
+++ b/test/widgets/chat/attachment_source_sheet_test.dart
@@ -66,4 +66,29 @@ void main() {
 
     expect(result, AttachmentSource.gif);
   });
+
+  testWidgets('always shows Poll option and returns poll source when tapped',
+      (tester) async {
+    AttachmentSource? result;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async {
+              result = await showAttachmentSourceSheet(context);
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Poll'), findsOneWidget);
+    await tester.tap(find.text('Poll'));
+    await tester.pumpAndSettle();
+
+    expect(result, AttachmentSource.poll);
+  });
 }

--- a/test/widgets/chat/create_poll_dialog_test.dart
+++ b/test/widgets/chat/create_poll_dialog_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/theme/kohera_theme.dart';
+import 'package:kohera/features/chat/models/kohera_poll_draft.dart';
+import 'package:kohera/features/chat/widgets/create_poll_dialog.dart';
+
+Widget _harness() => MaterialApp(
+      theme: KoheraTheme.light(),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () => CreatePollDialog.show(context),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+
+Future<void> _fillOption(WidgetTester tester, int index, String text) async {
+  await tester.enterText(find.widgetWithText(TextField, 'Option $index'), text);
+}
+
+void main() {
+  testWidgets('blocks send when question is empty', (tester) async {
+    await tester.pumpWidget(_harness());
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Send'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Enter a question.'), findsOneWidget);
+  });
+
+  testWidgets('blocks send when an option is empty', (tester) async {
+    await tester.pumpWidget(_harness());
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.widgetWithText(TextField, 'Question'), 'Tea?');
+    await _fillOption(tester, 1, 'Yes');
+    await tester.tap(find.text('Send'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('All options must have text.'), findsOneWidget);
+  });
+
+  testWidgets('blocks send when options are duplicated', (tester) async {
+    await tester.pumpWidget(_harness());
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.widgetWithText(TextField, 'Question'), 'Tea?');
+    await _fillOption(tester, 1, 'Yes');
+    await _fillOption(tester, 2, 'Yes');
+    await tester.tap(find.text('Send'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Options must be unique.'), findsOneWidget);
+  });
+
+  testWidgets('can add and remove options within 2–20 bounds', (tester) async {
+    await tester.pumpWidget(_harness());
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Option 1'), findsOneWidget);
+    expect(find.text('Option 2'), findsOneWidget);
+
+    await tester.tap(find.text('Add option'));
+    await tester.pumpAndSettle();
+    expect(find.text('Option 3'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Remove option').first);
+    await tester.pumpAndSettle();
+    expect(find.text('Option 3'), findsNothing);
+  });
+
+  testWidgets('returns a single-select disclosed draft on valid submit',
+      (tester) async {
+    KoheraPollDraft? result;
+    await tester.pumpWidget(MaterialApp(
+      theme: KoheraTheme.light(),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async {
+              result = await CreatePollDialog.show(context);
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.widgetWithText(TextField, 'Question'), 'Tea?');
+    await _fillOption(tester, 1, 'Yes');
+    await _fillOption(tester, 2, 'No');
+    await tester.tap(find.text('Send'));
+    await tester.pumpAndSettle();
+
+    expect(result, isNotNull);
+    expect(result!.question, 'Tea?');
+    expect(result!.answers, ['Yes', 'No']);
+    expect(result!.disclosed, isTrue);
+    expect(result!.maxSelections, 1);
+  });
+
+  testWidgets('returns multi-select draft when multi-select toggled',
+      (tester) async {
+    KoheraPollDraft? result;
+    await tester.pumpWidget(MaterialApp(
+      theme: KoheraTheme.light(),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async {
+              result = await CreatePollDialog.show(context);
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.widgetWithText(TextField, 'Question'), 'Pick');
+    await _fillOption(tester, 1, 'A');
+    await _fillOption(tester, 2, 'B');
+    await tester.tap(find.text('Allow multiple selections'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Send'));
+    await tester.pumpAndSettle();
+
+    expect(result, isNotNull);
+    expect(result!.maxSelections, 2);
+    expect(result!.disclosed, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

Users can compose and send disclosed/undisclosed, single- or multi-select polls from the compose attachment menu. The attachment sheet gains a Poll entry that opens a create-poll dialog; the resulting draft is sent via `room.startPoll` with generated `PollAnswer` ids.

## Changes

- `lib/features/chat/models/kohera_poll_draft.dart` — new immutable draft model (question, answers, disclosed, maxSelections). Keeps the dialog/send boundary free of `package:matrix/matrix.dart`.
- `lib/features/chat/widgets/create_poll_dialog.dart` — `CreatePollDialog`: question field, dynamic add/remove options (min 2, max 20), disclosed/undisclosed switch, multi-select switch. Validates non-empty question, non-empty unique options, 2–20 bound. Returns `KoheraPollDraft?`.
- `lib/features/chat/widgets/attachment_source_sheet.dart` — new `AttachmentSource.poll` + Poll `ListTile` (`Icons.poll_outlined`). Wrapped the sheet body in `SingleChildScrollView` so all entries fit on small viewports.
- `lib/features/chat/services/chat_message_actions.dart` — `sendPoll(KoheraPollDraft)` generates `PollAnswer` ids via `client.generateUniqueTransactionId()` and calls `room.startPoll`, mirroring the existing send/error snackbar pattern (`debugPrint('[Kohera] ...')` + friendly auth error).
- `lib/features/chat/screens/chat_screen.dart` — routes `AttachmentSource.poll` → `CreatePollDialog.show` → `_actions.sendPoll`.

## Testing

- [x] `flutter analyze` is clean
- [x] `flutter test` passes (run `dart run build_runner build --delete-conflicting-outputs` first if mocks changed)
  - `test/widgets/chat/create_poll_dialog_test.dart` — blocks send on empty question / empty option / duplicate options; add/remove within 2–20; returns single-select disclosed draft; returns multi-select draft when toggled.
  - `test/widgets/chat/attachment_source_sheet_test.dart` — Poll entry always shown; returns `AttachmentSource.poll` when tapped; sheet no longer overflows with all entries.
  - Note: 2 `message_bubble_golden_test.dart` failures pre-exist on `master`; unrelated to this change.

## Linked issues

Closes #596
Refs #524

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master` (not another feature branch, unless an explicitly requested stacked PR)