### PR TITLE
feat(chat): vote on polls, change, and retract

### DIFF
--- a/lib/features/chat/models/kohera_poll.dart
+++ b/lib/features/chat/models/kohera_poll.dart
@@ -36,6 +36,7 @@ class KoheraPoll {
     required this.ended,
     required this.responseCount,
     required this.tallies,
+    required this.mySelections,
   });
 
   final String question;
@@ -57,6 +58,11 @@ class KoheraPoll {
   /// Per-answer tally: answer id → vote count. Empty (all zero) when the
   /// tally is hidden for an open undisclosed poll.
   final Map<String, int> tallies;
+
+  /// Answer ids the current user has selected, derived from
+  /// `Event.getPollResponses(timeline)[myUserId]`. Empty when the user has
+  /// not voted (or retracted).
+  final Set<String> mySelections;
 
   /// Whether the running tally should be rendered.
   ///

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -1132,6 +1132,8 @@ class _ChatScreenState extends State<ChatScreen>
                 },
                 onStickerContextMenu: _showStickerContextMenu,
                 onStickerMobileActions: _showStickerMobileActions,
+                onVotePoll: (eventId, answerIds) =>
+                    unawaited(_actions.votePoll(eventId, answerIds)),
               ),
               if (_emojiPanelOpen) ...[
                 Positioned.fill(

--- a/lib/features/chat/services/chat_message_actions.dart
+++ b/lib/features/chat/services/chat_message_actions.dart
@@ -199,4 +199,33 @@ class ChatMessageActions {
       );
     }
   }
+
+  Future<void> votePoll(String eventId, List<String> answerIds) async {
+    final timeline = getTimeline();
+    final scaffold = getScaffold();
+    if (timeline == null) return;
+
+    Event? event;
+    for (final e in timeline.events) {
+      if (e.eventId == eventId) {
+        event = e;
+        break;
+      }
+    }
+    if (event == null) {
+      debugPrint('[Kohera] Poll start event not found in timeline: $eventId');
+      return;
+    }
+
+    try {
+      await event.answerPoll(answerIds);
+    } catch (e) {
+      debugPrint('[Kohera] Failed to submit poll vote: $e');
+      scaffold.showSnackBar(
+        SnackBar(
+          content: Text('Failed to vote: ${MatrixService.friendlyAuthError(e)}'),
+        ),
+      );
+    }
+  }
 }

