### PR TITLE
feat(#524): end polls and show poll preview text

### DIFF
--- a/lib/features/chat/models/kohera_poll.dart
+++ b/lib/features/chat/models/kohera_poll.dart
@@ -37,6 +37,7 @@ class KoheraPoll {
     required this.responseCount,
     required this.tallies,
     required this.mySelections,
+    required this.canEnd,
   });
 
   final String question;
@@ -63,6 +64,13 @@ class KoheraPoll {
   /// `Event.getPollResponses(timeline)[myUserId]`. Empty when the user has
   /// not voted (or retracted).
   final Set<String> mySelections;
+
+  /// Whether the current user is allowed to end this poll.
+  ///
+  /// True when the user is the poll creator (`event.senderId == myUserId`)
+  /// or holds redact power in the room. The SDK enforces this server-side;
+  /// this flag only gates the UI affordance.
+  final bool canEnd;
 
   /// Whether the running tally should be rendered.
   ///

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -1134,6 +1134,8 @@ class _ChatScreenState extends State<ChatScreen>
                 onStickerMobileActions: _showStickerMobileActions,
                 onVotePoll: (eventId, answerIds) =>
                     unawaited(_actions.votePoll(eventId, answerIds)),
+                onEndPoll: (eventId) =>
+                    _actions.endPoll(eventId),
               ),
               if (_emojiPanelOpen) ...[
                 Positioned.fill(

--- a/lib/features/chat/services/chat_message_actions.dart
+++ b/lib/features/chat/services/chat_message_actions.dart
@@ -228,4 +228,39 @@ class ChatMessageActions {
       );
     }
   }
+
+  /// Ends the MSC3381 poll whose start event has [eventId].
+  ///
+  /// The SDK (`Event.endPoll`) enforces that only the poll creator or a user
+  /// with redact power may end the poll; the UI gates the action upstream
+  /// via `KoheraPoll.canEnd`, so no extra permission check is needed here.
+  Future<void> endPoll(String eventId) async {
+    final timeline = getTimeline();
+    final scaffold = getScaffold();
+    if (timeline == null) return;
+
+    Event? event;
+    for (final e in timeline.events) {
+      if (e.eventId == eventId) {
+        event = e;
+        break;
+      }
+    }
+    if (event == null) {
+      debugPrint('[Kohera] Poll start event not found in timeline: $eventId');
+      return;
+    }
+
+    try {
+      await event.endPoll();
+    } catch (e) {
+      debugPrint('[Kohera] Failed to end poll: $e');
+      scaffold.showSnackBar(
+        SnackBar(
+          content:
+              Text('Failed to end poll: ${MatrixService.friendlyAuthError(e)}'),
+        ),
+      );
+    }
+  }
 }

