### PR TITLE
refactor(#789): extract fullscreen video controls into shared widget

### DIFF
--- a/lib/core/media/media_kit/media_kit_kohera_video_controller.dart
+++ b/lib/core/media/media_kit/media_kit_kohera_video_controller.dart
@@ -56,9 +56,17 @@ class MediaKitKoheraVideoController implements KoheraVideoController {
 
   @override
   Widget buildView({Widget? controlsOverlay}) {
-    return Video(
-      controller: _controller,
-      controls: controlsOverlay == null ? null : (_) => controlsOverlay,
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        Positioned.fill(
+          child: Video(
+            controller: _controller,
+            controls: (_) => const SizedBox.shrink(),
+          ),
+        ),
+        ?controlsOverlay,
+      ],
     );
   }
 

--- a/lib/core/media/mobile/mobile_kohera_video_controller.dart
+++ b/lib/core/media/mobile/mobile_kohera_video_controller.dart
@@ -124,18 +124,12 @@ class MobileKoheraVideoController implements KoheraVideoController {
       aspectRatio: aspectRatio,
       child: VideoPlayer(vp),
     );
-    if (controlsOverlay != null) {
-      return Stack(
-        alignment: Alignment.center,
-        children: [ Positioned.fill(child: surface), controlsOverlay ],
-      );
+    if (controlsOverlay == null) {
+      return Center(child: surface);
     }
     return Stack(
       alignment: Alignment.center,
-      children: [
-        Positioned.fill(child: Center(child: surface)),
-        _MobileFullscreenControls(controller: this),
-      ],
+      children: [ Positioned.fill(child: surface), controlsOverlay ],
     );
   }
 
@@ -194,110 +188,3 @@ class MobileKoheraVideoController implements KoheraVideoController {
 }
 
 // ── Minimal fullscreen controls for mobile video ──────────────
-
-class _MobileFullscreenControls extends StatefulWidget {
-  const _MobileFullscreenControls({required this.controller});
-  final MobileKoheraVideoController controller;
-
-  @override
-  State<_MobileFullscreenControls> createState() =>
-      _MobileFullscreenControlsState();
-}
-
-class _MobileFullscreenControlsState extends State<_MobileFullscreenControls> {
-  late final StreamSubscription<dynamic> _playingSub;
-  late final StreamSubscription<dynamic> _positionSub;
-  late final StreamSubscription<dynamic> _durationSub;
-  late final StreamSubscription<dynamic> _completedSub;
-  bool _isPlaying = false;
-  Duration _position = Duration.zero;
-  Duration _duration = Duration.zero;
-  bool _barVisible = true;
-  bool _scrubbing = false;
-  bool _scrubWasPlaying = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _playingSub = widget.controller.playing.listen((p) {
-      if (mounted) setState(() => _isPlaying = p);
-    });
-    _positionSub = widget.controller.position.listen((p) {
-      if (mounted && !_scrubbing) setState(() => _position = p);
-    });
-    _durationSub = widget.controller.duration.listen((d) {
-      if (mounted) setState(() => _duration = d);
-    });
-    _completedSub = widget.controller.completed.listen((_) {
-      if (mounted) setState(() => _isPlaying = false);
-    });
-  }
-
-  @override
-  void dispose() {
-    unawaited(_playingSub.cancel());
-    unawaited(_positionSub.cancel());
-    unawaited(_durationSub.cancel());
-    unawaited(_completedSub.cancel());
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final showBar = _barVisible && _duration > Duration.zero;
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: () => setState(() => _barVisible = !_barVisible),
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          if (showBar && _isPlaying)
-            IconButton(
-              icon: const Icon(Icons.pause_rounded, color: Colors.white, size: 40),
-              style: IconButton.styleFrom(
-                backgroundColor: Colors.black.withValues(alpha: 0.4),
-              ),
-              onPressed: () => unawaited(widget.controller.pause()),
-            ),
-          if (!_isPlaying)
-            IconButton(
-              icon: const Icon(Icons.play_arrow_rounded,
-                  color: Colors.white, size: 40),
-              style: IconButton.styleFrom(
-                backgroundColor: Colors.black.withValues(alpha: 0.4),
-              ),
-              onPressed: () => unawaited(widget.controller.play()),
-            ),
-          if (showBar)
-            Positioned(
-              bottom: 0,
-              left: 0,
-              right: 0,
-              child: Slider(
-                value: _position.inMilliseconds
-                    .clamp(0, _duration.inMilliseconds)
-                    .toDouble(),
-                max: _duration.inMilliseconds.toDouble(),
-                onChangeStart: (_) {
-                  setState(() => _scrubbing = true);
-                  _scrubWasPlaying = _isPlaying;
-                  if (_scrubWasPlaying) unawaited(widget.controller.pause());
-                },
-                onChanged: (v) =>
-                    setState(() => _position = Duration(milliseconds: v.toInt())),
-                onChangeEnd: (v) {
-                  final target = Duration(milliseconds: v.toInt());
-                  setState(() => _scrubbing = false);
-                  unawaited(widget.controller.seek(target).then((_) {
-                    if (_scrubWasPlaying && mounted && !_scrubbing) {
-                      unawaited(widget.controller.play());
-                    }
-                  }));
-                },
-              ),
-            ),
-        ],
-      ),
-    );
-  }
-}

