### PR TITLE
feat(#784): use platform media players on iOS instead of bundled libmpv

### DIFF
--- a/lib/core/media/kohera_media_source.dart
+++ b/lib/core/media/kohera_media_source.dart
@@ -1,0 +1,23 @@
+import 'dart:typed_data';
+
+// ── Platform-agnostic media source ────────────────────────────
+
+sealed class KoheraMediaSource {
+  const KoheraMediaSource();
+}
+
+class KoheraFileSource extends KoheraMediaSource {
+  const KoheraFileSource(this.path);
+  final String path;
+}
+
+class KoheraBytesSource extends KoheraMediaSource {
+  const KoheraBytesSource(this.bytes, {this.mimeType});
+  final Uint8List bytes;
+  final String? mimeType;
+}
+
+class KoheraAssetSource extends KoheraMediaSource {
+  const KoheraAssetSource(this.assetPath);
+  final String assetPath;
+}

--- a/lib/core/media/kohera_player.dart
+++ b/lib/core/media/kohera_player.dart
@@ -1,0 +1,33 @@
+import 'dart:async';
+
+import 'package:kohera/core/media/kohera_media_source.dart';
+
+// ── Platform-agnostic player interface ────────────────────────
+//
+// Desktop (Linux/macOS/Windows) is backed by media_kit; iOS/Android is
+// backed by just_audio (audio/ringtone) or video_player (video). Call sites
+// depend only on this interface, never on a backend package.
+
+abstract class KoheraPlayer {
+  Future<void> open(KoheraMediaSource source);
+
+  Future<void> play();
+
+  Future<void> pause();
+
+  Future<void> stop();
+
+  Future<void> seek(Duration position);
+
+  Future<void> setLoop(bool loop);
+
+  Stream<bool> get playing;
+
+  Stream<Duration> get position;
+
+  Stream<Duration> get duration;
+
+  Stream<bool> get completed;
+
+  Future<void> dispose();
+}

--- a/lib/core/media/kohera_player_factory.dart
+++ b/lib/core/media/kohera_player_factory.dart
@@ -1,0 +1,2 @@
+export 'kohera_player_factory_native.dart'
+    if (dart.library.js_interop) 'kohera_player_factory_web.dart';

--- a/lib/core/media/kohera_player_factory_native.dart
+++ b/lib/core/media/kohera_player_factory_native.dart
@@ -1,0 +1,21 @@
+import 'dart:io' show Platform;
+
+import 'package:kohera/core/media/kohera_player.dart';
+import 'package:kohera/core/media/kohera_video_controller.dart';
+import 'package:kohera/core/media/media_kit/media_kit_kohera_player.dart';
+import 'package:kohera/core/media/media_kit/media_kit_kohera_video_controller.dart';
+import 'package:kohera/core/media/mobile/mobile_kohera_player.dart';
+import 'package:kohera/core/media/mobile/mobile_kohera_video_controller.dart';
+
+// ── Player/video-controller factory (native) ──────────────────
+//
+// media_kit on desktop, video_player/just_audio on iOS/Android.
+
+bool get _isMobile => Platform.isAndroid || Platform.isIOS;
+
+KoheraPlayer createKoheraPlayer() =>
+    _isMobile ? MobileKoheraPlayer() : MediaKitKoheraPlayer();
+
+KoheraVideoController createKoheraVideoController() => _isMobile
+    ? MobileKoheraVideoController()
+    : MediaKitKoheraVideoController();

--- a/lib/core/media/kohera_player_factory_web.dart
+++ b/lib/core/media/kohera_player_factory_web.dart
@@ -1,0 +1,15 @@
+import 'package:kohera/core/media/kohera_player.dart';
+import 'package:kohera/core/media/kohera_video_controller.dart';
+import 'package:kohera/core/media/media_kit/media_kit_kohera_player.dart';
+import 'package:kohera/core/media/media_kit/media_kit_kohera_video_controller.dart';
+
+// ── Player/video-controller factory (web) ─────────────────────
+//
+// Web media playback is out of scope (see #784/#611). media_kit is used as a
+// compile-safe placeholder; runtime playback is unsupported without
+// media_kit_libs_video_web.
+
+KoheraPlayer createKoheraPlayer() => MediaKitKoheraPlayer();
+
+KoheraVideoController createKoheraVideoController() =>
+    MediaKitKoheraVideoController();

--- a/lib/core/media/kohera_video_controller.dart
+++ b/lib/core/media/kohera_video_controller.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:kohera/core/media/kohera_player.dart';
+
+// ── Platform-agnostic video controller ────────────────────────
+//
+// A KoheraVideoController is-a KoheraPlayer (play/pause/seek/streams) and
+// additionally renders a video surface widget via [buildView]. Inline bubbles
+// pass a [controlsOverlay] to render custom controls on top of the surface;
+// fullscreen passes null to use the backend's default controls.
+
+abstract class KoheraVideoController implements KoheraPlayer {
+  Widget buildView({Widget? controlsOverlay});
+}

--- a/lib/core/media/media_kit/media_kit_kohera_player.dart
+++ b/lib/core/media/media_kit/media_kit_kohera_player.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+
+import 'package:kohera/core/media/kohera_media_source.dart';
+import 'package:kohera/core/media/kohera_player.dart';
+import 'package:media_kit/media_kit.dart';
+
+// ── media_kit player backend (desktop) ────────────────────────
+
+class MediaKitKoheraPlayer implements KoheraPlayer {
+  MediaKitKoheraPlayer() : _player = Player();
+
+  final Player _player;
+  bool _loop = false;
+
+  Player get inner => _player;
+
+  @override
+  Future<void> open(KoheraMediaSource source) async {
+    await _player.open(await _toMedia(source));
+    await _player.setPlaylistMode(
+      _loop ? PlaylistMode.loop : PlaylistMode.single,
+    );
+  }
+
+  @override
+  Future<void> play() => _player.play();
+
+  @override
+  Future<void> pause() => _player.pause();
+
+  @override
+  Future<void> stop() => _player.stop();
+
+  @override
+  Future<void> seek(Duration position) => _player.seek(position);
+
+  @override
+  Future<void> setLoop(bool loop) {
+    _loop = loop;
+    return _player.setPlaylistMode(loop ? PlaylistMode.loop : PlaylistMode.single);
+  }
+
+  @override
+  Stream<bool> get playing => _player.stream.playing;
+
+  @override
+  Stream<Duration> get position => _player.stream.position;
+
+  @override
+  Stream<Duration> get duration => _player.stream.duration;
+
+  @override
+  Stream<bool> get completed => _player.stream.completed;
+
+  @override
+  Future<void> dispose() => _player.dispose();
+
+  Future<Media> _toMedia(KoheraMediaSource source) async => switch (source) {
+        KoheraFileSource(:final path) => Media(path),
+        KoheraBytesSource(:final bytes) => Media.memory(bytes),
+        KoheraAssetSource(:final assetPath) => Media('asset:///$assetPath'),
+      };
+}

--- a/lib/core/media/media_kit/media_kit_kohera_player.dart
+++ b/lib/core/media/media_kit/media_kit_kohera_player.dart
@@ -18,7 +18,7 @@ class MediaKitKoheraPlayer implements KoheraPlayer {
   Future<void> open(KoheraMediaSource source) async {
     await _player.open(await _toMedia(source));
     await _player.setPlaylistMode(
-      _loop ? PlaylistMode.loop : PlaylistMode.single,
+      _loop ? PlaylistMode.loop : PlaylistMode.none,
     );
   }
 
@@ -37,7 +37,7 @@ class MediaKitKoheraPlayer implements KoheraPlayer {
   @override
   Future<void> setLoop(bool loop) {
     _loop = loop;
-    return _player.setPlaylistMode(loop ? PlaylistMode.loop : PlaylistMode.single);
+    return _player.setPlaylistMode(loop ? PlaylistMode.loop : PlaylistMode.none);
   }
 
   @override

--- a/lib/core/media/media_kit/media_kit_kohera_video_controller.dart
+++ b/lib/core/media/media_kit/media_kit_kohera_video_controller.dart
@@ -17,7 +17,7 @@ class MediaKitKoheraVideoController implements KoheraVideoController {
   Future<void> open(KoheraMediaSource source) async {
     await _player.open(await _toMedia(source));
     await _player.setPlaylistMode(
-      _loop ? PlaylistMode.loop : PlaylistMode.single,
+      _loop ? PlaylistMode.loop : PlaylistMode.none,
     );
   }
 
@@ -36,7 +36,7 @@ class MediaKitKoheraVideoController implements KoheraVideoController {
   @override
   Future<void> setLoop(bool loop) {
     _loop = loop;
-    return _player.setPlaylistMode(loop ? PlaylistMode.loop : PlaylistMode.single);
+    return _player.setPlaylistMode(loop ? PlaylistMode.loop : PlaylistMode.none);
   }
 
   @override

--- a/lib/core/media/media_kit/media_kit_kohera_video_controller.dart
+++ b/lib/core/media/media_kit/media_kit_kohera_video_controller.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:kohera/core/media/kohera_media_source.dart';
+import 'package:kohera/core/media/kohera_video_controller.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:media_kit_video/media_kit_video.dart';
+
+// ── media_kit video backend (desktop) ─────────────────────────
+
+class MediaKitKoheraVideoController implements KoheraVideoController {
+  MediaKitKoheraVideoController() : _player = Player();
+
+  final Player _player;
+  late final VideoController _controller = VideoController(_player);
+  bool _loop = false;
+
+  @override
+  Future<void> open(KoheraMediaSource source) async {
+    await _player.open(await _toMedia(source));
+    await _player.setPlaylistMode(
+      _loop ? PlaylistMode.loop : PlaylistMode.single,
+    );
+  }
+
+  @override
+  Future<void> play() => _player.play();
+
+  @override
+  Future<void> pause() => _player.pause();
+
+  @override
+  Future<void> stop() => _player.stop();
+
+  @override
+  Future<void> seek(Duration position) => _player.seek(position);
+
+  @override
+  Future<void> setLoop(bool loop) {
+    _loop = loop;
+    return _player.setPlaylistMode(loop ? PlaylistMode.loop : PlaylistMode.single);
+  }
+
+  @override
+  Stream<bool> get playing => _player.stream.playing;
+
+  @override
+  Stream<Duration> get position => _player.stream.position;
+
+  @override
+  Stream<Duration> get duration => _player.stream.duration;
+
+  @override
+  Stream<bool> get completed => _player.stream.completed;
+
+  @override
+  Future<void> dispose() => _player.dispose();
+
+  @override
+  Widget buildView({Widget? controlsOverlay}) {
+    return Video(
+      controller: _controller,
+      controls: controlsOverlay == null ? null : (_) => controlsOverlay,
+    );
+  }
+
+  Future<Media> _toMedia(KoheraMediaSource source) async => switch (source) {
+        KoheraFileSource(:final path) => Media(path),
+        KoheraBytesSource(:final bytes) => Media.memory(bytes),
+        KoheraAssetSource(:final assetPath) => Media('asset:///$assetPath'),
+      };
+}

--- a/lib/core/media/mobile/mobile_kohera_player.dart
+++ b/lib/core/media/mobile/mobile_kohera_player.dart
@@ -1,0 +1,75 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:just_audio/just_audio.dart';
+import 'package:kohera/core/media/kohera_media_source.dart';
+import 'package:kohera/core/media/kohera_player.dart';
+
+// ── just_audio player backend (iOS/Android audio + ringtones) ─
+
+class MobileKoheraPlayer implements KoheraPlayer {
+  MobileKoheraPlayer() : _audio = AudioPlayer();
+
+  final AudioPlayer _audio;
+  bool _loop = false;
+
+  @override
+  Future<void> open(KoheraMediaSource source) async {
+    await _audio.setAudioSource(await _toAudioSource(source));
+    await _audio.setLoopMode(_loop ? LoopMode.one : LoopMode.off);
+    await _audio.play();
+  }
+
+  @override
+  Future<void> play() => _audio.play();
+
+  @override
+  Future<void> pause() => _audio.pause();
+
+  @override
+  Future<void> stop() => _audio.stop();
+
+  @override
+  Future<void> seek(Duration position) => _audio.seek(position);
+
+  @override
+  Future<void> setLoop(bool loop) {
+    _loop = loop;
+    return _audio.setLoopMode(loop ? LoopMode.one : LoopMode.off);
+  }
+
+  @override
+  Stream<bool> get playing => _audio.playerStateStream
+      .map((s) => s.processingState != ProcessingState.completed && s.playing);
+
+  @override
+  Stream<Duration> get position => _audio.positionStream;
+
+  @override
+  Stream<Duration> get duration =>
+      _audio.durationStream.where((d) => d != null).cast<Duration>();
+
+  @override
+  Stream<bool> get completed => _audio.processingStateStream
+      .where((s) => s == ProcessingState.completed)
+      .map((_) => true);
+
+  @override
+  Future<void> dispose() => _audio.dispose();
+
+  Future<AudioSource> _toAudioSource(KoheraMediaSource source) async =>
+      switch (source) {
+        KoheraFileSource(:final path) => AudioSource.file(path),
+        KoheraBytesSource(:final bytes) =>
+          AudioSource.file(await _bytesToTempPath(bytes)),
+        KoheraAssetSource(:final assetPath) => AudioSource.asset(assetPath),
+      };
+
+  Future<String> _bytesToTempPath(Uint8List bytes) async {
+    final dir = await Directory.systemTemp.createTemp('kohera_audio_');
+    final file = File('${dir.path}/media');
+    await file.writeAsBytes(bytes);
+    return file.path;
+  }
+}

--- a/lib/core/media/mobile/mobile_kohera_player.dart
+++ b/lib/core/media/mobile/mobile_kohera_player.dart
@@ -18,7 +18,7 @@ class MobileKoheraPlayer implements KoheraPlayer {
   Future<void> open(KoheraMediaSource source) async {
     await _audio.setAudioSource(await _toAudioSource(source));
     await _audio.setLoopMode(_loop ? LoopMode.one : LoopMode.off);
-    await _audio.play();
+    unawaited(_audio.play());
   }
 
   @override

--- a/lib/core/media/mobile/mobile_kohera_player.dart
+++ b/lib/core/media/mobile/mobile_kohera_player.dart
@@ -22,7 +22,12 @@ class MobileKoheraPlayer implements KoheraPlayer {
   }
 
   @override
-  Future<void> play() => _audio.play();
+  Future<void> play() async {
+    if (_audio.processingState == ProcessingState.completed) {
+      await _audio.seek(Duration.zero);
+    }
+    await _audio.play();
+  }
 
   @override
   Future<void> pause() => _audio.pause();

--- a/lib/core/media/mobile/mobile_kohera_player.dart
+++ b/lib/core/media/mobile/mobile_kohera_player.dart
@@ -13,10 +13,14 @@ class MobileKoheraPlayer implements KoheraPlayer {
 
   final AudioPlayer _audio;
   bool _loop = false;
+  File? _tempFile;
 
   @override
   Future<void> open(KoheraMediaSource source) async {
-    await _audio.setAudioSource(await _toAudioSource(source));
+    _deleteTempFile();
+    final sourceResult = await _toAudioSource(source);
+    _tempFile = sourceResult.tempFile;
+    await _audio.setAudioSource(sourceResult.audioSource);
     await _audio.setLoopMode(_loop ? LoopMode.one : LoopMode.off);
     unawaited(_audio.play());
   }
@@ -61,20 +65,40 @@ class MobileKoheraPlayer implements KoheraPlayer {
       .map((_) => true);
 
   @override
-  Future<void> dispose() => _audio.dispose();
+  Future<void> dispose() async {
+    await _audio.dispose();
+    _deleteTempFile();
+  }
 
-  Future<AudioSource> _toAudioSource(KoheraMediaSource source) async =>
-      switch (source) {
-        KoheraFileSource(:final path) => AudioSource.file(path),
-        KoheraBytesSource(:final bytes) =>
-          AudioSource.file(await _bytesToTempPath(bytes)),
-        KoheraAssetSource(:final assetPath) => AudioSource.asset(assetPath),
-      };
+  void _deleteTempFile() {
+    final temp = _tempFile;
+    _tempFile = null;
+    if (temp != null) unawaited(_deleteQuietly(temp));
+  }
 
-  Future<String> _bytesToTempPath(Uint8List bytes) async {
+  Future<void> _deleteQuietly(File f) async {
+    try {
+      await f.delete();
+    } catch (_) {}
+  }
+
+  Future<({AudioSource audioSource, File? tempFile})> _toAudioSource(
+      KoheraMediaSource source) async {
+    switch (source) {
+      case KoheraFileSource(:final path):
+        return (audioSource: AudioSource.file(path), tempFile: null);
+      case KoheraBytesSource(:final bytes):
+        final file = await _bytesToTempFile(bytes);
+        return (audioSource: AudioSource.file(file.path), tempFile: file);
+      case KoheraAssetSource(:final assetPath):
+        return (audioSource: AudioSource.asset(assetPath), tempFile: null);
+    }
+  }
+
+  Future<File> _bytesToTempFile(Uint8List bytes) async {
     final dir = await Directory.systemTemp.createTemp('kohera_audio_');
     final file = File('${dir.path}/media');
     await file.writeAsBytes(bytes);
-    return file.path;
+    return file;
   }
 }

--- a/lib/core/media/mobile/mobile_kohera_video_controller.dart
+++ b/lib/core/media/mobile/mobile_kohera_video_controller.dart
@@ -1,0 +1,253 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:kohera/core/media/kohera_media_source.dart';
+import 'package:kohera/core/media/kohera_video_controller.dart';
+import 'package:video_player/video_player.dart';
+
+// ── video_player video backend (iOS/Android) ──────────────────
+
+class MobileKoheraVideoController implements KoheraVideoController {
+  MobileKoheraVideoController();
+
+  VideoPlayerController? _vp;
+  bool _loop = false;
+
+  final StreamController<bool> _playing = StreamController<bool>.broadcast();
+  final StreamController<Duration> _position =
+      StreamController<Duration>.broadcast();
+  final StreamController<Duration> _duration =
+      StreamController<Duration>.broadcast();
+  final StreamController<bool> _completed =
+      StreamController<bool>.broadcast();
+  void Function()? _listener;
+  Duration _lastPosition = Duration.zero;
+  Duration _lastDuration = Duration.zero;
+  bool _lastPlaying = false;
+  bool _lastCompleted = false;
+
+  @override
+  Future<void> open(KoheraMediaSource source) async {
+    await _vp?.dispose();
+    _vp = await _makeController(source);
+    await _vp!.initialize();
+    _wire(_vp!);
+    await _vp!.setLooping(_loop);
+    await _vp!.play();
+  }
+
+  @override
+  Future<void> play() async {
+    await _vp?.play();
+  }
+
+  @override
+  Future<void> pause() async {
+    await _vp?.pause();
+  }
+
+  @override
+  Future<void> stop() async {
+    await _vp?.pause();
+    await _vp?.seekTo(Duration.zero);
+  }
+
+  @override
+  Future<void> seek(Duration position) async {
+    await _vp?.seekTo(position);
+  }
+
+  @override
+  Future<void> setLoop(bool loop) {
+    _loop = loop;
+    return _vp?.setLooping(loop) ?? Future<void>.value();
+  }
+
+  @override
+  Stream<bool> get playing => _playing.stream;
+
+  @override
+  Stream<Duration> get position => _position.stream;
+
+  @override
+  Stream<Duration> get duration => _duration.stream;
+
+  @override
+  Stream<bool> get completed => _completed.stream;
+
+  @override
+  Future<void> dispose() async {
+    _vp?.removeListener(_listener ?? () {});
+    await _vp?.dispose();
+    await _playing.close();
+    await _position.close();
+    await _duration.close();
+    await _completed.close();
+  }
+
+  @override
+  Widget buildView({Widget? controlsOverlay}) {
+    final vp = _vp;
+    if (vp == null || !vp.value.isInitialized) {
+      return const ColoredBox(
+        color: Colors.black,
+        child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+      );
+    }
+    final aspectRatio = vp.value.aspectRatio;
+    final surface = AspectRatio(
+      aspectRatio: aspectRatio,
+      child: VideoPlayer(vp),
+    );
+    if (controlsOverlay != null) {
+      return Stack(
+        alignment: Alignment.center,
+        children: [ Positioned.fill(child: surface), controlsOverlay ],
+      );
+    }
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        Positioned.fill(child: Center(child: surface)),
+        _MobileFullscreenControls(controller: this),
+      ],
+    );
+  }
+
+  Future<VideoPlayerController> _makeController(KoheraMediaSource source) async =>
+      switch (source) {
+        KoheraFileSource(:final path) => VideoPlayerController.file(File(path)),
+        KoheraAssetSource(:final assetPath) =>
+          VideoPlayerController.asset(assetPath),
+        KoheraBytesSource(:final bytes) =>
+          VideoPlayerController.file(await _bytesToTempFile(bytes)),
+      };
+
+  Future<File> _bytesToTempFile(Uint8List bytes) async {
+    final dir = await Directory.systemTemp.createTemp('kohera_video_');
+    final file = File('${dir.path}/media');
+    await file.writeAsBytes(bytes);
+    return file;
+  }
+
+  void _wire(VideoPlayerController vp) {
+    _listener = () {
+      if (vp.value.isInitialized) {
+        if (vp.value.position != _lastPosition) {
+          _lastPosition = vp.value.position;
+          _position.add(vp.value.position);
+        }
+        if (vp.value.duration != _lastDuration && vp.value.duration > Duration.zero) {
+          _lastDuration = vp.value.duration;
+          _duration.add(vp.value.duration);
+        }
+      }
+      if (vp.value.isPlaying != _lastPlaying) {
+        _lastPlaying = vp.value.isPlaying;
+        _playing.add(vp.value.isPlaying);
+      }
+      if (vp.value.isCompleted != _lastCompleted) {
+        _lastCompleted = vp.value.isCompleted;
+        if (vp.value.isCompleted) _completed.add(true);
+      }
+    };
+    vp.addListener(_listener!);
+  }
+}
+
+// ── Minimal fullscreen controls for mobile video ──────────────
+
+class _MobileFullscreenControls extends StatefulWidget {
+  const _MobileFullscreenControls({required this.controller});
+  final MobileKoheraVideoController controller;
+
+  @override
+  State<_MobileFullscreenControls> createState() =>
+      _MobileFullscreenControlsState();
+}
+
+class _MobileFullscreenControlsState extends State<_MobileFullscreenControls> {
+  late final StreamSubscription<dynamic> _playingSub;
+  late final StreamSubscription<dynamic> _positionSub;
+  late final StreamSubscription<dynamic> _durationSub;
+  late final StreamSubscription<dynamic> _completedSub;
+  bool _isPlaying = false;
+  Duration _position = Duration.zero;
+  Duration _duration = Duration.zero;
+  bool _barVisible = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _playingSub = widget.controller.playing.listen((p) {
+      if (mounted) setState(() => _isPlaying = p);
+    });
+    _positionSub = widget.controller.position.listen((p) {
+      if (mounted) setState(() => _position = p);
+    });
+    _durationSub = widget.controller.duration.listen((d) {
+      if (mounted) setState(() => _duration = d);
+    });
+    _completedSub = widget.controller.completed.listen((_) {
+      if (mounted) setState(() => _isPlaying = false);
+    });
+  }
+
+  @override
+  void dispose() {
+    unawaited(_playingSub.cancel());
+    unawaited(_positionSub.cancel());
+    unawaited(_durationSub.cancel());
+    unawaited(_completedSub.cancel());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () {
+        setState(() => _barVisible = !_barVisible);
+        if (_isPlaying) {
+          unawaited(widget.controller.pause());
+        } else {
+          unawaited(widget.controller.play());
+        }
+      },
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          if (!_isPlaying)
+            Container(
+              decoration: BoxDecoration(
+                color: Colors.black.withValues(alpha: 0.4),
+                shape: BoxShape.circle,
+              ),
+              padding: const EdgeInsets.all(12),
+              child: const Icon(
+                Icons.play_arrow_rounded,
+                color: Colors.white,
+                size: 32,
+              ),
+            ),
+          if (_barVisible && _duration > Duration.zero)
+            Positioned(
+              bottom: 0,
+              left: 0,
+              right: 0,
+              child: Slider(
+                value: _position.inMilliseconds
+                    .clamp(0, _duration.inMilliseconds)
+                    .toDouble(),
+                max: _duration.inMilliseconds.toDouble(),
+                onChanged: (v) =>
+                    unawaited(widget.controller.seek(Duration(milliseconds: v.toInt()))),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/core/media/mobile/mobile_kohera_video_controller.dart
+++ b/lib/core/media/mobile/mobile_kohera_video_controller.dart
@@ -14,6 +14,7 @@ class MobileKoheraVideoController implements KoheraVideoController {
 
   VideoPlayerController? _vp;
   bool _loop = false;
+  File? _tempFile;
 
   final StreamController<bool> _playing = StreamController<bool>.broadcast();
   final StreamController<Duration> _position =
@@ -30,8 +31,10 @@ class MobileKoheraVideoController implements KoheraVideoController {
 
   @override
   Future<void> open(KoheraMediaSource source) async {
-    await _vp?.dispose();
-    _vp = await _makeController(source);
+    _disposeCurrent();
+    final made = await _makeController(source);
+    _vp = made.controller;
+    _tempFile = made.tempFile;
     await _vp!.initialize();
     _wire(_vp!);
     await _vp!.setLooping(_loop);
@@ -40,6 +43,9 @@ class MobileKoheraVideoController implements KoheraVideoController {
 
   @override
   Future<void> play() async {
+    if (_vp?.value.isCompleted == true) {
+      await _vp!.seekTo(Duration.zero);
+    }
     await _vp?.play();
   }
 
@@ -79,12 +85,29 @@ class MobileKoheraVideoController implements KoheraVideoController {
 
   @override
   Future<void> dispose() async {
-    _vp?.removeListener(_listener ?? () {});
-    await _vp?.dispose();
+    _disposeCurrent();
     await _playing.close();
     await _position.close();
     await _duration.close();
     await _completed.close();
+  }
+
+  void _disposeCurrent() {
+    final vp = _vp;
+    final listener = _listener;
+    if (vp != null && listener != null) vp.removeListener(listener);
+    unawaited(vp?.dispose());
+    _vp = null;
+    _listener = null;
+    final temp = _tempFile;
+    _tempFile = null;
+    if (temp != null) unawaited(_deleteQuietly(temp));
+  }
+
+  Future<void> _deleteQuietly(File f) async {
+    try {
+      await f.delete();
+    } catch (_) {}
   }
 
   @override
@@ -116,14 +139,27 @@ class MobileKoheraVideoController implements KoheraVideoController {
     );
   }
 
-  Future<VideoPlayerController> _makeController(KoheraMediaSource source) async =>
-      switch (source) {
-        KoheraFileSource(:final path) => VideoPlayerController.file(File(path)),
-        KoheraAssetSource(:final assetPath) =>
-          VideoPlayerController.asset(assetPath),
-        KoheraBytesSource(:final bytes) =>
-          VideoPlayerController.file(await _bytesToTempFile(bytes)),
-      };
+  Future<({VideoPlayerController controller, File? tempFile})>
+      _makeController(KoheraMediaSource source) async {
+    switch (source) {
+      case KoheraFileSource(:final path):
+        return (
+          controller: VideoPlayerController.file(File(path)),
+          tempFile: null,
+        );
+      case KoheraAssetSource(:final assetPath):
+        return (
+          controller: VideoPlayerController.asset(assetPath),
+          tempFile: null,
+        );
+      case KoheraBytesSource(:final bytes):
+        final file = await _bytesToTempFile(bytes);
+        return (
+          controller: VideoPlayerController.file(file),
+          tempFile: file,
+        );
+    }
+  }
 
   Future<File> _bytesToTempFile(Uint8List bytes) async {
     final dir = await Directory.systemTemp.createTemp('kohera_video_');
@@ -177,6 +213,8 @@ class _MobileFullscreenControlsState extends State<_MobileFullscreenControls> {
   Duration _position = Duration.zero;
   Duration _duration = Duration.zero;
   bool _barVisible = true;
+  bool _scrubbing = false;
+  bool _scrubWasPlaying = false;
 
   @override
   void initState() {
@@ -185,7 +223,7 @@ class _MobileFullscreenControlsState extends State<_MobileFullscreenControls> {
       if (mounted) setState(() => _isPlaying = p);
     });
     _positionSub = widget.controller.position.listen((p) {
-      if (mounted) setState(() => _position = p);
+      if (mounted && !_scrubbing) setState(() => _position = p);
     });
     _durationSub = widget.controller.duration.listen((d) {
       if (mounted) setState(() => _duration = d);
@@ -206,33 +244,31 @@ class _MobileFullscreenControlsState extends State<_MobileFullscreenControls> {
 
   @override
   Widget build(BuildContext context) {
+    final showBar = _barVisible && _duration > Duration.zero;
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
-      onTap: () {
-        setState(() => _barVisible = !_barVisible);
-        if (_isPlaying) {
-          unawaited(widget.controller.pause());
-        } else {
-          unawaited(widget.controller.play());
-        }
-      },
+      onTap: () => setState(() => _barVisible = !_barVisible),
       child: Stack(
         alignment: Alignment.center,
         children: [
-          if (!_isPlaying)
-            Container(
-              decoration: BoxDecoration(
-                color: Colors.black.withValues(alpha: 0.4),
-                shape: BoxShape.circle,
+          if (showBar && _isPlaying)
+            IconButton(
+              icon: const Icon(Icons.pause_rounded, color: Colors.white, size: 40),
+              style: IconButton.styleFrom(
+                backgroundColor: Colors.black.withValues(alpha: 0.4),
               ),
-              padding: const EdgeInsets.all(12),
-              child: const Icon(
-                Icons.play_arrow_rounded,
-                color: Colors.white,
-                size: 32,
-              ),
+              onPressed: () => unawaited(widget.controller.pause()),
             ),
-          if (_barVisible && _duration > Duration.zero)
+          if (!_isPlaying)
+            IconButton(
+              icon: const Icon(Icons.play_arrow_rounded,
+                  color: Colors.white, size: 40),
+              style: IconButton.styleFrom(
+                backgroundColor: Colors.black.withValues(alpha: 0.4),
+              ),
+              onPressed: () => unawaited(widget.controller.play()),
+            ),
+          if (showBar)
             Positioned(
               bottom: 0,
               left: 0,
@@ -242,8 +278,22 @@ class _MobileFullscreenControlsState extends State<_MobileFullscreenControls> {
                     .clamp(0, _duration.inMilliseconds)
                     .toDouble(),
                 max: _duration.inMilliseconds.toDouble(),
+                onChangeStart: (_) {
+                  setState(() => _scrubbing = true);
+                  _scrubWasPlaying = _isPlaying;
+                  if (_scrubWasPlaying) unawaited(widget.controller.pause());
+                },
                 onChanged: (v) =>
-                    unawaited(widget.controller.seek(Duration(milliseconds: v.toInt()))),
+                    setState(() => _position = Duration(milliseconds: v.toInt())),
+                onChangeEnd: (v) {
+                  final target = Duration(milliseconds: v.toInt());
+                  setState(() => _scrubbing = false);
+                  unawaited(widget.controller.seek(target).then((_) {
+                    if (_scrubWasPlaying && mounted && !_scrubbing) {
+                      unawaited(widget.controller.play());
+                    }
+                  }));
+                },
               ),
             ),
         ],

--- a/lib/core/utils/media_cache.dart
+++ b/lib/core/utils/media_cache.dart
@@ -1,10 +1,10 @@
 import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
+import 'package:kohera/core/media/kohera_media_source.dart';
 import 'package:kohera/core/utils/media_cache_io.dart'
     if (dart.library.js_interop) 'package:kohera/core/utils/media_cache_web.dart';
 import 'package:kohera/shared/services/media_controller.dart';
-import 'package:media_kit/media_kit.dart';
 import 'package:path_provider/path_provider.dart';
 
 // ── Media cache (download/decrypt → temp file or memory) ──────
@@ -13,21 +13,21 @@ class MediaCache {
   static const _maxEntries = 50;
   static final LinkedHashMap<String, String> _tempFiles = LinkedHashMap();
 
-  static Future<Media> resolve(MediaController controller) async {
+  static Future<KoheraMediaSource> resolve(MediaController controller) async {
     final cached = _tempFiles[controller.eventId];
     if (cached != null && !kIsWeb && File(cached).existsSync()) {
       _promote(controller.eventId);
-      return Media(cached);
+      return KoheraFileSource(cached);
     }
 
     final bytes = await controller.downloadAndDecrypt();
     return _bytesToMedia(controller.eventId, bytes, controller.mimeType);
   }
 
-  static Future<Media> _bytesToMedia(
+  static Future<KoheraMediaSource> _bytesToMedia(
       String eventId, Uint8List bytes, String? mimetype,) async {
     if (kIsWeb) {
-      return Media.memory(bytes);
+      return KoheraBytesSource(bytes, mimeType: mimetype);
     }
     final dir = await getTemporaryDirectory();
     final sanitized = eventId.replaceAll(RegExp(r'[^\w]'), '_');
@@ -37,7 +37,7 @@ class MediaCache {
     await file.writeAsBytes(bytes);
     _tempFiles[eventId] = path;
     _evictOldest();
-    return Media(path);
+    return KoheraFileSource(path);
   }
 
   static String _extensionForMime(String? mime) {

--- a/lib/core/utils/media_cache.dart
+++ b/lib/core/utils/media_cache.dart
@@ -37,36 +37,67 @@ class MediaCache {
     final path = '${dir.path}/kohera_media_$sanitized$ext';
     final file = File(path);
     await file.writeAsBytes(bytes);
-    final playablePath = await _ensureIosPlayable(path, mimetype);
+    final playablePath = await _ensureIosPlayable(path, bytes);
     _tempFiles[eventId] = playablePath;
     _evictOldest();
     return KoheraFileSource(playablePath);
   }
 
-  // ── iOS Opus handling ───────────────────────────────────────
-  // iOS AVPlayer cannot decode Ogg/Opus. Remux Ogg/Opus to CAF/Opus (CAF is
-  // AVPlayer-supported on iOS 11+) so just_audio can play voice messages.
-  // Falls back to the original path if the input is not valid Ogg/Opus.
-  static Future<String> _ensureIosPlayable(String path, String? mime) async {
-    if (!isNativeIOS || !_isOggOpus(mime)) return path;
-    final cafPath = path.replaceAll(_oggOpusExt, '.caf');
-    try {
-      await OggCafConverter().convertOggToCaf(
-        input: path,
-        output: cafPath,
-        deleteInput: true,
-      );
-      return cafPath;
-    } catch (e) {
-      debugPrint('[Kohera] iOS Ogg to CAF remux failed, using original: $e');
-      return path;
+  // ── iOS playback prep ────────────────────────────────────────
+  // iOS AVPlayer cannot decode the Ogg container. Sniff the actual content
+  // (the mimetype label is unreliable: Kohera previously sent AAC/m4a bytes
+  // labelled audio/ogg) and:
+  //   - real Ogg/Opus → remux to CAF/Opus (AVPlayer-supported on iOS 11+)
+  //   - real m4a/mp4 → rename to .m4a so AVPlayer decodes AAC natively
+  // Falls back to the original path if the format is unknown.
+  static Future<String> _ensureIosPlayable(String path, Uint8List bytes) async {
+    if (!isNativeIOS) return path;
+    final fmt = _sniffFormat(bytes);
+    switch (fmt) {
+      case _AudioFormat.ogg:
+        final cafPath = _replaceExt(path, '.caf');
+        try {
+          await OggCafConverter().convertOggToCaf(
+            input: path,
+            output: cafPath,
+            deleteInput: true,
+          );
+          return cafPath;
+        } catch (e) {
+          debugPrint('[Kohera] iOS Ogg to CAF remux failed: $e');
+          return path;
+        }
+      case _AudioFormat.mp4:
+        final m4aPath = _replaceExt(path, '.m4a');
+        if (m4aPath == path) return path;
+        try {
+          await File(path).rename(m4aPath);
+          return m4aPath;
+        } catch (e) {
+          debugPrint('[Kohera] iOS m4a rename failed: $e');
+          return path;
+        }
+      case _AudioFormat.unknown:
+        return path;
     }
   }
 
-  static bool _isOggOpus(String? mime) =>
-      mime == 'audio/ogg' || mime == 'audio/opus';
+  static _AudioFormat _sniffFormat(Uint8List b) {
+    if (b.length >= 4 &&
+        b[0] == 0x4F && b[1] == 0x67 && b[2] == 0x67 && b[3] == 0x53) {
+      return _AudioFormat.ogg;
+    }
+    if (b.length >= 8 &&
+        b[4] == 0x66 && b[5] == 0x74 && b[6] == 0x79 && b[7] == 0x70) {
+      return _AudioFormat.mp4;
+    }
+    return _AudioFormat.unknown;
+  }
 
-  static final RegExp _oggOpusExt = RegExp(r'\.(ogg|opus)$');
+  static String _replaceExt(String path, String newExt) {
+    final dot = path.lastIndexOf('.');
+    return dot >= 0 ? '${path.substring(0, dot)}$newExt' : '$path$newExt';
+  }
 
   static String _extensionForMime(String? mime) {
     if (mime == null) return '';
@@ -117,3 +148,5 @@ class MediaCache {
     _tempFiles.clear();
   }
 }
+
+enum _AudioFormat { ogg, mp4, unknown }

--- a/lib/core/utils/media_cache.dart
+++ b/lib/core/utils/media_cache.dart
@@ -4,7 +4,9 @@ import 'package:flutter/foundation.dart';
 import 'package:kohera/core/media/kohera_media_source.dart';
 import 'package:kohera/core/utils/media_cache_io.dart'
     if (dart.library.js_interop) 'package:kohera/core/utils/media_cache_web.dart';
+import 'package:kohera/core/utils/platform_info.dart';
 import 'package:kohera/shared/services/media_controller.dart';
+import 'package:ogg_caf_converter/ogg_caf_converter.dart';
 import 'package:path_provider/path_provider.dart';
 
 // ── Media cache (download/decrypt → temp file or memory) ──────
@@ -35,10 +37,36 @@ class MediaCache {
     final path = '${dir.path}/kohera_media_$sanitized$ext';
     final file = File(path);
     await file.writeAsBytes(bytes);
-    _tempFiles[eventId] = path;
+    final playablePath = await _ensureIosPlayable(path, mimetype);
+    _tempFiles[eventId] = playablePath;
     _evictOldest();
-    return KoheraFileSource(path);
+    return KoheraFileSource(playablePath);
   }
+
+  // ── iOS Opus handling ───────────────────────────────────────
+  // iOS AVPlayer cannot decode Ogg/Opus. Remux Ogg/Opus to CAF/Opus (CAF is
+  // AVPlayer-supported on iOS 11+) so just_audio can play voice messages.
+  // Falls back to the original path if the input is not valid Ogg/Opus.
+  static Future<String> _ensureIosPlayable(String path, String? mime) async {
+    if (!isNativeIOS || !_isOggOpus(mime)) return path;
+    final cafPath = path.replaceAll(_oggOpusExt, '.caf');
+    try {
+      await OggCafConverter().convertOggToCaf(
+        input: path,
+        output: cafPath,
+        deleteInput: true,
+      );
+      return cafPath;
+    } catch (e) {
+      debugPrint('[Kohera] iOS Ogg to CAF remux failed, using original: $e');
+      return path;
+    }
+  }
+
+  static bool _isOggOpus(String? mime) =>
+      mime == 'audio/ogg' || mime == 'audio/opus';
+
+  static final RegExp _oggOpusExt = RegExp(r'\.(ogg|opus)$');
 
   static String _extensionForMime(String? mime) {
     if (mime == null) return '';

--- a/lib/features/calling/services/ringtone_service.dart
+++ b/lib/features/calling/services/ringtone_service.dart
@@ -2,29 +2,29 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:media_kit/media_kit.dart';
+import 'package:kohera/core/media/kohera_media_source.dart';
+import 'package:kohera/core/media/kohera_player.dart';
+import 'package:kohera/core/media/kohera_player_factory.dart';
 
 // coverage:ignore-start
 class RingtoneService {
-  Player? _player;
+  KoheraPlayer? _player;
 
-  Player _ensurePlayer() => _player ??= Player();
+  KoheraPlayer _ensurePlayer() => _player ??= createKoheraPlayer();
 
   Future<void> playRingtone({bool loop = true}) async {
     await stop();
-    await _ensurePlayer().open(Media('asset:///assets/audio/ringtone.mp3'));
-    if (loop) {
-      await _player!.setPlaylistMode(PlaylistMode.loop);
-    }
+    await _ensurePlayer()
+        .open(const KoheraAssetSource('assets/audio/ringtone.mp3'));
+    await _player!.setLoop(loop);
     if (!kIsWeb) unawaited(HapticFeedback.mediumImpact().catchError((_) {}));
   }
 
   Future<void> playDialtone({bool loop = true}) async {
     await stop();
-    await _ensurePlayer().open(Media('asset:///assets/audio/dialtone.mp3'));
-    if (loop) {
-      await _player!.setPlaylistMode(PlaylistMode.loop);
-    }
+    await _ensurePlayer()
+        .open(const KoheraAssetSource('assets/audio/dialtone.mp3'));
+    await _player!.setLoop(loop);
   }
 
   Future<void> stop() async {
@@ -35,33 +35,35 @@ class RingtoneService {
 
   // ── PTT sounds ──────────────────────────────────────────────
 
-  Player? _pttPlayer;
+  KoheraPlayer? _pttPlayer;
 
-  Player _ensurePttPlayer() => _pttPlayer ??= Player();
+  KoheraPlayer _ensurePttPlayer() => _pttPlayer ??= createKoheraPlayer();
 
   Future<void> playPTTOn() async {
-    await _ensurePttPlayer().open(Media('asset:///assets/audio/ptt_on.mp3'));
+    await _ensurePttPlayer()
+        .open(const KoheraAssetSource('assets/audio/ptt_on.mp3'));
   }
 
   Future<void> playPTTOff() async {
-    await _ensurePttPlayer().open(Media('asset:///assets/audio/ptt_off.mp3'));
+    await _ensurePttPlayer()
+        .open(const KoheraAssetSource('assets/audio/ptt_off.mp3'));
   }
 
   // ── Participant join/leave sounds ──────────────────────────
 
-  final List<Player?> _participantPlayers = [null, null];
+  final List<KoheraPlayer?> _participantPlayers = [null, null];
   int _participantPlayerIndex = 0;
 
-  Player _nextParticipantPlayer() {
+  KoheraPlayer _nextParticipantPlayer() {
     final idx = _participantPlayerIndex;
     _participantPlayerIndex = (idx + 1) % _participantPlayers.length;
-    return _participantPlayers[idx] ??= Player();
+    return _participantPlayers[idx] ??= createKoheraPlayer();
   }
 
   Future<void> playUserJoined() async {
     try {
       await _nextParticipantPlayer()
-          .open(Media('asset:///assets/audio/user_join.mp3'));
+          .open(const KoheraAssetSource('assets/audio/user_join.mp3'));
     } catch (e) {
       debugPrint('[Kohera] playUserJoined failed: $e');
     }
@@ -70,7 +72,7 @@ class RingtoneService {
   Future<void> playUserLeft() async {
     try {
       await _nextParticipantPlayer()
-          .open(Media('asset:///assets/audio/user_leave.mp3'));
+          .open(const KoheraAssetSource('assets/audio/user_leave.mp3'));
     } catch (e) {
       debugPrint('[Kohera] playUserLeft failed: $e');
     }

--- a/lib/features/chat/services/media_playback_service.dart
+++ b/lib/features/chat/services/media_playback_service.dart
@@ -1,7 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:media_kit/media_kit.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:kohera/core/media/kohera_player.dart';
 
 // coverage:ignore-start
 
@@ -9,29 +10,41 @@ import 'package:media_kit/media_kit.dart';
 
 class MediaPlaybackService extends ChangeNotifier {
   String? _activeEventId;
-  Player? _activePlayer;
+  KoheraPlayer? _activePlayer;
 
   String? get activeEventId => _activeEventId;
 
-  void registerPlayer(String eventId, Player player) {
+  void registerPlayer(String eventId, KoheraPlayer player) {
     if (_activeEventId != null && _activeEventId != eventId) {
       unawaited(_activePlayer?.pause());
     }
     _activeEventId = eventId;
     _activePlayer = player;
-    notifyListeners();
+    _notify();
   }
 
   void unregisterPlayer(String eventId) {
     if (_activeEventId == eventId) {
       _activeEventId = null;
       _activePlayer = null;
-      notifyListeners();
+      _notify();
     }
   }
 
   void pauseActive() {
     unawaited(_activePlayer?.pause());
+  }
+
+  // notifyListeners() may be invoked from a State.dispose() callback, which
+  // runs while the widget tree is locked (build/layout/paint phase). Deferring
+  // to the next frame avoids the "widget tree was locked" assertion.
+  void _notify() {
+    if (SchedulerBinding.instance.schedulerPhase ==
+        SchedulerPhase.persistentCallbacks) {
+      SchedulerBinding.instance.addPostFrameCallback((_) => notifyListeners());
+    } else {
+      notifyListeners();
+    }
   }
 
   @override

--- a/lib/features/chat/services/voice_send_handler.dart
+++ b/lib/features/chat/services/voice_send_handler.dart
@@ -38,7 +38,7 @@ Future<void> sendVoiceMessage(
       extraContent: {
         'info': {
           'duration': duration.inMilliseconds,
-          'mimetype': 'audio/ogg',
+          'mimetype': 'audio/mp4',
           'size': bytes.length,
         },
         'org.matrix.msc3245.voice': <String, dynamic>{},

--- a/lib/features/chat/widgets/attachment_preview_bar.dart
+++ b/lib/features/chat/widgets/attachment_preview_bar.dart
@@ -88,7 +88,7 @@ class _AttachmentCard extends StatelessWidget {
                   ? Image.memory(
                       attachment.bytes,
                       fit: BoxFit.cover,
-                      errorBuilder: (_, _, _) => Container(
+                      errorBuilder: (_, _, _) => ColoredBox(
                         color: cs.surfaceContainerHighest,
                         child: const Icon(Icons.broken_image_outlined),
                       ),

--- a/lib/features/chat/widgets/attachment_preview_bar.dart
+++ b/lib/features/chat/widgets/attachment_preview_bar.dart
@@ -88,6 +88,10 @@ class _AttachmentCard extends StatelessWidget {
                   ? Image.memory(
                       attachment.bytes,
                       fit: BoxFit.cover,
+                      errorBuilder: (_, _, _) => Container(
+                        color: cs.surfaceContainerHighest,
+                        child: const Icon(Icons.broken_image_outlined),
+                      ),
                     )
                   : Container(
                       decoration: BoxDecoration(

--- a/lib/features/chat/widgets/audio_bubble.dart
+++ b/lib/features/chat/widgets/audio_bubble.dart
@@ -103,13 +103,10 @@ class _AudioBubbleState extends State<AudioBubble> {
         }
       }),);
 
+      _playbackService.registerPlayer(widget.controller.eventId, _player!);
       await _player!.open(media);
       if (!mounted) return;
 
-      _playbackService.registerPlayer(
-            widget.controller.eventId,
-            _player!,
-          );
       setState(() => _state = _AudioState.ready);
     } catch (e) {
       debugPrint('[Kohera] Audio playback failed: $e');

--- a/lib/features/chat/widgets/audio_bubble.dart
+++ b/lib/features/chat/widgets/audio_bubble.dart
@@ -1,13 +1,14 @@
 import 'dart:async';
 import 'dart:math';
 import 'package:flutter/material.dart';
+import 'package:kohera/core/media/kohera_player.dart';
+import 'package:kohera/core/media/kohera_player_factory.dart';
 import 'package:kohera/core/utils/format_duration.dart';
 import 'package:kohera/core/utils/format_file_size.dart';
 import 'package:kohera/core/utils/media_cache.dart';
 import 'package:kohera/features/chat/models/kohera_media_content.dart';
 import 'package:kohera/features/chat/services/media_playback_service.dart';
 import 'package:kohera/shared/services/media_controller.dart';
-import 'package:media_kit/media_kit.dart';
 import 'package:provider/provider.dart';
 
 
@@ -36,7 +37,7 @@ enum _AudioState { initial, loading, ready, error }
 
 class _AudioBubbleState extends State<AudioBubble> {
   _AudioState _state = _AudioState.initial;
-  Player? _player;
+  KoheraPlayer? _player;
   bool _playing = false;
   Duration _position = Duration.zero;
   Duration _duration = Duration.zero;
@@ -83,17 +84,17 @@ class _AudioBubbleState extends State<AudioBubble> {
       final media = await MediaCache.resolve(widget.controller);
       if (!mounted) return;
 
-      _player = Player();
-      _subs.add(_player!.stream.playing.listen((playing) {
+      _player = createKoheraPlayer();
+      _subs.add(_player!.playing.listen((playing) {
         if (mounted) setState(() => _playing = playing);
       }),);
-      _subs.add(_player!.stream.position.listen((pos) {
+      _subs.add(_player!.position.listen((pos) {
         if (mounted) setState(() => _position = pos);
       }),);
-      _subs.add(_player!.stream.duration.listen((dur) {
+      _subs.add(_player!.duration.listen((dur) {
         if (mounted) setState(() => _duration = dur);
       }),);
-      _subs.add(_player!.stream.completed.listen((completed) {
+      _subs.add(_player!.completed.listen((completed) {
         if (completed && mounted) {
           setState(() {
             _playing = false;

--- a/lib/features/chat/widgets/full_video_view.dart
+++ b/lib/features/chat/widgets/full_video_view.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:kohera/core/media/kohera_video_controller.dart';
 import 'package:kohera/features/chat/models/kohera_media_content.dart';
 import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/services/media_controller.dart';
 import 'package:kohera/shared/widgets/media_viewer_shell.dart';
-import 'package:media_kit/media_kit.dart';
-import 'package:media_kit_video/media_kit_video.dart';
 
 // coverage:ignore-start
 
@@ -15,15 +14,14 @@ void showFullVideoDialog(
   required KoheraMediaContent media,
   required MediaController mediaController,
   required AvatarResolver avatarResolver,
-  required Player player,
-  required VideoController controller,
+  required KoheraVideoController controller,
 }) {
   showMediaViewer(
     context,
     media: media,
     controller: mediaController,
     avatarResolver: avatarResolver,
-    child: Video(controller: controller),
+    child: controller.buildView(),
   );
 }
 // coverage:ignore-end

--- a/lib/features/chat/widgets/video_bubble.dart
+++ b/lib/features/chat/widgets/video_bubble.dart
@@ -128,13 +128,10 @@ class _VideoBubbleState extends State<VideoBubble> {
         }
       }),);
 
+      _playbackService.registerPlayer(widget.controller.eventId, _videoController!);
       await _videoController!.open(media);
       if (!mounted) return;
 
-      _playbackService.registerPlayer(
-            widget.controller.eventId,
-            _videoController!,
-          );
       setState(() => _state = _VideoState.playing);
     } catch (e) {
       debugPrint('[Kohera] Video playback failed: $e');

--- a/lib/features/chat/widgets/video_bubble.dart
+++ b/lib/features/chat/widgets/video_bubble.dart
@@ -185,8 +185,14 @@ class _VideoBubbleState extends State<VideoBubble> {
         : null;
 
     Widget thumb;
-    if (_thumbBytes != null) {
-      thumb = Image.memory(_thumbBytes!, fit: BoxFit.cover, width: 280, height: 180);
+    if (_thumbBytes != null && _thumbBytes!.isNotEmpty) {
+      thumb = Image.memory(
+        _thumbBytes!,
+        fit: BoxFit.cover,
+        width: 280,
+        height: 180,
+        errorBuilder: (_, _, _) => _placeholderThumb(cs),
+      );
     } else if (_thumbUrl != null) {
       thumb = Image.network(
         _thumbUrl!,

--- a/lib/features/chat/widgets/video_bubble.dart
+++ b/lib/features/chat/widgets/video_bubble.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
+import 'package:kohera/core/media/kohera_player_factory.dart';
+import 'package:kohera/core/media/kohera_video_controller.dart';
 import 'package:kohera/core/utils/format_duration.dart';
 import 'package:kohera/core/utils/format_file_size.dart';
 import 'package:kohera/core/utils/media_cache.dart';
@@ -9,8 +11,6 @@ import 'package:kohera/features/chat/services/media_playback_service.dart';
 import 'package:kohera/features/chat/widgets/full_video_view.dart';
 import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/services/media_controller.dart';
-import 'package:media_kit/media_kit.dart';
-import 'package:media_kit_video/media_kit_video.dart';
 import 'package:provider/provider.dart';
 
 
@@ -42,8 +42,7 @@ class _VideoBubbleState extends State<VideoBubble> {
   _VideoState _state = _VideoState.initial;
   Uint8List? _thumbBytes;
   String? _thumbUrl;
-  Player? _player;
-  VideoController? _controller;
+  KoheraVideoController? _videoController;
   bool _isPlaying = false;
   late final MediaPlaybackService _playbackService;
   final List<StreamSubscription<dynamic>> _subs = [];
@@ -65,9 +64,9 @@ class _VideoBubbleState extends State<VideoBubble> {
     for (final sub in _subs) {
       unawaited(sub.cancel());
     }
-    if (_player != null) {
+    if (_videoController != null) {
       _playbackService.unregisterPlayer(widget.controller.eventId);
-      unawaited(_player!.dispose());
+      unawaited(_videoController!.dispose());
     }
     super.dispose();
   }
@@ -117,25 +116,24 @@ class _VideoBubbleState extends State<VideoBubble> {
       final media = await MediaCache.resolve(widget.controller);
       if (!mounted) return;
 
-      _player = Player();
-      _controller = VideoController(_player!);
+      _videoController = createKoheraVideoController();
 
-      _subs.add(_player!.stream.playing.listen((playing) {
+      _subs.add(_videoController!.playing.listen((playing) {
         if (mounted) setState(() => _isPlaying = playing);
       }),);
-      _subs.add(_player!.stream.completed.listen((completed) {
+      _subs.add(_videoController!.completed.listen((completed) {
         if (completed && mounted) {
-          unawaited(_player!.seek(Duration.zero));
-          unawaited(_player!.pause());
+          unawaited(_videoController!.seek(Duration.zero));
+          unawaited(_videoController!.pause());
         }
       }),);
 
-      await _player!.open(media);
+      await _videoController!.open(media);
       if (!mounted) return;
 
       _playbackService.registerPlayer(
             widget.controller.eventId,
-            _player!,
+            _videoController!,
           );
       setState(() => _state = _VideoState.playing);
     } catch (e) {
@@ -149,21 +147,20 @@ class _VideoBubbleState extends State<VideoBubble> {
       unawaited(sub.cancel());
     }
     _subs.clear();
-    if (_player != null) unawaited(_player!.dispose());
-    _player = null;
-    _controller = null;
+    if (_videoController != null) unawaited(_videoController!.dispose());
+    _videoController = null;
     unawaited(_initPlayer());
   }
 
   void _openFullscreen() {
-    if (_player == null || _controller == null) return;
+    final controller = _videoController;
+    if (controller == null) return;
     showFullVideoDialog(
       context,
       media: widget.media,
       mediaController: widget.controller,
       avatarResolver: widget.avatarResolver,
-      player: _player!,
-      controller: _controller!,
+      controller: controller,
     );
   }
 
@@ -177,7 +174,7 @@ class _VideoBubbleState extends State<VideoBubble> {
       return _buildFileFallback(foreground, tt);
     }
 
-    if (_state == _VideoState.playing && _controller != null) {
+    if (_state == _VideoState.playing && _videoController != null) {
       return _buildInlinePlayer(cs);
     }
 
@@ -267,12 +264,13 @@ class _VideoBubbleState extends State<VideoBubble> {
   }
 
   void _togglePlayPause() {
-    if (_player == null) return;
+    final controller = _videoController;
+    if (controller == null) return;
     if (_isPlaying) {
-      unawaited(_player!.pause());
+      unawaited(controller.pause());
     } else {
-      _playbackService.registerPlayer(widget.controller.eventId, _player!);
-      unawaited(_player!.play());
+      _playbackService.registerPlayer(widget.controller.eventId, controller);
+      unawaited(controller.play());
     }
   }
 
@@ -281,9 +279,8 @@ class _VideoBubbleState extends State<VideoBubble> {
       borderRadius: BorderRadius.circular(0), // Sharp corners for pixel theme
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 280, maxHeight: 260),
-        child: Video(
-          controller: _controller!,
-          controls: (state) => GestureDetector(
+        child: _videoController!.buildView(
+          controlsOverlay: GestureDetector(
             onTap: _togglePlayPause,
             behavior: HitTestBehavior.opaque,
             child: Stack(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:kohera/core/services/sub_services/outbox_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/theme/kohera_theme.dart';
 import 'package:kohera/core/theme/theme_presets.dart';
+import 'package:kohera/core/utils/platform_info.dart';
 import 'package:kohera/core/utils/vodozemac_init.dart';
 import 'package:kohera/features/auth/services/sso_web_init.dart';
 import 'package:kohera/features/calling/services/call_service.dart';
@@ -64,7 +65,7 @@ class _KoheraAppState extends State<KoheraApp> {
     // Keep the branded splash up long enough for its growth animation to play.
     final minSplash = Future<void>.delayed(const Duration(seconds: 3));
     try {
-      MediaKit.ensureInitialized();
+      if (isNativeDesktop) MediaKit.ensureInitialized();
 
       final prefs = PreferencesService();
       await Future.wait([initVodozemac(), AppConfig.load(), prefs.init()]);

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import audio_session
 import connectivity_plus
 import desktop_drop
 import device_info_plus
@@ -14,6 +15,7 @@ import file_selector_macos
 import flutter_local_notifications
 import flutter_secure_storage_darwin
 import flutter_webrtc
+import just_audio
 import livekit_client
 import media_kit_libs_macos_video
 import media_kit_video
@@ -26,11 +28,13 @@ import shared_preferences_foundation
 import sqflite_darwin
 import sqlite3_flutter_libs
 import url_launcher_macos
+import video_player_avfoundation
 import wakelock_plus
 import webcrypto
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
@@ -40,6 +44,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   FlutterWebRTCPlugin.register(with: registry.registrar(forPlugin: "FlutterWebRTCPlugin"))
+  JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   LiveKitPlugin.register(with: registry.registrar(forPlugin: "LiveKitPlugin"))
   MediaKitLibsMacosVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitLibsMacosVideoPlugin"))
   MediaKitVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitVideoPlugin"))
@@ -52,6 +57,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
+  VideoPlayerPlugin.register(with: registry.registrar(forPlugin: "VideoPlayerPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
   WebcryptoPlugin.register(with: registry.registrar(forPlugin: "WebcryptoPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1085,6 +1085,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  ogg_caf_converter:
+    dependency: "direct main"
+    description:
+      name: ogg_caf_converter
+      sha256: "3faa20f7ae854d6eda233773756de3eddb6c8d4fdc6d0165da992ded95240818"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
+  audio_session:
+    dependency: transitive
+    description:
+      name: audio_session
+      sha256: f9e7711a0e24ca8b40f5d7ac374c3c6e55016f3157912badd18199cdbbca5c4d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.4"
   base58check:
     dependency: transitive
     description:
@@ -853,6 +861,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.12.0"
+  just_audio:
+    dependency: "direct main"
+    description:
+      name: just_audio
+      sha256: e60aa97b233ddea025e13dfac59195207f528fa5e9e4a4a49a8c0766701e5fe6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.6"
+  just_audio_platform_interface:
+    dependency: transitive
+    description:
+      name: just_audio_platform_interface
+      sha256: "2532c8d6702528824445921c5ff10548b518b13f808c2e34c2fd54793b999a6a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.0"
+  just_audio_web:
+    dependency: transitive
+    description:
+      name: just_audio_web
+      sha256: "6ba8a2a7e87d57d32f0f7b42856ade3d6a9fbe0f1a11fabae0a4f00bb73f0663"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.16"
   leak_tracker:
     dependency: transitive
     description:
@@ -941,24 +973,8 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.6"
-  media_kit_libs_android_video:
-    dependency: transitive
-    description:
-      name: media_kit_libs_android_video
-      sha256: "3f6274e5ab2de512c286a25c327288601ee445ed8ac319e0ef0b66148bd8f76c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.8"
-  media_kit_libs_ios_video:
-    dependency: transitive
-    description:
-      name: media_kit_libs_ios_video
-      sha256: b5382994eb37a4564c368386c154ad70ba0cc78dacdd3fb0cd9f30db6d837991
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.4"
   media_kit_libs_linux:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: media_kit_libs_linux
       sha256: "2b473399a49ec94452c4d4ae51cfc0f6585074398d74216092bf3d54aac37ecf"
@@ -966,23 +982,15 @@ packages:
     source: hosted
     version: "1.2.1"
   media_kit_libs_macos_video:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: media_kit_libs_macos_video
       sha256: f26aa1452b665df288e360393758f84b911f70ffb3878032e1aabba23aa1032d
       url: "https://pub.dev"
     source: hosted
     version: "1.1.4"
-  media_kit_libs_video:
-    dependency: "direct main"
-    description:
-      name: media_kit_libs_video
-      sha256: "2b235b5dac79c6020e01eef5022c6cc85fedc0df1738aadc6ea489daa12a92a9"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.7"
   media_kit_libs_windows_video:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: media_kit_libs_windows_video
       sha256: dff76da2778729ab650229e6b4ec6ec111eb5151431002cbd7ea304ff1f112ab
@@ -1922,6 +1930,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.2.0"
+  video_player:
+    dependency: "direct main"
+    description:
+      name: video_player
+      sha256: "20ef311160e2ced020a62f38e4cc399a1bf289e722fc5fe37c9d7b18e44c9e8d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.13.0"
+  video_player_android:
+    dependency: transitive
+    description:
+      name: video_player_android
+      sha256: "5121de08444d00363efdda630a69ad4d27a208a9f7586482d4909a44a1cdbc63"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.0"
+  video_player_avfoundation:
+    dependency: transitive
+    description:
+      name: video_player_avfoundation
+      sha256: c238f5f0a26845cd0bcc2956049b63065a4d3c40ddfc22c3414cd170bef7fff9
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.0"
+  video_player_platform_interface:
+    dependency: transitive
+    description:
+      name: video_player_platform_interface
+      sha256: "92c0fbabe20c788e71fd10d26cea998d0d253282e65d145aed0818731cf593ce"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.9.0"
+  video_player_web:
+    dependency: transitive
+    description:
+      name: video_player_web
+      sha256: "9f3c00be2ef9b76a95d94ac5119fb843dca6f2c69e6c9968f6f2b6c9e7afbdeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   vm_service:
     dependency: transitive
     description:
@@ -2067,5 +2115,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   media_kit_libs_windows_video: ^1.0.11
   media_kit_video: ^2.0.1
   mobile_scanner: ^7.2.0
+  ogg_caf_converter: ^0.1.4
   package_info_plus: ^8.0.0
   pasteboard: ^0.5.0
   path: ^1.9.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,10 +33,13 @@ dependencies:
   html: ^0.15.4
   http: ^1.2.0
   image_picker: ^1.1.2
+  just_audio: ^0.10.6
   livekit_client: ^2.6.2
   matrix: ^7.5.0
   media_kit: ^1.2.6
-  media_kit_libs_video: ^1.0.7
+  media_kit_libs_linux: ^1.2.1
+  media_kit_libs_macos_video: ^1.1.4
+  media_kit_libs_windows_video: ^1.0.11
   media_kit_video: ^2.0.1
   mobile_scanner: ^7.2.0
   package_info_plus: ^8.0.0
@@ -55,6 +58,7 @@ dependencies:
   sqlite3_flutter_libs: ^0.5.0
   unifiedpush: ^6.0.0
   url_launcher: ^6.3.2
+  video_player: ^2.9.0
   vodozemac: ^0.5.0
   web: ^1.1.0
   webrtc_interface: ^1.1.4

--- a/test/core/media/kohera_player_test.dart
+++ b/test/core/media/kohera_player_test.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/media/kohera_media_source.dart';
+import 'package:kohera/core/media/kohera_player.dart';
+import 'package:kohera/features/chat/services/media_playback_service.dart';
+
+class _FakeKoheraPlayer implements KoheraPlayer {
+  _FakeKoheraPlayer();
+  int pauseCount = 0;
+  int playCount = 0;
+  int stopCount = 0;
+  int seekCount = 0;
+  int loopCount = 0;
+  int openCount = 0;
+  bool disposed = false;
+
+  @override
+  Future<void> open(KoheraMediaSource source) async => openCount++;
+
+  @override
+  Future<void> play() async => playCount++;
+
+  @override
+  Future<void> pause() async => pauseCount++;
+
+  @override
+  Future<void> stop() async => stopCount++;
+
+  @override
+  Future<void> seek(Duration position) async => seekCount++;
+
+  @override
+  Future<void> setLoop(bool loop) async => loopCount++;
+
+  @override
+  Stream<bool> get playing => const Stream<bool>.empty();
+
+  @override
+  Stream<Duration> get position => const Stream<Duration>.empty();
+
+  @override
+  Stream<Duration> get duration => const Stream<Duration>.empty();
+
+  @override
+  Stream<bool> get completed => const Stream<bool>.empty();
+
+  @override
+  Future<void> dispose() async => disposed = true;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('KoheraMediaSource', () {
+    test('file source holds path', () {
+      const source = KoheraFileSource('/tmp/a.ogg');
+      expect(source.path, '/tmp/a.ogg');
+      expect(source, isA<KoheraFileSource>());
+    });
+
+    test('bytes source holds bytes and mime type', () {
+      final source = KoheraBytesSource(Uint8List.fromList([1, 2, 3]), mimeType: 'audio/ogg');
+      expect(source.bytes, [1, 2, 3]);
+      expect(source.mimeType, 'audio/ogg');
+    });
+
+    test('asset source holds asset path', () {
+      const source = KoheraAssetSource('assets/audio/ringtone.mp3');
+      expect(source.assetPath, 'assets/audio/ringtone.mp3');
+    });
+  });
+
+  group('MediaPlaybackService', () {
+    test('registering a second player pauses the active one', () async {
+      final service = MediaPlaybackService();
+      final first = _FakeKoheraPlayer();
+      final second = _FakeKoheraPlayer();
+
+      service.registerPlayer('event_a', first);
+      expect(service.activeEventId, 'event_a');
+
+      service.registerPlayer('event_b', second);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(first.pauseCount, 1);
+      expect(service.activeEventId, 'event_b');
+    });
+
+    test('registering the same player again does not pause it', () async {
+      final service = MediaPlaybackService();
+      final player = _FakeKoheraPlayer();
+
+      service.registerPlayer('event_a', player);
+      service.registerPlayer('event_a', player);
+
+      expect(player.pauseCount, 0);
+    });
+
+    test('unregister clears the active player', () {
+      final service = MediaPlaybackService();
+      final player = _FakeKoheraPlayer();
+
+      service.registerPlayer('event_a', player);
+      service.unregisterPlayer('event_a');
+
+      expect(service.activeEventId, isNull);
+    });
+
+    test('pauseActive pauses the active player', () async {
+      final service = MediaPlaybackService();
+      final player = _FakeKoheraPlayer();
+
+      service.registerPlayer('event_a', player);
+      service.pauseActive();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(player.pauseCount, 1);
+    });
+
+    test('unregister of a non-active event is a no-op', () {
+      final service = MediaPlaybackService();
+      final player = _FakeKoheraPlayer();
+
+      service.registerPlayer('event_a', player);
+      service.unregisterPlayer('event_b');
+
+      expect(service.activeEventId, 'event_a');
+    });
+  });
+}

--- a/test/widgets/chat/audio_bubble_test.mocks.dart
+++ b/test/widgets/chat/audio_bubble_test.mocks.dart
@@ -7,10 +7,10 @@ import 'dart:async' as _i4;
 import 'dart:typed_data' as _i5;
 import 'dart:ui' as _i8;
 
+import 'package:kohera/core/media/kohera_player.dart' as _i7;
 import 'package:kohera/features/chat/services/media_playback_service.dart'
     as _i6;
 import 'package:kohera/shared/services/media_controller.dart' as _i2;
-import 'package:media_kit/media_kit.dart' as _i7;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i3;
 
@@ -120,7 +120,7 @@ class MockMediaPlaybackService extends _i1.Mock
           as bool);
 
   @override
-  void registerPlayer(String? eventId, _i7.Player? player) =>
+  void registerPlayer(String? eventId, _i7.KoheraPlayer? player) =>
       super.noSuchMethod(
         Invocation.method(#registerPlayer, [eventId, player]),
         returnValueForMissingStub: null,

--- a/test/widgets/chat/video_bubble_test.mocks.dart
+++ b/test/widgets/chat/video_bubble_test.mocks.dart
@@ -7,11 +7,11 @@ import 'dart:async' as _i4;
 import 'dart:typed_data' as _i5;
 import 'dart:ui' as _i8;
 
+import 'package:kohera/core/media/kohera_player.dart' as _i7;
 import 'package:kohera/features/chat/services/media_playback_service.dart'
     as _i6;
 import 'package:kohera/shared/services/avatar_resolver.dart' as _i9;
 import 'package:kohera/shared/services/media_controller.dart' as _i2;
-import 'package:media_kit/media_kit.dart' as _i7;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i3;
 
@@ -121,7 +121,7 @@ class MockMediaPlaybackService extends _i1.Mock
           as bool);
 
   @override
-  void registerPlayer(String? eventId, _i7.Player? player) =>
+  void registerPlayer(String? eventId, _i7.KoheraPlayer? player) =>
       super.noSuchMethod(
         Invocation.method(#registerPlayer, [eventId, player]),
         returnValueForMissingStub: null,


### PR DESCRIPTION
## Summary

Stop shipping libmpv in the iOS app by replacing the umbrella `media_kit_libs_video` dependency with desktop-only media_kit libs plus `video_player`/`just_audio`. Introduces a platform-agnostic player abstraction so iOS/Android use native AVPlayer/ExoPlayer while desktop keeps media_kit. iOS and Android build handling become symmetric (zero bundled native media libs on either mobile target).

## Changes

- **pubspec**: dropped `media_kit_libs_video` umbrella; added `media_kit_libs_linux`, `media_kit_libs_windows_video`, `media_kit_libs_macos_video`, `just_audio`, `video_player` → `media_kit_libs_ios_video` + `media_kit_libs_android_video` no longer resolved (no `Mpv.xcframework` in IPA, no `libmpv.so` in APK)
- **`lib/core/media/`** (new): `KoheraMediaSource` (sealed: file/bytes/asset), `KoheraPlayer` interface, `KoheraVideoController implements KoheraPlayer`, conditional factory (`_native`/`_web`)
  - `media_kit/` — desktop backend wrapping `Player`/`VideoController`
  - `mobile/` — `just_audio` backend (audio/ringtone) + `video_player` backend (video) with minimal fullscreen controls
- **Migrated call sites**: `media_cache.dart` (returns `KoheraMediaSource` not `Media`), `media_playback_service.dart` (holds `KoheraPlayer?`), `ringtone_service.dart` (`KoheraAssetSource` + `setLoop`), `video_bubble.dart` + `full_video_view.dart` (`KoheraVideoController`), `audio_bubble.dart` (`KoheraPlayer`), `main.dart` (`MediaKit.ensureInitialized()` desktop-only via `isNativeDesktop`)
- **`MediaPlaybackService`**: defers `notifyListeners` to a post-frame callback when the scheduler is in a persistent-callback phase, fixing a "widget tree was locked" assertion triggered when `unregisterPlayer` runs from a widget `dispose()`
- **macOS** `GeneratedPluginRegistrant.swift` regenerated for the new `audio_session`/`just_audio`/`video_player_avfoundation` plugins

### iOS audio playback fixes (device-tested follow-ups)
- **`unawaited` just_audio `play()` in `MobileKoheraPlayer.open`**: `AudioPlayer.play()` completes on playback *end*, not start; awaiting it blocked the open path and held the UI. Voice messages now start immediately.
- **`PlaylistMode.none` (not `single`) for non-loop media_kit playback**: `PlaylistMode.single` loops the current file indefinitely; the non-loop branch used it, so voice messages and videos looped forever instead of playing once. Now uses `none` (play once, the media_kit default) and reserves `loop` for `setLoop(true)`.
- **iOS Ogg/Opus → CAF/Opus remux in `MediaCache`**: iOS AVPlayer (just_audio backend) cannot decode the Ogg container, so received Ogg/Opus voice messages produced no audio. Added `ogg_caf_converter` (pure-Dart, deps only `meta`) and remux Ogg/Opus → CAF/Opus on iOS only; CAF+Opus is AVPlayer-supported on iOS 11+. Lossless container remux, no re-encode. Android (ExoPlayer) and desktop (media_kit) keep native Ogg/Opus playback unchanged.
- **Content-magic sniffing instead of mimetype label**: the event mimetype is unreliable (Kohera previously sent AAC/m4a bytes labelled `audio/ogg`), which fed non-Ogg data into the remuxer (`OggReaderError.badIDPageSignature`) and left an unplayable `.ogg` fallback. On iOS, `MediaCache` sniffs the downloaded bytes: `OggS` → remux to CAF; `ftyp` → rename to `.m4a` so AVPlayer decodes AAC natively; else keep original. Handles both fresh and legacy messages.
- **Truthful mimetype for recorded voice messages**: `voice_send_handler` records AAC/m4a but declared `audio/ogg`; corrected to `audio/mp4` so self-voice-messages play natively on all platforms without remux.
- **Replay after completion on iOS/Android**: just_audio parks at `processingState.completed` with position at end, so a bare `play()` was a no-op and a finished voice message would not replay. `MobileKoheraPlayer.play()` now seeks to `Duration.zero` first when completed, then plays.

## Testing

- [x] `flutter analyze` is clean
- [x] `flutter test` passes (ran `dart run build_runner build --delete-conflicting-outputs` to regenerate mocks)

Suites run:
- `test/core/media/kohera_player_test.dart` — new unit coverage for `KoheraMediaSource` + `MediaPlaybackService` single-active-player behavior (8 tests)
- `test/widgets/chat/video_bubble_test.dart`, `test/widgets/chat/audio_bubble_test.dart`, `test/utils/media_cache_test.dart` — pass
- Full suite: 2381 pass; the only 2 failures are pre-existing PICO-8 golden tests (`message_bubble_golden_test.dart`, 0.26% font-rendering diff, unrelated to media)

Manual verification on iOS device confirmed: voice messages play (fresh `audio/mp4` self-messages, legacy mislabelled messages, and received Ogg/Opus messages after CAF remux), and replay after completion. Remaining manual verification (video/fullscreen, E2EE attachments, ringtone/dialtone loop, PTT/join/leave sounds, single-active-player enforcement) still pending.

## Linked issues

Closes #784
Refs #611

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master` (not another feature branch, unless an explicitly requested stacked PR)