--- a/lib/features/chat/services/message_timeline_controller.dart
+++ b/lib/features/chat/services/message_timeline_controller.dart
@@ -501,7 +501,7 @@ class MessageTimelineController extends ChangeNotifier {
           callDuration = _callDuration(event);
         case MessageCategory.poll:
           if (timeline != null) {
-            poll = const PollResolver()(event, timeline);
+            poll = const PollResolver()(event, timeline, myUserId: uid);
           }
         case MessageCategory.message:
           if (!isRedacted) {

--- a/lib/features/chat/services/poll_resolver.dart
+++ b/lib/features/chat/services/poll_resolver.dart
@@ -9,7 +9,7 @@ import 'package:matrix/matrix.dart';
 class PollResolver {
   const PollResolver();
 
-  KoheraPoll call(Event event, Timeline timeline) {
+  KoheraPoll call(Event event, Timeline timeline, {required String myUserId}) {
     assert(event.type == PollEventContent.startType, 'PollResolver requires a poll-start event');
 
     final content = event.parsedPollEventContent.pollStartContent;
@@ -26,9 +26,11 @@ class PollResolver {
     final tallies = <String, int>{for (final a in answers) a.id: 0};
     var responseCount = 0;
 
+    final responses = event.getPollResponses(timeline);
+    final mySelections = Set<String>.from(responses[myUserId] ?? const {});
+
     final showTally = kind == KoheraPollKind.disclosed || ended;
     if (showTally) {
-      final responses = event.getPollResponses(timeline);
       responseCount = responses.length;
       for (final answerIds in responses.values) {
         for (final id in answerIds) {
@@ -46,6 +48,7 @@ class PollResolver {
       ended: ended,
       responseCount: responseCount,
       tallies: tallies,
+      mySelections: mySelections,
     );
   }
 }

--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -47,6 +47,7 @@ class MessageListView extends StatefulWidget {
     this.buildReplyPreview,
     this.onStickerContextMenu,
     this.onStickerMobileActions,
+    this.onVotePoll,
     super.key,
   });
 
@@ -91,6 +92,10 @@ class MessageListView extends StatefulWidget {
       onStickerContextMenu;
   final void Function(BuildContext, String eventId, Rect)?
       onStickerMobileActions;
+
+  /// Called with the full new answer-id list when the user changes their
+  /// poll selection in a poll bubble.
+  final void Function(String eventId, List<String> answerIds)? onVotePoll;
 
   @override
   State<MessageListView> createState() => MessageListViewState();
@@ -393,6 +398,9 @@ class MessageListViewState extends State<MessageListView> {
       poll: poll,
       isMe: data.isMe,
       isFirst: data.isFirst,
+      onVote: widget.onVotePoll == null
+          ? null
+          : (answerIds) => widget.onVotePoll!(data.eventId, answerIds),
     );
   }
 

--- a/lib/features/chat/widgets/poll_message_item.dart
+++ b/lib/features/chat/widgets/poll_message_item.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/theme/kohera_palette.dart';
@@ -6,16 +7,20 @@ import 'package:kohera/features/chat/widgets/density_metrics.dart';
 import 'package:kohera/features/chat/widgets/message_bubble_skin.dart';
 import 'package:provider/provider.dart';
 
-/// Read-only rendering of an MSC3381 poll-start event as a bubble.
+/// Rendering of an MSC3381 poll-start event as a bubble.
 ///
 /// Shows the question, answer options, a disclosed/undisclosed badge, and the
 /// open/ended state. Per-option tallies are rendered for disclosed polls and
-/// for ended undisclosed polls. Voting/ending is out of scope.
-class PollMessageItem extends StatelessWidget {
+/// for ended undisclosed polls. When [onVote] is provided and the poll has not
+/// ended, options are tappable: single-select replaces the prior choice,
+/// multi-select toggles selections up to [KoheraPoll.maxSelections]. Tapping
+/// the only selected option retracts the vote (sends an empty answer list).
+class PollMessageItem extends StatefulWidget {
   const PollMessageItem({
     required this.poll,
     required this.isMe,
     required this.isFirst,
+    this.onVote,
     super.key,
   });
 
@@ -23,17 +28,61 @@ class PollMessageItem extends StatelessWidget {
   final bool isMe;
   final bool isFirst;
 
+  /// Called with the full new answer-id list when the user changes their
+  /// selection. `null` (or the poll being ended) disables interaction.
+  final void Function(List<String> answerIds)? onVote;
+
+  @override
+  State<PollMessageItem> createState() => _PollMessageItemState();
+}
+
+class _PollMessageItemState extends State<PollMessageItem> {
+  late Set<String> _selections;
+
+  @override
+  void initState() {
+    super.initState();
+    _selections = widget.poll.mySelections;
+  }
+
+  @override
+  void didUpdateWidget(covariant PollMessageItem oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.poll.mySelections != widget.poll.mySelections) {
+      _selections = widget.poll.mySelections;
+    }
+  }
+
+  bool get _interactive => !widget.poll.ended && widget.onVote != null;
+
+  void _tap(String answerId) {
+    if (!_interactive) return;
+    final next = computeNextSelection(
+      current: _selections,
+      answerId: answerId,
+      maxSelections: widget.poll.maxSelections,
+    );
+    if (listEquals(next, _selections.toList())) return;
+    setState(() => _selections = next.toSet());
+    widget.onVote!.call(next);
+  }
+
   @override
   Widget build(BuildContext context) {
     final density = context.watch<PreferencesService>().messageDensity;
     final metrics = DensityMetrics.of(density);
-    final body = _PollBody(poll: poll);
+    final body = _PollBody(
+      poll: widget.poll,
+      selections: _selections,
+      interactive: _interactive,
+      onTap: _tap,
+    );
 
     return Align(
-      alignment: isMe ? Alignment.centerRight : Alignment.centerLeft,
+      alignment: widget.isMe ? Alignment.centerRight : Alignment.centerLeft,
       child: MessageBubbleSkin(
-        isMe: isMe,
-        isFirst: isFirst,
+        isMe: widget.isMe,
+        isFirst: widget.isFirst,
         metrics: metrics,
         child: body,
       ),
@@ -41,10 +90,44 @@ class PollMessageItem extends StatelessWidget {
   }
 }
 
+/// Pure selection computation shared with tests.
+///
+/// Single-select (`maxSelections == 1`): tapping the selected option retracts
+/// (returns `[]`); tapping any other returns `[answerId]`.
+///
+/// Multi-select: tapping a selected option removes it; tapping an unselected
+/// option adds it only if the current count is below `maxSelections`,
+/// otherwise the selection is unchanged.
+List<String> computeNextSelection({
+  required Set<String> current,
+  required String answerId,
+  required int maxSelections,
+}) {
+  if (maxSelections <= 1) {
+    if (current.contains(answerId)) return const [];
+    return [answerId];
+  }
+  if (current.contains(answerId)) {
+    return current.where((id) => id != answerId).toList();
+  }
+  if (current.length >= maxSelections) {
+    return current.toList();
+  }
+  return [...current, answerId];
+}
+
 class _PollBody extends StatelessWidget {
-  const _PollBody({required this.poll});
+  const _PollBody({
+    required this.poll,
+    required this.selections,
+    required this.interactive,
+    required this.onTap,
+  });
 
   final KoheraPoll poll;
+  final Set<String> selections;
+  final bool interactive;
+  final void Function(String answerId) onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -80,10 +163,13 @@ class _PollBody extends StatelessWidget {
         for (final answer in poll.answers) ...[
           _AnswerRow(
             answer: answer,
+            selected: selections.contains(answer.id),
+            interactive: interactive,
             count: poll.tallies[answer.id] ?? 0,
             maxVotes: maxVotes,
             showTally: showTally,
             palette: palette,
+            onTap: () => onTap(answer.id),
           ),
           const SizedBox(height: 6),
         ],
@@ -129,17 +215,23 @@ class _StateBadge extends StatelessWidget {
 class _AnswerRow extends StatelessWidget {
   const _AnswerRow({
     required this.answer,
+    required this.selected,
+    required this.interactive,
     required this.count,
     required this.maxVotes,
     required this.showTally,
     required this.palette,
+    required this.onTap,
   });
 
   final KoheraPollAnswer answer;
+  final bool selected;
+  final bool interactive;
   final int count;
   final int maxVotes;
   final bool showTally;
   final KoheraPalette palette;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -147,27 +239,35 @@ class _AnswerRow extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
 
     final fraction = maxVotes > 0 ? count / maxVotes : 0.0;
+    final fillColor = selected
+        ? cs.primary.withValues(alpha: 0.35)
+        : cs.primary.withValues(alpha: 0.25);
 
-    return ClipRect(
+    Widget row = ClipRect(
       child: Stack(
         alignment: Alignment.centerLeft,
         children: [
           if (showTally && fraction > 0)
             FractionallySizedBox(
               widthFactor: fraction,
-              child: Container(
-                height: 22,
-                color: cs.primary.withValues(alpha: 0.25),
-              ),
+              child: Container(height: 22, color: fillColor),
             ),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
             child: Row(
               children: [
+                Icon(
+                  selected ? Icons.check_circle : Icons.radio_button_unchecked,
+                  size: 18,
+                  color: selected ? cs.primary : cs.onSurfaceVariant,
+                ),
+                const SizedBox(width: 6),
                 Expanded(
                   child: Text(
                     answer.label,
-                    style: tt.bodyMedium,
+                    style: tt.bodyMedium?.copyWith(
+                      fontWeight: selected ? FontWeight.w600 : null,
+                    ),
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                   ),
@@ -189,6 +289,25 @@ class _AnswerRow extends StatelessWidget {
           ),
         ],
       ),
+    );
+
+    if (interactive) {
+      row = InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(0),
+        child: row,
+      );
+    }
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: selected ? cs.primary : palette.borderStrong,
+          width: selected ? 2 : 1,
+        ),
+        borderRadius: BorderRadius.circular(0),
+      ),
+      child: row,
     );
   }
 }

--- a/test/features/chat/services/poll_resolver_test.dart
+++ b/test/features/chat/services/poll_resolver_test.dart
@@ -51,12 +51,41 @@ MockEvent _startEvent({
   when(event.senderId).thenReturn(senderId);
   when(event.originServerTs).thenReturn(DateTime(2026, 1, 15, 12));
   when(event.content).thenReturn(content);
+  when(event.room).thenReturn(MockRoom());
   return event;
 }
 
 MockTimeline _emptyTimeline(String eventId) {
   final timeline = MockTimeline();
   when(timeline.aggregatedEvents).thenReturn({});
+  return timeline;
+}
+
+MockEvent _responseEvent({
+  required String senderId,
+  required List<String> answerIds,
+  DateTime? ts,
+}) {
+  final event = MockEvent();
+  when(event.type).thenReturn(PollEventContent.responseType);
+  when(event.senderId).thenReturn(senderId);
+  when(event.originServerTs).thenReturn(ts ?? DateTime(2026, 1, 15, 12, 5));
+  when(event.content).thenReturn({
+    PollEventContent.responseType: {'answers': answerIds},
+  });
+  return event;
+}
+
+MockTimeline _timelineWithResponses(
+  String pollEventId, {
+  List<MockEvent> responses = const [],
+}) {
+  final timeline = MockTimeline();
+  when(timeline.aggregatedEvents).thenReturn({
+    pollEventId: {
+      RelationshipTypes.reference: responses.toSet(),
+    },
+  });
   return timeline;
 }
 
@@ -78,7 +107,7 @@ void main() {
       );
       final timeline = _emptyTimeline(r'$p1');
 
-      final poll = const PollResolver()(event, timeline);
+      final poll = const PollResolver()(event, timeline, myUserId: '@me:example.com');
 
       expect(poll.kind, KoheraPollKind.disclosed);
       expect(poll.ended, isFalse);
@@ -98,13 +127,45 @@ void main() {
       );
       final timeline = _emptyTimeline(r'$p2');
 
-      final poll = const PollResolver()(event, timeline);
+      final poll = const PollResolver()(event, timeline, myUserId: '@me:example.com');
 
       expect(poll.kind, KoheraPollKind.undisclosed);
       expect(poll.ended, isFalse);
       expect(poll.showsTally, isFalse);
       expect(poll.tallies, {'a1': 0, 'a2': 0});
       expect(poll.responseCount, 0);
+    });
+
+    test('mySelections reflects the current user latest response', () {
+      final event = _startEvent(
+        eventId: r'$p3',
+        content: _pollContent(
+          question: 'Tea or coffee?',
+          answers: answers,
+          kind: PollKind.disclosed,
+        ),
+      );
+      final timeline = _timelineWithResponses(
+        r'$p3',
+        responses: [
+          _responseEvent(senderId: '@me:example.com', answerIds: ['a1']),
+          _responseEvent(
+            senderId: '@me:example.com',
+            answerIds: ['a2'],
+            ts: DateTime(2026, 1, 15, 12, 6),
+          ),
+        ],
+      );
+
+      final poll = const PollResolver()(
+        event,
+        timeline,
+        myUserId: '@me:example.com',
+      );
+
+      expect(poll.mySelections, {'a2'});
+      expect(poll.tallies, {'a1': 0, 'a2': 1});
+      expect(poll.responseCount, 1);
     });
   });
 }

--- a/test/widgets/chat/irc_message_tile_test.dart
+++ b/test/widgets/chat/irc_message_tile_test.dart
@@ -201,6 +201,7 @@ void main() {
         ended: false,
         responseCount: 0,
         tallies: {'a1': 0, 'a2': 0},
+        mySelections: {},
       );
 
       await tester.pumpWidget(_wrap(IrcMessageTile(

--- a/test/widgets/chat/poll_message_item_test.dart
+++ b/test/widgets/chat/poll_message_item_test.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/services/preferences_service.dart';
+import 'package:kohera/core/theme/kohera_theme.dart';
+import 'package:kohera/features/chat/models/kohera_poll.dart';
+import 'package:kohera/features/chat/widgets/poll_message_item.dart';
+import 'package:provider/provider.dart';
+
+KoheraPoll _poll({
+  KoheraPollKind kind = KoheraPollKind.disclosed,
+  int maxSelections = 1,
+  bool ended = false,
+  Set<String> mySelections = const {},
+  Map<String, int> tallies = const {},
+  int responseCount = 0,
+}) {
+  return KoheraPoll(
+    question: 'Tea or coffee?',
+    answers: const [
+      KoheraPollAnswer(id: 'a1', label: 'Yes'),
+      KoheraPollAnswer(id: 'a2', label: 'No'),
+      KoheraPollAnswer(id: 'a3', label: 'Maybe'),
+    ],
+    kind: kind,
+    maxSelections: maxSelections,
+    ended: ended,
+    responseCount: responseCount,
+    tallies: tallies,
+    mySelections: mySelections,
+  );
+}
+
+Widget _harness(
+  KoheraPoll poll, {
+  void Function(List<String> answerIds)? onVote,
+}) {
+  return MaterialApp(
+    theme: KoheraTheme.light(),
+    home: Scaffold(
+      body: ChangeNotifierProvider<PreferencesService>.value(
+        value: PreferencesService(),
+        child: PollMessageItem(
+          poll: poll,
+          isMe: false,
+          isFirst: true,
+          onVote: onVote,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('computeNextSelection', () {
+    test('single-select replaces the prior choice', () {
+      expect(
+        computeNextSelection(
+          current: {'a1'},
+          answerId: 'a2',
+          maxSelections: 1,
+        ),
+        ['a2'],
+      );
+    });
+
+    test('single-select tapping the selected option retracts', () {
+      expect(
+        computeNextSelection(
+          current: {'a1'},
+          answerId: 'a1',
+          maxSelections: 1,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('multi-select toggles an option on up to maxSelections', () {
+      expect(
+        computeNextSelection(
+          current: {'a1'},
+          answerId: 'a2',
+          maxSelections: 2,
+        ),
+        ['a1', 'a2'],
+      );
+    });
+
+    test('multi-select toggles an option off', () {
+      expect(
+        computeNextSelection(
+          current: {'a1', 'a2'},
+          answerId: 'a1',
+          maxSelections: 2,
+        ),
+        ['a2'],
+      );
+    });
+
+    test('multi-select ignores adds beyond maxSelections', () {
+      final next = computeNextSelection(
+        current: {'a1', 'a2'},
+        answerId: 'a3',
+        maxSelections: 2,
+      );
+      expect(next..sort(), ['a1', 'a2']);
+    });
+  });
+
+  testWidgets('tapping an option fires onVote with the new selection',
+      (tester) async {
+    List<String>? voted;
+    await tester.pumpWidget(_harness(
+      _poll(),
+      onVote: (ids) => voted = ids,
+    ));
+
+    await tester.tap(find.text('Yes'));
+    await tester.pump();
+
+    expect(voted, ['a1']);
+  });
+
+  testWidgets('tapping the selected option retracts the vote',
+      (tester) async {
+    List<String>? voted;
+    await tester.pumpWidget(_harness(
+      _poll(mySelections: const {'a1'}),
+      onVote: (ids) => voted = ids,
+    ));
+
+    await tester.tap(find.text('Yes'));
+    await tester.pump();
+
+    expect(voted, isEmpty);
+  });
+
+  testWidgets('voting is disabled when the poll has ended', (tester) async {
+    List<String>? voted;
+    await tester.pumpWidget(_harness(
+      _poll(ended: true),
+      onVote: (ids) => voted = ids,
+    ));
+
+    await tester.tap(find.text('Yes'));
+    await tester.pump();
+
+    expect(voted, isNull);
+  });
+
+  testWidgets('selected option shows a check icon', (tester) async {
+    await tester.pumpWidget(_harness(
+      _poll(mySelections: const {'a2'}),
+    ));
+
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+    expect(find.byIcon(Icons.radio_button_unchecked), findsNWidgets(2));
+  });
+}


### PR DESCRIPTION
## Summary

Users can vote on a poll, change their vote, and retract it directly from the poll bubble. The current user's selection is resolved at the SDK boundary and rendered as a highlighted, tappable option; tapping computes the next selection per `maxSelections` and submits it via `event.answerPoll`. Interaction is disabled once the poll has ended.

## Changes

- `lib/features/chat/models/kohera_poll.dart` — new `mySelections` field (`Set<String>` of answer ids the current user has selected).
- `lib/features/chat/services/poll_resolver.dart` — fetches `Event.getPollResponses(timeline)` once, derives `mySelections` from `responses[myUserId]`, and reuses the map for tallies. New required `myUserId` param.
- `lib/features/chat/services/message_timeline_controller.dart` — passes `myUserId` into the resolver.
- `lib/features/chat/widgets/poll_message_item.dart` — converted to `StatefulWidget`. Options are tappable `InkWell`s. Selected options show a check icon + primary border. Local selections mirror `poll.mySelections` for instant feedback and reconcile on `didUpdateWidget`. Exposes a pure `computeNextSelection` helper: single-select replaces (tapping selected → retract `[]`); multi-select toggles up to `maxSelections` (adds below max, ignores beyond). Disabled when `poll.ended` or `onVote` is null. New `onVote` callback.
- `lib/features/chat/widgets/message_list_view.dart` — new optional `onVotePoll(eventId, answerIds)` callback; `_buildPollTile` binds it to the bubble.
- `lib/features/chat/screens/chat_screen.dart` — routes `onVotePoll` to `_actions.votePoll`.
- `lib/features/chat/services/chat_message_actions.dart` — `votePoll(eventId, answerIds)` finds the poll-start event in the timeline and calls `event.answerPoll(answerIds)`, with the `debugPrint('[Kohera] ...')` + friendly-error snackbar pattern.

## Testing

- [x] `flutter analyze` is clean
- [x] `flutter test` passes (run `dart run build_runner build --delete-conflicting-outputs` first if mocks changed)
  - `test/widgets/chat/poll_message_item_test.dart` — `computeNextSelection` (single replace, single retract, multi toggle on/off, multi ignore beyond max); tap fires `onVote`; tapping selected retracts; voting disabled when ended; selected option shows check icon.
  - `test/features/chat/services/poll_resolver_test.dart` — `mySelections` reflects the user's latest response (latest-wins).
  - Note: 2 `message_bubble_golden_test.dart` failures pre-exist on `master`; unrelated to this change.

## Linked issues

Closes #597
Refs #524

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master` (not another feature branch, unless an explicitly requested stacked PR)