### PR TITLE
feat(chat): vote on, retract, and end polls; show poll previews

### DIFF
--- a/lib/features/chat/models/kohera_poll.dart
+++ b/lib/features/chat/models/kohera_poll.dart
@@ -36,6 +36,7 @@ class KoheraPoll {
     required this.ended,
     required this.responseCount,
     required this.tallies,
+    required this.mySelections,
   });
 
   final String question;
@@ -57,6 +58,11 @@ class KoheraPoll {
   /// Per-answer tally: answer id → vote count. Empty (all zero) when the
   /// tally is hidden for an open undisclosed poll.
   final Map<String, int> tallies;
+
+  /// Answer ids the current user has selected, derived from
+  /// `Event.getPollResponses(timeline)[myUserId]`. Empty when the user has
+  /// not voted (or retracted).
+  final Set<String> mySelections;
 
   /// Whether the running tally should be rendered.
   ///

--- a/lib/features/chat/models/kohera_poll.dart
+++ b/lib/features/chat/models/kohera_poll.dart
@@ -37,6 +37,7 @@ class KoheraPoll {
     required this.responseCount,
     required this.tallies,
     required this.mySelections,
+    required this.canEnd,
   });
 
   final String question;
@@ -63,6 +64,13 @@ class KoheraPoll {
   /// `Event.getPollResponses(timeline)[myUserId]`. Empty when the user has
   /// not voted (or retracted).
   final Set<String> mySelections;
+
+  /// Whether the current user is allowed to end this poll.
+  ///
+  /// True when the user is the poll creator (`event.senderId == myUserId`)
+  /// or holds redact power in the room. The SDK enforces this server-side;
+  /// this flag only gates the UI affordance.
+  final bool canEnd;
 
   /// Whether the running tally should be rendered.
   ///

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -1132,6 +1132,8 @@ class _ChatScreenState extends State<ChatScreen>
                 },
                 onStickerContextMenu: _showStickerContextMenu,
                 onStickerMobileActions: _showStickerMobileActions,
+                onVotePoll: (eventId, answerIds) =>
+                    unawaited(_actions.votePoll(eventId, answerIds)),
               ),
               if (_emojiPanelOpen) ...[
                 Positioned.fill(

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -1134,6 +1134,8 @@ class _ChatScreenState extends State<ChatScreen>
                 onStickerMobileActions: _showStickerMobileActions,
                 onVotePoll: (eventId, answerIds) =>
                     unawaited(_actions.votePoll(eventId, answerIds)),
+                onEndPoll: (eventId) =>
+                    _actions.endPoll(eventId),
               ),
               if (_emojiPanelOpen) ...[
                 Positioned.fill(

--- a/lib/features/chat/services/chat_message_actions.dart
+++ b/lib/features/chat/services/chat_message_actions.dart
@@ -199,4 +199,33 @@ class ChatMessageActions {
       );
     }
   }
+
+  Future<void> votePoll(String eventId, List<String> answerIds) async {
+    final timeline = getTimeline();
+    final scaffold = getScaffold();
+    if (timeline == null) return;
+
+    Event? event;
+    for (final e in timeline.events) {
+      if (e.eventId == eventId) {
+        event = e;
+        break;
+      }
+    }
+    if (event == null) {
+      debugPrint('[Kohera] Poll start event not found in timeline: $eventId');
+      return;
+    }
+
+    try {
+      await event.answerPoll(answerIds);
+    } catch (e) {
+      debugPrint('[Kohera] Failed to submit poll vote: $e');
+      scaffold.showSnackBar(
+        SnackBar(
+          content: Text('Failed to vote: ${MatrixService.friendlyAuthError(e)}'),
+        ),
+      );
+    }
+  }
 }

--- a/lib/features/chat/services/chat_message_actions.dart
+++ b/lib/features/chat/services/chat_message_actions.dart
@@ -228,4 +228,39 @@ class ChatMessageActions {
       );
     }
   }
+
+  /// Ends the MSC3381 poll whose start event has [eventId].
+  ///
+  /// The SDK (`Event.endPoll`) enforces that only the poll creator or a user
+  /// with redact power may end the poll; the UI gates the action upstream
+  /// via `KoheraPoll.canEnd`, so no extra permission check is needed here.
+  Future<void> endPoll(String eventId) async {
+    final timeline = getTimeline();
+    final scaffold = getScaffold();
+    if (timeline == null) return;
+
+    Event? event;
+    for (final e in timeline.events) {
+      if (e.eventId == eventId) {
+        event = e;
+        break;
+      }
+    }
+    if (event == null) {
+      debugPrint('[Kohera] Poll start event not found in timeline: $eventId');
+      return;
+    }
+
+    try {
+      await event.endPoll();
+    } catch (e) {
+      debugPrint('[Kohera] Failed to end poll: $e');
+      scaffold.showSnackBar(
+        SnackBar(
+          content:
+              Text('Failed to end poll: ${MatrixService.friendlyAuthError(e)}'),
+        ),
+      );
+    }
+  }
 }