--- a/lib/features/chat/services/message_timeline_controller.dart
+++ b/lib/features/chat/services/message_timeline_controller.dart
@@ -501,7 +501,12 @@ class MessageTimelineController extends ChangeNotifier {
           callDuration = _callDuration(event);
         case MessageCategory.poll:
           if (timeline != null) {
-            poll = const PollResolver()(event, timeline, myUserId: uid);
+            poll = const PollResolver()(
+              event,
+              timeline,
+              myUserId: uid,
+              canRedact: canRedact,
+            );
           }
         case MessageCategory.message:
           if (!isRedacted) {

--- a/lib/features/chat/services/poll_resolver.dart
+++ b/lib/features/chat/services/poll_resolver.dart
@@ -9,7 +9,8 @@ import 'package:matrix/matrix.dart';
 class PollResolver {
   const PollResolver();
 
-  KoheraPoll call(Event event, Timeline timeline, {required String myUserId}) {
+  KoheraPoll call(Event event, Timeline timeline,
+      {required String myUserId, required bool canRedact}) {
     assert(event.type == PollEventContent.startType, 'PollResolver requires a poll-start event');
 
     final content = event.parsedPollEventContent.pollStartContent;
@@ -49,6 +50,7 @@ class PollResolver {
       responseCount: responseCount,
       tallies: tallies,
       mySelections: mySelections,
+      canEnd: event.senderId == myUserId || canRedact,
     );
   }
 }

--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -48,6 +48,7 @@ class MessageListView extends StatefulWidget {
     this.onStickerContextMenu,
     this.onStickerMobileActions,
     this.onVotePoll,
+    this.onEndPoll,
     super.key,
   });
 
@@ -96,6 +97,10 @@ class MessageListView extends StatefulWidget {
   /// Called with the full new answer-id list when the user changes their
   /// poll selection in a poll bubble.
   final void Function(String eventId, List<String> answerIds)? onVotePoll;
+
+  /// Called when the user taps the "End poll" affordance on a poll bubble
+  /// they are allowed to end. Resolves to `ChatMessageActions.endPoll`.
+  final Future<void> Function(String eventId)? onEndPoll;
 
   @override
   State<MessageListView> createState() => MessageListViewState();
@@ -401,6 +406,9 @@ class MessageListViewState extends State<MessageListView> {
       onVote: widget.onVotePoll == null
           ? null
           : (answerIds) => widget.onVotePoll!(data.eventId, answerIds),
+      onEnd: widget.onEndPoll == null
+          ? null
+          : () => widget.onEndPoll!(data.eventId),
     );
   }
 

--- a/lib/features/chat/widgets/poll_message_item.dart
+++ b/lib/features/chat/widgets/poll_message_item.dart
@@ -21,6 +21,7 @@ class PollMessageItem extends StatefulWidget {
     required this.isMe,
     required this.isFirst,
     this.onVote,
+    this.onEnd,
     super.key,
   });
 
@@ -31,6 +32,10 @@ class PollMessageItem extends StatefulWidget {
   /// Called with the full new answer-id list when the user changes their
   /// selection. `null` (or the poll being ended) disables interaction.
   final void Function(List<String> answerIds)? onVote;
+
+  /// Called when the user ends the poll. Only invoked when [KoheraPoll.canEnd]
+  /// is true and the poll has not already ended. `null` hides the affordance.
+  final Future<void> Function()? onEnd;
 
   @override
   State<PollMessageItem> createState() => _PollMessageItemState();
@@ -55,6 +60,9 @@ class _PollMessageItemState extends State<PollMessageItem> {
 
   bool get _interactive => !widget.poll.ended && widget.onVote != null;
 
+  bool get _canEnd =>
+      widget.onEnd != null && widget.poll.canEnd && !widget.poll.ended;
+
   void _tap(String answerId) {
     if (!_interactive) return;
     final next = computeNextSelection(
@@ -67,6 +75,18 @@ class _PollMessageItemState extends State<PollMessageItem> {
     widget.onVote!.call(next);
   }
 
+  bool _ending = false;
+
+  Future<void> _endPoll() async {
+    if (_ending || !_canEnd) return;
+    setState(() => _ending = true);
+    try {
+      await widget.onEnd!();
+    } finally {
+      if (mounted) setState(() => _ending = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final density = context.watch<PreferencesService>().messageDensity;
@@ -75,7 +95,10 @@ class _PollMessageItemState extends State<PollMessageItem> {
       poll: widget.poll,
       selections: _selections,
       interactive: _interactive,
+      canEnd: _canEnd,
+      ending: _ending,
       onTap: _tap,
+      onEnd: _endPoll,
     );
 
     return Align(
@@ -121,13 +144,19 @@ class _PollBody extends StatelessWidget {
     required this.poll,
     required this.selections,
     required this.interactive,
+    required this.canEnd,
+    required this.ending,
     required this.onTap,
+    required this.onEnd,
   });
 
   final KoheraPoll poll;
   final Set<String> selections;
   final bool interactive;
+  final bool canEnd;
+  final bool ending;
   final void Function(String answerId) onTap;
+  final Future<void> Function() onEnd;
 
   @override
   Widget build(BuildContext context) {
@@ -177,6 +206,43 @@ class _PollBody extends StatelessWidget {
           Text(
             '${poll.responseCount} ${poll.responseCount == 1 ? "vote" : "votes"}',
             style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+          ),
+        if (poll.ended)
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              'Final results',
+              style: tt.labelSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: cs.onSurfaceVariant,
+              ),
+            ),
+          )
+        else if (canEnd)
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: TextButton.icon(
+                onPressed: ending ? null : onEnd,
+                icon: ending
+                    ? SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: cs.primary,
+                        ),
+                      )
+                    : const Icon(Icons.stop_circle_outlined, size: 16),
+                label: const Text('End poll'),
+                style: TextButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  minimumSize: const Size(0, 28),
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+              ),
+            ),
           ),
       ],
     );

--- a/lib/features/notifications/services/notification_service.dart
+++ b/lib/features/notifications/services/notification_service.dart
@@ -290,7 +290,9 @@ class NotificationService {
     // If any event is from the current user, they're active in this room —
     // clear any existing notification and stop processing.
     final hasOwnMessage = events.any((e) =>
-        (e.type == EventTypes.Message || e.type == EventTypes.Encrypted) &&
+        (e.type == EventTypes.Message ||
+            e.type == EventTypes.Encrypted ||
+            e.type == PollEventContent.startType) &&
         e.senderId == client.userID,);
     if (hasOwnMessage) {
       await cancelForRoom(roomId);
@@ -319,8 +321,10 @@ class NotificationService {
     final notifiable = <(String senderName, String body, Uri? avatarUrl)>[];
 
     for (final matrixEvent in events) {
+      final isPollStart = matrixEvent.type == PollEventContent.startType;
       if (matrixEvent.type != EventTypes.Message &&
-          matrixEvent.type != EventTypes.Encrypted) {
+          matrixEvent.type != EventTypes.Encrypted &&
+          !isPollStart) {
         continue;
       }
 
@@ -329,6 +333,10 @@ class NotificationService {
 
       if (matrixEvent.type == EventTypes.Encrypted) {
         body = await _tryDecrypt(room, event);
+      } else if (isPollStart) {
+        final question =
+            event.parsedPollEventContent.pollStartContent.question.mText;
+        body = question.isEmpty ? '📊 Poll' : '📊 Poll: $question';
       } else {
         body = event.body;
       }

--- a/lib/shared/services/room_summary_resolver.dart
+++ b/lib/shared/services/room_summary_resolver.dart
@@ -49,6 +49,11 @@ class RoomSummaryResolver {
   /// Replicates the last-event preview logic from RoomTile._lastMessagePreview.
   String _lastEventPreview(Event? event, Room room, String? myUserId) {
     if (event == null) return 'No messages yet';
+    if (event.type == PollEventContent.startType) {
+      final question =
+          event.parsedPollEventContent.pollStartContent.question.mText;
+      return question.isEmpty ? '📊 Poll' : '📊 Poll: $question';
+    }
     if (event.type == kCallInvite) return 'Call in progress';
     if (event.type == kCallMember ||
         event.type == kCallMemberMsc ||

--- a/test/features/chat/services/poll_resolver_test.dart
+++ b/test/features/chat/services/poll_resolver_test.dart
@@ -107,7 +107,7 @@ void main() {
       );
       final timeline = _emptyTimeline(r'$p1');
 
-      final poll = const PollResolver()(event, timeline, myUserId: '@me:example.com');
+      final poll = const PollResolver()(event, timeline, myUserId: '@me:example.com', canRedact: false);
 
       expect(poll.kind, KoheraPollKind.disclosed);
       expect(poll.ended, isFalse);
@@ -115,6 +115,7 @@ void main() {
       expect(poll.answers.map((a) => a.label), ['Yes', 'No']);
       expect(poll.tallies, {'a1': 0, 'a2': 0});
       expect(poll.responseCount, 0);
+      expect(poll.canEnd, isFalse);
     });
 
     test('undisclosed open poll hides tally', () {
@@ -127,13 +128,14 @@ void main() {
       );
       final timeline = _emptyTimeline(r'$p2');
 
-      final poll = const PollResolver()(event, timeline, myUserId: '@me:example.com');
+      final poll = const PollResolver()(event, timeline, myUserId: '@me:example.com', canRedact: false);
 
       expect(poll.kind, KoheraPollKind.undisclosed);
       expect(poll.ended, isFalse);
       expect(poll.showsTally, isFalse);
       expect(poll.tallies, {'a1': 0, 'a2': 0});
       expect(poll.responseCount, 0);
+      expect(poll.canEnd, isFalse);
     });
 
     test('mySelections reflects the current user latest response', () {
@@ -161,11 +163,50 @@ void main() {
         event,
         timeline,
         myUserId: '@me:example.com',
+        canRedact: false,
       );
 
       expect(poll.mySelections, {'a2'});
       expect(poll.tallies, {'a1': 0, 'a2': 1});
       expect(poll.responseCount, 1);
+      expect(poll.canEnd, isFalse);
+    });
+
+    test('canEnd is true for the creator and when redact power is held', () {
+      // Creator is the current user.
+      final creatorEvent = _startEvent(
+        eventId: r'$p4',
+        content: _pollContent(
+          question: 'Owner poll?',
+          answers: answers,
+          kind: PollKind.disclosed,
+        ),
+        senderId: '@me:example.com',
+      );
+      final creatorPoll = const PollResolver()(
+        creatorEvent,
+        _emptyTimeline(r'$p4'),
+        myUserId: '@me:example.com',
+        canRedact: false,
+      );
+      expect(creatorPoll.canEnd, isTrue);
+
+      // Non-creator with redact power.
+      final redactEvent = _startEvent(
+        eventId: r'$p5',
+        content: _pollContent(
+          question: 'Mod poll?',
+          answers: answers,
+          kind: PollKind.disclosed,
+        ),
+      );
+      final redactPoll = const PollResolver()(
+        redactEvent,
+        _emptyTimeline(r'$p5'),
+        myUserId: '@me:example.com',
+        canRedact: true,
+      );
+      expect(redactPoll.canEnd, isTrue);
     });
   });
 }

--- a/test/widgets/chat/irc_message_tile_test.dart
+++ b/test/widgets/chat/irc_message_tile_test.dart
@@ -202,6 +202,7 @@ void main() {
         responseCount: 0,
         tallies: {'a1': 0, 'a2': 0},
         mySelections: {},
+        canEnd: false,
       );
 
       await tester.pumpWidget(_wrap(IrcMessageTile(

--- a/test/widgets/chat/poll_message_item_test.dart
+++ b/test/widgets/chat/poll_message_item_test.dart
@@ -13,6 +13,7 @@ KoheraPoll _poll({
   Set<String> mySelections = const {},
   Map<String, int> tallies = const {},
   int responseCount = 0,
+  bool canEnd = false,
 }) {
   return KoheraPoll(
     question: 'Tea or coffee?',
@@ -27,12 +28,14 @@ KoheraPoll _poll({
     responseCount: responseCount,
     tallies: tallies,
     mySelections: mySelections,
+    canEnd: canEnd,
   );
 }
 
 Widget _harness(
   KoheraPoll poll, {
   void Function(List<String> answerIds)? onVote,
+  Future<void> Function()? onEnd,
 }) {
   return MaterialApp(
     theme: KoheraTheme.light(),
@@ -44,6 +47,7 @@ Widget _harness(
           isMe: false,
           isFirst: true,
           onVote: onVote,
+          onEnd: onEnd,
         ),
       ),
     ),
@@ -154,5 +158,50 @@ void main() {
 
     expect(find.byIcon(Icons.check_circle), findsOneWidget);
     expect(find.byIcon(Icons.radio_button_unchecked), findsNWidgets(2));
+  });
+
+  testWidgets('shows End poll button when canEnd and not ended',
+      (tester) async {
+    await tester.pumpWidget(_harness(
+      _poll(canEnd: true),
+      onEnd: () async {},
+    ));
+
+    expect(find.text('End poll'), findsOneWidget);
+  });
+
+  testWidgets('hides End poll button when canEnd is false', (tester) async {
+    await tester.pumpWidget(_harness(
+      _poll(),
+      onEnd: () async {},
+    ));
+
+    expect(find.text('End poll'), findsNothing);
+  });
+
+  testWidgets('hides End poll button and shows Final results when ended',
+      (tester) async {
+    await tester.pumpWidget(_harness(
+      _poll(ended: true, canEnd: true),
+      onEnd: () async {},
+    ));
+
+    expect(find.text('End poll'), findsNothing);
+    expect(find.text('Final results'), findsOneWidget);
+  });
+
+  testWidgets('tapping End poll fires onEnd', (tester) async {
+    var ended = false;
+    await tester.pumpWidget(_harness(
+      _poll(canEnd: true),
+      onEnd: () async {
+        ended = true;
+      },
+    ));
+
+    await tester.tap(find.text('End poll'));
+    await tester.pump();
+
+    expect(ended, isTrue);
   });
 }


### PR DESCRIPTION
## Summary

Completes the final two slices of the MSC3381 polls epic (#524): ending a poll with final results (#598) and poll preview text in the room list & notifications (#599). Slices #595–#597 (render / create / vote) were already on `master`.

## Changes

- **End poll (#598):**
  - `ChatMessageActions.endPoll(eventId)` → `Event.endPoll()` with snackbar error handling (mirrors `votePoll`).
  - `KoheraPoll.canEnd` field; `PollResolver.call` now takes `canRedact` and computes `canEnd = event.senderId == myUserId || canRedact`. `message_timeline_controller` passes the per-event `canRedact` into the resolver.
  - `onEndPoll` callback threaded `chat_screen` → `MessageListView` → `PollMessageItem`.
  - `PollMessageItem` renders an "End poll" button (gated on `canEnd && !ended`, with a spinner while the request is in flight) and a "Final results" caption once ended. Undisclosed tallies reveal automatically via the existing `showsTally`/`ended` logic on the next sync — no extra rendering path.
- **Preview text (#599):**
  - `RoomSummaryResolver._lastEventPreview` returns `📊 Poll: {question}` for `PollEventContent.startType` last events (was raw body dump).
  - `NotificationService` admits poll-start events in own-message detection and the notifiable loop, emitting the `📊 Poll: {question}` body. Response/end events stay excluded (relations, aggregated by the SDK).

## Testing

- [x] `flutter analyze` is clean (0 issues)
- [x] `flutter test` passes — 415 tests across `test/features/chat`, `test/widgets/chat`, inbox + notification suites, 0 failures. Mocks unchanged (no `@GenerateNiceMocks` edits), so no build_runner run required.
- New tests: 4 `canEnd` resolver cases (creator / redact-power / neither), 4 "End poll" widget cases (shown when `canEnd && !ended`, hidden when `!canEnd`, hidden + "Final results" when ended, `onEnd` fires on tap).

## Screenshots / recordings

N/A — UI affordance is a standard `TextButton` consistent with existing poll bubble skin; deferred to device capture if reviewers want it.

## Linked issues

Closes #598
Closes #599
Refs #524

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master`