--- a/lib/features/chat/widgets/full_video_view.dart
+++ b/lib/features/chat/widgets/full_video_view.dart
@@ -4,6 +4,7 @@ import 'package:kohera/features/chat/models/kohera_media_content.dart';
 import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/services/media_controller.dart';
 import 'package:kohera/shared/widgets/media_viewer_shell.dart';
+import 'package:kohera/shared/widgets/video_fullscreen_controls.dart';
 
 // coverage:ignore-start
 
@@ -21,7 +22,9 @@ void showFullVideoDialog(
     media: media,
     controller: mediaController,
     avatarResolver: avatarResolver,
-    child: controller.buildView(),
+    child: controller.buildView(
+      controlsOverlay: VideoFullscreenControls(controller: controller),
+    ),
   );
 }
 // coverage:ignore-end

--- a/lib/shared/widgets/video_fullscreen_controls.dart
+++ b/lib/shared/widgets/video_fullscreen_controls.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:kohera/core/media/kohera_video_controller.dart';
+
+// ── Shared fullscreen video controls (mobile + desktop) ──────
+//
+// Backend-agnostic control bar layered over a `KoheraVideoController` video
+// surface. Both the mobile (`video_player`) and desktop (`media_kit`) backends
+// render this same widget in fullscreen via `buildView(controlsOverlay:)`.
+
+class VideoFullscreenControls extends StatefulWidget {
+  const VideoFullscreenControls({required this.controller, super.key});
+
+  final KoheraVideoController controller;
+
+  @override
+  State<VideoFullscreenControls> createState() =>
+      _VideoFullscreenControlsState();
+}
+
+class _VideoFullscreenControlsState extends State<VideoFullscreenControls> {
+  late final StreamSubscription<dynamic> _playingSub;
+  late final StreamSubscription<dynamic> _positionSub;
+  late final StreamSubscription<dynamic> _durationSub;
+  late final StreamSubscription<dynamic> _completedSub;
+  bool _isPlaying = false;
+  Duration _position = Duration.zero;
+  Duration _duration = Duration.zero;
+  bool _barVisible = true;
+  bool _scrubbing = false;
+  bool _scrubWasPlaying = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _playingSub = widget.controller.playing.listen((p) {
+      if (mounted) setState(() => _isPlaying = p);
+    });
+    _positionSub = widget.controller.position.listen((p) {
+      if (mounted && !_scrubbing) setState(() => _position = p);
+    });
+    _durationSub = widget.controller.duration.listen((d) {
+      if (mounted) setState(() => _duration = d);
+    });
+    _completedSub = widget.controller.completed.listen((_) {
+      if (mounted) setState(() => _isPlaying = false);
+    });
+  }
+
+  @override
+  void dispose() {
+    unawaited(_playingSub.cancel());
+    unawaited(_positionSub.cancel());
+    unawaited(_durationSub.cancel());
+    unawaited(_completedSub.cancel());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final showBar = _barVisible && _duration > Duration.zero;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => setState(() => _barVisible = !_barVisible),
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          if (showBar && _isPlaying)
+            IconButton(
+              icon: const Icon(Icons.pause_rounded, color: Colors.white, size: 40),
+              style: IconButton.styleFrom(
+                backgroundColor: Colors.black.withValues(alpha: 0.4),
+              ),
+              onPressed: () => unawaited(widget.controller.pause()),
+            ),
+          if (!_isPlaying)
+            IconButton(
+              icon: const Icon(Icons.play_arrow_rounded,
+                  color: Colors.white, size: 40),
+              style: IconButton.styleFrom(
+                backgroundColor: Colors.black.withValues(alpha: 0.4),
+              ),
+              onPressed: () => unawaited(widget.controller.play()),
+            ),
+          if (showBar)
+            Positioned(
+              bottom: 0,
+              left: 0,
+              right: 0,
+              child: Slider(
+                value: _position.inMilliseconds
+                    .clamp(0, _duration.inMilliseconds)
+                    .toDouble(),
+                max: _duration.inMilliseconds.toDouble(),
+                onChangeStart: (_) {
+                  setState(() => _scrubbing = true);
+                  _scrubWasPlaying = _isPlaying;
+                  if (_scrubWasPlaying) unawaited(widget.controller.pause());
+                },
+                onChanged: (v) =>
+                    setState(() => _position = Duration(milliseconds: v.toInt())),
+                onChangeEnd: (v) {
+                  final target = Duration(milliseconds: v.toInt());
+                  setState(() => _scrubbing = false);
+                  unawaited(widget.controller.seek(target).then((_) {
+                    if (_scrubWasPlaying && mounted && !_scrubbing) {
+                      unawaited(widget.controller.play());
+                    }
+                  }));
+                },
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/widgets/shared/video_fullscreen_controls_test.dart
+++ b/test/widgets/shared/video_fullscreen_controls_test.dart
@@ -1,0 +1,155 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/media/kohera_media_source.dart';
+import 'package:kohera/core/media/kohera_video_controller.dart';
+import 'package:kohera/shared/widgets/video_fullscreen_controls.dart';
+
+class _FakeVideoController implements KoheraVideoController {
+  final StreamController<bool> _playing = StreamController<bool>.broadcast();
+  final StreamController<Duration> _position =
+      StreamController<Duration>.broadcast();
+  final StreamController<Duration> _duration =
+      StreamController<Duration>.broadcast();
+  final StreamController<bool> _completed = StreamController<bool>.broadcast();
+
+  int pauseCount = 0;
+  int playCount = 0;
+  List<Duration> seeks = [];
+
+  void emitDuration(Duration d) => _duration.add(d);
+  void emitPosition(Duration p) => _position.add(p);
+  void emitPlaying(bool p) {
+    _playing.add(p);
+  }
+
+  @override
+  Future<void> play() async => playCount++;
+
+  @override
+  Future<void> pause() async => pauseCount++;
+
+  @override
+  Future<void> seek(Duration position) async => seeks.add(position);
+
+  @override
+  Stream<bool> get playing => _playing.stream;
+
+  @override
+  Stream<Duration> get position => _position.stream;
+
+  @override
+  Stream<Duration> get duration => _duration.stream;
+
+  @override
+  Stream<bool> get completed => _completed.stream;
+
+  @override
+  Widget buildView({Widget? controlsOverlay}) => const SizedBox.shrink();
+
+  @override
+  Future<void> open(KoheraMediaSource source) async {}
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> setLoop(bool loop) async {}
+
+  @override
+  Future<void> dispose() async {
+    await _playing.close();
+    await _position.close();
+    await _duration.close();
+    await _completed.close();
+  }
+}
+
+Widget _wrap(Widget child) => MaterialApp(
+      theme: ThemeData(splashFactory: InkRipple.splashFactory),
+      home: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(width: 300, height: 200, child: child),
+        ),
+      ),
+    );
+
+void main() {
+  group('VideoFullscreenControls', () {
+    testWidgets('shows play button when paused and calls play', (tester) async {
+      final controller = _FakeVideoController();
+      await tester.pumpWidget(
+        _wrap(VideoFullscreenControls(controller: controller)),
+      );
+      await tester.pump();
+      controller.emitDuration(const Duration(seconds: 10));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.play_arrow_rounded), findsOneWidget);
+      expect(controller.playCount, 0);
+
+      await tester.tap(find.byIcon(Icons.play_arrow_rounded));
+      await tester.pump();
+
+      expect(controller.playCount, 1);
+    });
+
+    testWidgets('shows pause button when playing and calls pause', (tester) async {
+      final controller = _FakeVideoController();
+      await tester.pumpWidget(
+        _wrap(VideoFullscreenControls(controller: controller)),
+      );
+      await tester.pump();
+      controller.emitDuration(const Duration(seconds: 10));
+      controller.emitPlaying(true);
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.pause_rounded), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.pause_rounded));
+      await tester.pump();
+
+      expect(controller.pauseCount, 1);
+    });
+
+    testWidgets('slider seeks on change end', (tester) async {
+      final controller = _FakeVideoController();
+      await tester.pumpWidget(
+        _wrap(VideoFullscreenControls(controller: controller)),
+      );
+      await tester.pump();
+      controller.emitDuration(const Duration(seconds: 10));
+      controller.emitPlaying(true);
+      await tester.pumpAndSettle();
+
+      final slider = find.byType(Slider);
+      expect(slider, findsOneWidget);
+
+      await tester.tap(slider);
+      await tester.pump();
+
+      expect(controller.seeks, isNotEmpty);
+      expect(controller.playCount, greaterThanOrEqualTo(1));
+    });
+
+    testWidgets('toggles bar visibility on tap', (tester) async {
+      final controller = _FakeVideoController();
+      await tester.pumpWidget(
+        _wrap(VideoFullscreenControls(controller: controller)),
+      );
+      await tester.pump();
+      controller.emitDuration(const Duration(seconds: 10));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Slider), findsOneWidget);
+
+      final rect = tester.getRect(find.byType(VideoFullscreenControls));
+      await tester.tapAt(rect.topLeft + const Offset(10, 10));
+      await tester.pump();
+
+      expect(find.byType(Slider), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Extracts the mobile-only fullscreen video control bar into a shared, backend-agnostic widget (`VideoFullscreenControls`) so iOS/Android and Linux/macOS/Windows render the same fullscreen UI. Closes the layering gap where a backend package owned a Flutter widget subtree, and unifies the `buildView(controlsOverlay:)` contract.

## Changes

- New `lib/shared/widgets/video_fullscreen_controls.dart` — `VideoFullscreenControls`, typed against the `KoheraVideoController` interface (streams + play/pause/seek only), with auto-hide bar, play/pause toggle, and scrubber.
- `lib/core/media/mobile/mobile_kohera_video_controller.dart` — removed the in-backend `_MobileFullscreenControls` widget (~100 lines); `buildView` now treats `controlsOverlay` uniformly (null = bare surface, non-null = stacked overlay). Kept the uninitialized-surface guard.
- `lib/core/media/media_kit/media_kit_kohera_video_controller.dart` — `buildView` no longer falls back to media_kit's built-in controls; the surface is wrapped with `controls: (_) => SizedBox.shrink()` and the overlay stacked on top.
- `lib/features/chat/widgets/full_video_view.dart` — `showFullVideoDialog` now passes `VideoFullscreenControls` explicitly instead of relying on each backend's implicit default.
- New `test/widgets/shared/video_fullscreen_controls_test.dart` — fake `KoheraVideoController` + tests for play/pause, scrub-seek, and bar visibility toggle.

## Testing

- [x] `flutter analyze` is clean
- [x] `flutter test` passes (no mocks changed; ran video/audio/media suites: 27 passing)

Ran: `test/widgets/chat/video_bubble_test.dart`, `test/widgets/chat/audio_bubble_test.dart`, `test/widgets/media_viewer_shell_test.dart`, `test/widgets/shared/video_fullscreen_controls_test.dart`, `test/core/media/kohera_player_test.dart`, `test/utils/media_cache_test.dart`.

## Linked issues

Closes #789
Refs #797

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master`