--- a/lib/features/chat/services/message_timeline_controller.dart
+++ b/lib/features/chat/services/message_timeline_controller.dart
@@ -501,7 +501,7 @@ class MessageTimelineController extends ChangeNotifier {
           callDuration = _callDuration(event);
         case MessageCategory.poll:
           if (timeline != null) {
-            poll = const PollResolver()(event, timeline);
+            poll = const PollResolver()(event, timeline, myUserId: uid);
           }
         case MessageCategory.message:
           if (!isRedacted) {

--- a/lib/features/chat/services/message_timeline_controller.dart
+++ b/lib/features/chat/services/message_timeline_controller.dart
@@ -501,7 +501,12 @@ class MessageTimelineController extends ChangeNotifier {
           callDuration = _callDuration(event);
         case MessageCategory.poll:
           if (timeline != null) {
-            poll = const PollResolver()(event, timeline, myUserId: uid);
+            poll = const PollResolver()(
+              event,
+              timeline,
+              myUserId: uid,
+              canRedact: canRedact,
+            );
           }
         case MessageCategory.message:
           if (!isRedacted) {

--- a/lib/features/chat/services/poll_resolver.dart
+++ b/lib/features/chat/services/poll_resolver.dart
@@ -9,7 +9,8 @@ import 'package:matrix/matrix.dart';
 class PollResolver {
   const PollResolver();
 
-  KoheraPoll call(Event event, Timeline timeline, {required String myUserId}) {
+  KoheraPoll call(Event event, Timeline timeline,
+      {required String myUserId, required bool canRedact}) {
     assert(event.type == PollEventContent.startType, 'PollResolver requires a poll-start event');
 
     final content = event.parsedPollEventContent.pollStartContent;
@@ -49,6 +50,7 @@ class PollResolver {
       responseCount: responseCount,
       tallies: tallies,
       mySelections: mySelections,
+      canEnd: event.senderId == myUserId || canRedact,
     );
   }
 }

--- a/lib/features/chat/services/poll_resolver.dart
+++ b/lib/features/chat/services/poll_resolver.dart
@@ -9,7 +9,7 @@ import 'package:matrix/matrix.dart';
 class PollResolver {
   const PollResolver();
 
-  KoheraPoll call(Event event, Timeline timeline) {
+  KoheraPoll call(Event event, Timeline timeline, {required String myUserId}) {
     assert(event.type == PollEventContent.startType, 'PollResolver requires a poll-start event');
 
     final content = event.parsedPollEventContent.pollStartContent;
@@ -26,9 +26,11 @@ class PollResolver {
     final tallies = <String, int>{for (final a in answers) a.id: 0};
     var responseCount = 0;
 
+    final responses = event.getPollResponses(timeline);
+    final mySelections = Set<String>.from(responses[myUserId] ?? const {});
+
     final showTally = kind == KoheraPollKind.disclosed || ended;
     if (showTally) {
-      final responses = event.getPollResponses(timeline);
       responseCount = responses.length;
       for (final answerIds in responses.values) {
         for (final id in answerIds) {
@@ -46,6 +48,7 @@ class PollResolver {
       ended: ended,
       responseCount: responseCount,
       tallies: tallies,
+      mySelections: mySelections,
     );
   }
 }

--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -47,6 +47,7 @@ class MessageListView extends StatefulWidget {
     this.buildReplyPreview,
     this.onStickerContextMenu,
     this.onStickerMobileActions,
+    this.onVotePoll,
     super.key,
   });
 
@@ -91,6 +92,10 @@ class MessageListView extends StatefulWidget {
       onStickerContextMenu;
   final void Function(BuildContext, String eventId, Rect)?
       onStickerMobileActions;
+
+  /// Called with the full new answer-id list when the user changes their
+  /// poll selection in a poll bubble.
+  final void Function(String eventId, List<String> answerIds)? onVotePoll;
 
   @override
   State<MessageListView> createState() => MessageListViewState();
@@ -393,6 +398,9 @@ class MessageListViewState extends State<MessageListView> {
       poll: poll,
       isMe: data.isMe,
       isFirst: data.isFirst,
+      onVote: widget.onVotePoll == null
+          ? null
+          : (answerIds) => widget.onVotePoll!(data.eventId, answerIds),
     );
   }
 

--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -48,6 +48,7 @@ class MessageListView extends StatefulWidget {
     this.onStickerContextMenu,
     this.onStickerMobileActions,
     this.onVotePoll,
+    this.onEndPoll,
     super.key,
   });
 
@@ -96,6 +97,10 @@ class MessageListView extends StatefulWidget {
   /// Called with the full new answer-id list when the user changes their
   /// poll selection in a poll bubble.
   final void Function(String eventId, List<String> answerIds)? onVotePoll;
+
+  /// Called when the user taps the "End poll" affordance on a poll bubble
+  /// they are allowed to end. Resolves to `ChatMessageActions.endPoll`.
+  final Future<void> Function(String eventId)? onEndPoll;
 
   @override
   State<MessageListView> createState() => MessageListViewState();
@@ -401,6 +406,9 @@ class MessageListViewState extends State<MessageListView> {
       onVote: widget.onVotePoll == null
           ? null
           : (answerIds) => widget.onVotePoll!(data.eventId, answerIds),
+      onEnd: widget.onEndPoll == null
+          ? null
+          : () => widget.onEndPoll!(data.eventId),
     );
   }
 

--- a/lib/features/chat/widgets/poll_message_item.dart
+++ b/lib/features/chat/widgets/poll_message_item.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/theme/kohera_palette.dart';
@@ -6,16 +7,20 @@ import 'package:kohera/features/chat/widgets/density_metrics.dart';
 import 'package:kohera/features/chat/widgets/message_bubble_skin.dart';
 import 'package:provider/provider.dart';
 
-/// Read-only rendering of an MSC3381 poll-start event as a bubble.
+/// Rendering of an MSC3381 poll-start event as a bubble.
 ///
 /// Shows the question, answer options, a disclosed/undisclosed badge, and the
 /// open/ended state. Per-option tallies are rendered for disclosed polls and
-/// for ended undisclosed polls. Voting/ending is out of scope.
-class PollMessageItem extends StatelessWidget {
+/// for ended undisclosed polls. When [onVote] is provided and the poll has not
+/// ended, options are tappable: single-select replaces the prior choice,
+/// multi-select toggles selections up to [KoheraPoll.maxSelections]. Tapping
+/// the only selected option retracts the vote (sends an empty answer list).
+class PollMessageItem extends StatefulWidget {
   const PollMessageItem({
     required this.poll,
     required this.isMe,
     required this.isFirst,
+    this.onVote,
     super.key,
   });
 
@@ -23,17 +28,61 @@ class PollMessageItem extends StatelessWidget {
   final bool isMe;
   final bool isFirst;
 
+  /// Called with the full new answer-id list when the user changes their
+  /// selection. `null` (or the poll being ended) disables interaction.
+  final void Function(List<String> answerIds)? onVote;
+
+  @override
+  State<PollMessageItem> createState() => _PollMessageItemState();
+}
+
+class _PollMessageItemState extends State<PollMessageItem> {
+  late Set<String> _selections;
+
+  @override
+  void initState() {
+    super.initState();
+    _selections = widget.poll.mySelections;
+  }
+
+  @override
+  void didUpdateWidget(covariant PollMessageItem oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.poll.mySelections != widget.poll.mySelections) {
+      _selections = widget.poll.mySelections;
+    }
+  }
+
+  bool get _interactive => !widget.poll.ended && widget.onVote != null;
+
+  void _tap(String answerId) {
+    if (!_interactive) return;
+    final next = computeNextSelection(
+      current: _selections,
+      answerId: answerId,
+      maxSelections: widget.poll.maxSelections,
+    );
+    if (listEquals(next, _selections.toList())) return;
+    setState(() => _selections = next.toSet());
+    widget.onVote!.call(next);
+  }
+
   @override
   Widget build(BuildContext context) {
     final density = context.watch<PreferencesService>().messageDensity;
     final metrics = DensityMetrics.of(density);
-    final body = _PollBody(poll: poll);
+    final body = _PollBody(
+      poll: widget.poll,
+      selections: _selections,
+      interactive: _interactive,
+      onTap: _tap,
+    );
 
     return Align(
-      alignment: isMe ? Alignment.centerRight : Alignment.centerLeft,
+      alignment: widget.isMe ? Alignment.centerRight : Alignment.centerLeft,
       child: MessageBubbleSkin(
-        isMe: isMe,
-        isFirst: isFirst,
+        isMe: widget.isMe,
+        isFirst: widget.isFirst,
         metrics: metrics,
         child: body,
       ),
@@ -41,10 +90,44 @@ class PollMessageItem extends StatelessWidget {
   }
 }
 
+/// Pure selection computation shared with tests.
+///
+/// Single-select (`maxSelections == 1`): tapping the selected option retracts
+/// (returns `[]`); tapping any other returns `[answerId]`.
+///
+/// Multi-select: tapping a selected option removes it; tapping an unselected
+/// option adds it only if the current count is below `maxSelections`,
+/// otherwise the selection is unchanged.
+List<String> computeNextSelection({
+  required Set<String> current,
+  required String answerId,
+  required int maxSelections,
+}) {
+  if (maxSelections <= 1) {
+    if (current.contains(answerId)) return const [];
+    return [answerId];
+  }
+  if (current.contains(answerId)) {
+    return current.where((id) => id != answerId).toList();
+  }
+  if (current.length >= maxSelections) {
+    return current.toList();
+  }
+  return [...current, answerId];
+}
+
 class _PollBody extends StatelessWidget {
-  const _PollBody({required this.poll});
+  const _PollBody({
+    required this.poll,
+    required this.selections,
+    required this.interactive,
+    required this.onTap,
+  });
 
   final KoheraPoll poll;
+  final Set<String> selections;
+  final bool interactive;
+  final void Function(String answerId) onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -80,10 +163,13 @@ class _PollBody extends StatelessWidget {
         for (final answer in poll.answers) ...[
           _AnswerRow(
             answer: answer,
+            selected: selections.contains(answer.id),
+            interactive: interactive,
             count: poll.tallies[answer.id] ?? 0,
             maxVotes: maxVotes,
             showTally: showTally,
             palette: palette,
+            onTap: () => onTap(answer.id),
           ),
           const SizedBox(height: 6),
         ],
@@ -129,17 +215,23 @@ class _StateBadge extends StatelessWidget {
 class _AnswerRow extends StatelessWidget {
   const _AnswerRow({
     required this.answer,
+    required this.selected,
+    required this.interactive,
     required this.count,
     required this.maxVotes,
     required this.showTally,
     required this.palette,
+    required this.onTap,
   });
 
   final KoheraPollAnswer answer;
+  final bool selected;
+  final bool interactive;
   final int count;
   final int maxVotes;
   final bool showTally;
   final KoheraPalette palette;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -147,27 +239,35 @@ class _AnswerRow extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
 
     final fraction = maxVotes > 0 ? count / maxVotes : 0.0;
+    final fillColor = selected
+        ? cs.primary.withValues(alpha: 0.35)
+        : cs.primary.withValues(alpha: 0.25);
 
-    return ClipRect(
+    Widget row = ClipRect(
       child: Stack(
         alignment: Alignment.centerLeft,
         children: [
           if (showTally && fraction > 0)
             FractionallySizedBox(
               widthFactor: fraction,
-              child: Container(
-                height: 22,
-                color: cs.primary.withValues(alpha: 0.25),
-              ),
+              child: Container(height: 22, color: fillColor),
             ),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
             child: Row(
               children: [
+                Icon(
+                  selected ? Icons.check_circle : Icons.radio_button_unchecked,
+                  size: 18,
+                  color: selected ? cs.primary : cs.onSurfaceVariant,
+                ),
+                const SizedBox(width: 6),
                 Expanded(
                   child: Text(
                     answer.label,
-                    style: tt.bodyMedium,
+                    style: tt.bodyMedium?.copyWith(
+                      fontWeight: selected ? FontWeight.w600 : null,
+                    ),
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                   ),
@@ -189,6 +289,25 @@ class _AnswerRow extends StatelessWidget {
           ),
         ],
       ),
+    );
+
+    if (interactive) {
+      row = InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(0),
+        child: row,
+      );
+    }
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: selected ? cs.primary : palette.borderStrong,
+          width: selected ? 2 : 1,
+        ),
+        borderRadius: BorderRadius.circular(0),
+      ),
+      child: row,
     );
   }
 }

--- a/lib/features/chat/widgets/poll_message_item.dart
+++ b/lib/features/chat/widgets/poll_message_item.dart
@@ -21,6 +21,7 @@ class PollMessageItem extends StatefulWidget {
     required this.isMe,
     required this.isFirst,
     this.onVote,
+    this.onEnd,
     super.key,
   });
 
@@ -31,6 +32,10 @@ class PollMessageItem extends StatefulWidget {
   /// Called with the full new answer-id list when the user changes their
   /// selection. `null` (or the poll being ended) disables interaction.
   final void Function(List<String> answerIds)? onVote;
+
+  /// Called when the user ends the poll. Only invoked when [KoheraPoll.canEnd]
+  /// is true and the poll has not already ended. `null` hides the affordance.
+  final Future<void> Function()? onEnd;
 
   @override
   State<PollMessageItem> createState() => _PollMessageItemState();
@@ -55,6 +60,9 @@ class _PollMessageItemState extends State<PollMessageItem> {
 
   bool get _interactive => !widget.poll.ended && widget.onVote != null;
 
+  bool get _canEnd =>
+      widget.onEnd != null && widget.poll.canEnd && !widget.poll.ended;
+
   void _tap(String answerId) {
     if (!_interactive) return;
     final next = computeNextSelection(
@@ -67,6 +75,18 @@ class _PollMessageItemState extends State<PollMessageItem> {
     widget.onVote!.call(next);
   }
 
+  bool _ending = false;
+
+  Future<void> _endPoll() async {
+    if (_ending || !_canEnd) return;
+    setState(() => _ending = true);
+    try {
+      await widget.onEnd!();
+    } finally {
+      if (mounted) setState(() => _ending = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final density = context.watch<PreferencesService>().messageDensity;
@@ -75,7 +95,10 @@ class _PollMessageItemState extends State<PollMessageItem> {
       poll: widget.poll,
       selections: _selections,
       interactive: _interactive,
+      canEnd: _canEnd,
+      ending: _ending,
       onTap: _tap,
+      onEnd: _endPoll,
     );
 
     return Align(
@@ -121,13 +144,19 @@ class _PollBody extends StatelessWidget {
     required this.poll,
     required this.selections,
     required this.interactive,
+    required this.canEnd,
+    required this.ending,
     required this.onTap,
+    required this.onEnd,
   });
 
   final KoheraPoll poll;
   final Set<String> selections;
   final bool interactive;
+  final bool canEnd;
+  final bool ending;
   final void Function(String answerId) onTap;
+  final Future<void> Function() onEnd;
 
   @override
   Widget build(BuildContext context) {
@@ -177,6 +206,43 @@ class _PollBody extends StatelessWidget {
           Text(
             '${poll.responseCount} ${poll.responseCount == 1 ? "vote" : "votes"}',
             style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+          ),
+        if (poll.ended)
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              'Final results',
+              style: tt.labelSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: cs.onSurfaceVariant,
+              ),
+            ),
+          )
+        else if (canEnd)
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: TextButton.icon(
+                onPressed: ending ? null : onEnd,
+                icon: ending
+                    ? SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: cs.primary,
+                        ),
+                      )
+                    : const Icon(Icons.stop_circle_outlined, size: 16),
+                label: const Text('End poll'),
+                style: TextButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  minimumSize: const Size(0, 28),
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+              ),
+            ),
           ),
       ],
     );

--- a/lib/features/notifications/services/notification_service.dart
+++ b/lib/features/notifications/services/notification_service.dart
@@ -290,7 +290,9 @@ class NotificationService {
     // If any event is from the current user, they're active in this room —
     // clear any existing notification and stop processing.
     final hasOwnMessage = events.any((e) =>
-        (e.type == EventTypes.Message || e.type == EventTypes.Encrypted) &&
+        (e.type == EventTypes.Message ||
+            e.type == EventTypes.Encrypted ||
+            e.type == PollEventContent.startType) &&
         e.senderId == client.userID,);
     if (hasOwnMessage) {
       await cancelForRoom(roomId);
@@ -319,8 +321,10 @@ class NotificationService {
     final notifiable = <(String senderName, String body, Uri? avatarUrl)>[];
 
     for (final matrixEvent in events) {
+      final isPollStart = matrixEvent.type == PollEventContent.startType;
       if (matrixEvent.type != EventTypes.Message &&
-          matrixEvent.type != EventTypes.Encrypted) {
+          matrixEvent.type != EventTypes.Encrypted &&
+          !isPollStart) {
         continue;
       }
 
@@ -329,6 +333,10 @@ class NotificationService {
 
       if (matrixEvent.type == EventTypes.Encrypted) {
         body = await _tryDecrypt(room, event);
+      } else if (isPollStart) {
+        final question =
+            event.parsedPollEventContent.pollStartContent.question.mText;
+        body = question.isEmpty ? '📊 Poll' : '📊 Poll: $question';
       } else {
         body = event.body;
       }

--- a/lib/shared/services/room_summary_resolver.dart
+++ b/lib/shared/services/room_summary_resolver.dart
@@ -49,6 +49,11 @@ class RoomSummaryResolver {
   /// Replicates the last-event preview logic from RoomTile._lastMessagePreview.
   String _lastEventPreview(Event? event, Room room, String? myUserId) {
     if (event == null) return 'No messages yet';
+    if (event.type == PollEventContent.startType) {
+      final question =
+          event.parsedPollEventContent.pollStartContent.question.mText;
+      return question.isEmpty ? '📊 Poll' : '📊 Poll: $question';
+    }
     if (event.type == kCallInvite) return 'Call in progress';
     if (event.type == kCallMember ||
         event.type == kCallMemberMsc ||

--- a/test/features/chat/services/poll_resolver_test.dart
+++ b/test/features/chat/services/poll_resolver_test.dart
@@ -107,7 +107,7 @@ void main() {
       );
       final timeline = _emptyTimeline(r'$p1');
 
-      final poll = const PollResolver()(event, timeline, myUserId: '@me:example.com');
+      final poll = const PollResolver()(event, timeline, myUserId: '@me:example.com', canRedact: false);
 
       expect(poll.kind, KoheraPollKind.disclosed);
       expect(poll.ended, isFalse);
@@ -115,6 +115,7 @@ void main() {
       expect(poll.answers.map((a) => a.label), ['Yes', 'No']);
       expect(poll.tallies, {'a1': 0, 'a2': 0});
       expect(poll.responseCount, 0);
+      expect(poll.canEnd, isFalse);
     });
 
     test('undisclosed open poll hides tally', () {
@@ -127,13 +128,14 @@ void main() {
       );
       final timeline = _emptyTimeline(r'$p2');
 
-      final poll = const PollResolver()(event, timeline, myUserId: '@me:example.com');
+      final poll = const PollResolver()(event, timeline, myUserId: '@me:example.com', canRedact: false);
 
       expect(poll.kind, KoheraPollKind.undisclosed);
       expect(poll.ended, isFalse);
       expect(poll.showsTally, isFalse);
       expect(poll.tallies, {'a1': 0, 'a2': 0});
       expect(poll.responseCount, 0);
+      expect(poll.canEnd, isFalse);
     });
 
     test('mySelections reflects the current user latest response', () {
@@ -161,11 +163,50 @@ void main() {
         event,
         timeline,
         myUserId: '@me:example.com',
+        canRedact: false,
       );
 
       expect(poll.mySelections, {'a2'});
       expect(poll.tallies, {'a1': 0, 'a2': 1});
       expect(poll.responseCount, 1);
+      expect(poll.canEnd, isFalse);
+    });
+
+    test('canEnd is true for the creator and when redact power is held', () {
+      // Creator is the current user.
+      final creatorEvent = _startEvent(
+        eventId: r'$p4',
+        content: _pollContent(
+          question: 'Owner poll?',
+          answers: answers,
+          kind: PollKind.disclosed,
+        ),
+        senderId: '@me:example.com',
+      );
+      final creatorPoll = const PollResolver()(
+        creatorEvent,
+        _emptyTimeline(r'$p4'),
+        myUserId: '@me:example.com',
+        canRedact: false,
+      );
+      expect(creatorPoll.canEnd, isTrue);
+
+      // Non-creator with redact power.
+      final redactEvent = _startEvent(
+        eventId: r'$p5',
+        content: _pollContent(
+          question: 'Mod poll?',
+          answers: answers,
+          kind: PollKind.disclosed,
+        ),
+      );
+      final redactPoll = const PollResolver()(
+        redactEvent,
+        _emptyTimeline(r'$p5'),
+        myUserId: '@me:example.com',
+        canRedact: true,
+      );
+      expect(redactPoll.canEnd, isTrue);
     });
   });
 }

--- a/test/features/chat/services/poll_resolver_test.dart
+++ b/test/features/chat/services/poll_resolver_test.dart
@@ -51,12 +51,41 @@ MockEvent _startEvent({
   when(event.senderId).thenReturn(senderId);
   when(event.originServerTs).thenReturn(DateTime(2026, 1, 15, 12));
   when(event.content).thenReturn(content);
+  when(event.room).thenReturn(MockRoom());
   return event;
 }
 
 MockTimeline _emptyTimeline(String eventId) {
   final timeline = MockTimeline();
   when(timeline.aggregatedEvents).thenReturn({});
+  return timeline;
+}
+
+MockEvent _responseEvent({
+  required String senderId,
+  required List<String> answerIds,
+  DateTime? ts,
+}) {
+  final event = MockEvent();
+  when(event.type).thenReturn(PollEventContent.responseType);
+  when(event.senderId).thenReturn(senderId);
+  when(event.originServerTs).thenReturn(ts ?? DateTime(2026, 1, 15, 12, 5));
+  when(event.content).thenReturn({
+    PollEventContent.responseType: {'answers': answerIds},
+  });
+  return event;
+}
+
+MockTimeline _timelineWithResponses(
+  String pollEventId, {
+  List<MockEvent> responses = const [],
+}) {
+  final timeline = MockTimeline();
+  when(timeline.aggregatedEvents).thenReturn({
+    pollEventId: {
+      RelationshipTypes.reference: responses.toSet(),
+    },
+  });
   return timeline;
 }
 
@@ -78,7 +107,7 @@ void main() {
       );
       final timeline = _emptyTimeline(r'$p1');
 
-      final poll = const PollResolver()(event, timeline);
+      final poll = const PollResolver()(event, timeline, myUserId: '@me:example.com');
 
       expect(poll.kind, KoheraPollKind.disclosed);
       expect(poll.ended, isFalse);
@@ -98,13 +127,45 @@ void main() {
       );
       final timeline = _emptyTimeline(r'$p2');
 
-      final poll = const PollResolver()(event, timeline);
+      final poll = const PollResolver()(event, timeline, myUserId: '@me:example.com');
 
       expect(poll.kind, KoheraPollKind.undisclosed);
       expect(poll.ended, isFalse);
       expect(poll.showsTally, isFalse);
       expect(poll.tallies, {'a1': 0, 'a2': 0});
       expect(poll.responseCount, 0);
+    });
+
+    test('mySelections reflects the current user latest response', () {
+      final event = _startEvent(
+        eventId: r'$p3',
+        content: _pollContent(
+          question: 'Tea or coffee?',
+          answers: answers,
+          kind: PollKind.disclosed,
+        ),
+      );
+      final timeline = _timelineWithResponses(
+        r'$p3',
+        responses: [
+          _responseEvent(senderId: '@me:example.com', answerIds: ['a1']),
+          _responseEvent(
+            senderId: '@me:example.com',
+            answerIds: ['a2'],
+            ts: DateTime(2026, 1, 15, 12, 6),
+          ),
+        ],
+      );
+
+      final poll = const PollResolver()(
+        event,
+        timeline,
+        myUserId: '@me:example.com',
+      );
+
+      expect(poll.mySelections, {'a2'});
+      expect(poll.tallies, {'a1': 0, 'a2': 1});
+      expect(poll.responseCount, 1);
     });
   });
 }

--- a/test/widgets/chat/irc_message_tile_test.dart
+++ b/test/widgets/chat/irc_message_tile_test.dart
@@ -201,6 +201,7 @@ void main() {
         ended: false,
         responseCount: 0,
         tallies: {'a1': 0, 'a2': 0},
+        mySelections: {},
       );
 
       await tester.pumpWidget(_wrap(IrcMessageTile(

--- a/test/widgets/chat/irc_message_tile_test.dart
+++ b/test/widgets/chat/irc_message_tile_test.dart
@@ -202,6 +202,7 @@ void main() {
         responseCount: 0,
         tallies: {'a1': 0, 'a2': 0},
         mySelections: {},
+        canEnd: false,
       );
 
       await tester.pumpWidget(_wrap(IrcMessageTile(

--- a/test/widgets/chat/poll_message_item_test.dart
+++ b/test/widgets/chat/poll_message_item_test.dart
@@ -13,6 +13,7 @@ KoheraPoll _poll({
   Set<String> mySelections = const {},
   Map<String, int> tallies = const {},
   int responseCount = 0,
+  bool canEnd = false,
 }) {
   return KoheraPoll(
     question: 'Tea or coffee?',
@@ -27,12 +28,14 @@ KoheraPoll _poll({
     responseCount: responseCount,
     tallies: tallies,
     mySelections: mySelections,
+    canEnd: canEnd,
   );
 }
 
 Widget _harness(
   KoheraPoll poll, {
   void Function(List<String> answerIds)? onVote,
+  Future<void> Function()? onEnd,
 }) {
   return MaterialApp(
     theme: KoheraTheme.light(),
@@ -44,6 +47,7 @@ Widget _harness(
           isMe: false,
           isFirst: true,
           onVote: onVote,
+          onEnd: onEnd,
         ),
       ),
     ),
@@ -154,5 +158,50 @@ void main() {
 
     expect(find.byIcon(Icons.check_circle), findsOneWidget);
     expect(find.byIcon(Icons.radio_button_unchecked), findsNWidgets(2));
+  });
+
+  testWidgets('shows End poll button when canEnd and not ended',
+      (tester) async {
+    await tester.pumpWidget(_harness(
+      _poll(canEnd: true),
+      onEnd: () async {},
+    ));
+
+    expect(find.text('End poll'), findsOneWidget);
+  });
+
+  testWidgets('hides End poll button when canEnd is false', (tester) async {
+    await tester.pumpWidget(_harness(
+      _poll(),
+      onEnd: () async {},
+    ));
+
+    expect(find.text('End poll'), findsNothing);
+  });
+
+  testWidgets('hides End poll button and shows Final results when ended',
+      (tester) async {
+    await tester.pumpWidget(_harness(
+      _poll(ended: true, canEnd: true),
+      onEnd: () async {},
+    ));
+
+    expect(find.text('End poll'), findsNothing);
+    expect(find.text('Final results'), findsOneWidget);
+  });
+
+  testWidgets('tapping End poll fires onEnd', (tester) async {
+    var ended = false;
+    await tester.pumpWidget(_harness(
+      _poll(canEnd: true),
+      onEnd: () async {
+        ended = true;
+      },
+    ));
+
+    await tester.tap(find.text('End poll'));
+    await tester.pump();
+
+    expect(ended, isTrue);
   });
 }

--- a/test/widgets/chat/poll_message_item_test.dart
+++ b/test/widgets/chat/poll_message_item_test.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/services/preferences_service.dart';
+import 'package:kohera/core/theme/kohera_theme.dart';
+import 'package:kohera/features/chat/models/kohera_poll.dart';
+import 'package:kohera/features/chat/widgets/poll_message_item.dart';
+import 'package:provider/provider.dart';
+
+KoheraPoll _poll({
+  KoheraPollKind kind = KoheraPollKind.disclosed,
+  int maxSelections = 1,
+  bool ended = false,
+  Set<String> mySelections = const {},
+  Map<String, int> tallies = const {},
+  int responseCount = 0,
+}) {
+  return KoheraPoll(
+    question: 'Tea or coffee?',
+    answers: const [
+      KoheraPollAnswer(id: 'a1', label: 'Yes'),
+      KoheraPollAnswer(id: 'a2', label: 'No'),
+      KoheraPollAnswer(id: 'a3', label: 'Maybe'),
+    ],
+    kind: kind,
+    maxSelections: maxSelections,
+    ended: ended,
+    responseCount: responseCount,
+    tallies: tallies,
+    mySelections: mySelections,
+  );
+}
+
+Widget _harness(
+  KoheraPoll poll, {
+  void Function(List<String> answerIds)? onVote,
+}) {
+  return MaterialApp(
+    theme: KoheraTheme.light(),
+    home: Scaffold(
+      body: ChangeNotifierProvider<PreferencesService>.value(
+        value: PreferencesService(),
+        child: PollMessageItem(
+          poll: poll,
+          isMe: false,
+          isFirst: true,
+          onVote: onVote,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('computeNextSelection', () {
+    test('single-select replaces the prior choice', () {
+      expect(
+        computeNextSelection(
+          current: {'a1'},
+          answerId: 'a2',
+          maxSelections: 1,
+        ),
+        ['a2'],
+      );
+    });
+
+    test('single-select tapping the selected option retracts', () {
+      expect(
+        computeNextSelection(
+          current: {'a1'},
+          answerId: 'a1',
+          maxSelections: 1,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('multi-select toggles an option on up to maxSelections', () {
+      expect(
+        computeNextSelection(
+          current: {'a1'},
+          answerId: 'a2',
+          maxSelections: 2,
+        ),
+        ['a1', 'a2'],
+      );
+    });
+
+    test('multi-select toggles an option off', () {
+      expect(
+        computeNextSelection(
+          current: {'a1', 'a2'},
+          answerId: 'a1',
+          maxSelections: 2,
+        ),
+        ['a2'],
+      );
+    });
+
+    test('multi-select ignores adds beyond maxSelections', () {
+      final next = computeNextSelection(
+        current: {'a1', 'a2'},
+        answerId: 'a3',
+        maxSelections: 2,
+      );
+      expect(next..sort(), ['a1', 'a2']);
+    });
+  });
+
+  testWidgets('tapping an option fires onVote with the new selection',
+      (tester) async {
+    List<String>? voted;
+    await tester.pumpWidget(_harness(
+      _poll(),
+      onVote: (ids) => voted = ids,
+    ));
+
+    await tester.tap(find.text('Yes'));
+    await tester.pump();
+
+    expect(voted, ['a1']);
+  });
+
+  testWidgets('tapping the selected option retracts the vote',
+      (tester) async {
+    List<String>? voted;
+    await tester.pumpWidget(_harness(
+      _poll(mySelections: const {'a1'}),
+      onVote: (ids) => voted = ids,
+    ));
+
+    await tester.tap(find.text('Yes'));
+    await tester.pump();
+
+    expect(voted, isEmpty);
+  });
+
+  testWidgets('voting is disabled when the poll has ended', (tester) async {
+    List<String>? voted;
+    await tester.pumpWidget(_harness(
+      _poll(ended: true),
+      onVote: (ids) => voted = ids,
+    ));
+
+    await tester.tap(find.text('Yes'));
+    await tester.pump();
+
+    expect(voted, isNull);
+  });
+
+  testWidgets('selected option shows a check icon', (tester) async {
+    await tester.pumpWidget(_harness(
+      _poll(mySelections: const {'a2'}),
+    ));
+
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+    expect(find.byIcon(Icons.radio_button_unchecked), findsNWidgets(2));
+  });
+}


### PR DESCRIPTION
## Summary

Add interactive voting and ending to MSC3381 poll bubbles, and surface poll-start events in notifications and room-list previews. Previously poll bubbles were read-only renderings.

## Changes

- `lib/features/chat/models/kohera_poll.dart` — add `mySelections` (current user's answer ids from `getPollResponses`) and `canEnd` (creator OR redact power).
- `lib/features/chat/services/poll_resolver.dart` — accept `myUserId`/`canRedact`, compute `mySelections` unconditionally and `canEnd` from `event.senderId == myUserId || canRedact`.
- `lib/features/chat/services/message_timeline_controller.dart` — pass `myUserId`/`canRedact` into the resolver.
- `lib/features/chat/widgets/poll_message_item.dart` — `StatefulWidget` with optimistic selection; `computeNextSelection` (single-select replaces/retracts, multi-select toggles up to `maxSelections`); check/uncheck icons; "End poll" affordance gated by `canEnd`; "Final results" label when ended.
- `lib/features/chat/widgets/message_list_view.dart` + `chat_screen.dart` + `chat_message_actions.dart` — wire `onVotePoll` → `votePoll()` (`event.answerPoll`) and `onEndPoll` → `endPoll()` (`event.endPoll()`).
- `lib/features/notifications/services/notification_service.dart` + `lib/shared/services/room_summary_resolver.dart` — render poll-start as `📊 Poll: <question>` in notifications and last-event previews.

## Testing

- [x] `flutter analyze` is clean
- [x] `flutter test` passes for `poll_resolver_test.dart`, `poll_message_item_test.dart`, `irc_message_tile_test.dart` after `dart run build_runner build --delete-conflicting-outputs`

## Linked issues

Closes #782
Refs #524

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master`