### PR TITLE
feat(#790): inline video seek bar, time labels, and play-button tap target

### DIFF
--- a/lib/features/chat/widgets/inline_video_controls.dart
+++ b/lib/features/chat/widgets/inline_video_controls.dart
@@ -1,0 +1,221 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:kohera/core/media/kohera_video_controller.dart';
+import 'package:kohera/core/utils/format_duration.dart';
+
+// ── Inline video overlay controls (seek + time + play/pause) ───
+//
+// Rendered as the `controlsOverlay` of a `KoheraVideoController` surface inside
+// `VideoBubble`. Display values (playing/position/duration) are pushed in from
+// the bubble's stream subscriptions; this widget owns only scrub gesture state.
+
+class InlineVideoControls extends StatefulWidget {
+  const InlineVideoControls({
+    required this.controller,
+    required this.isPlaying,
+    required this.position,
+    required this.duration,
+    required this.onOpenFullscreen,
+    super.key,
+  });
+
+  final KoheraVideoController controller;
+  final bool isPlaying;
+  final Duration position;
+  final Duration duration;
+  final VoidCallback onOpenFullscreen;
+
+  @override
+  State<InlineVideoControls> createState() => _InlineVideoControlsState();
+}
+
+class _InlineVideoControlsState extends State<InlineVideoControls> {
+  bool _scrubbing = false;
+  bool _scrubWasPlaying = false;
+  Duration _scrubPosition = Duration.zero;
+
+  Duration get _displayPosition =>
+      _scrubbing ? _scrubPosition : widget.position;
+
+  double get _progressFraction {
+    final total = widget.duration.inMilliseconds;
+    if (total <= 0) return 0;
+    return (_displayPosition.inMilliseconds / total).clamp(0.0, 1.0);
+  }
+
+  void _togglePlayPause() {
+    if (widget.isPlaying) {
+      unawaited(widget.controller.pause());
+    } else {
+      unawaited(widget.controller.play());
+    }
+  }
+
+  void _seekFromDx(double dx, BuildContext barContext) {
+    if (widget.duration == Duration.zero) return;
+    final box = barContext.findRenderObject()! as RenderBox;
+    final width = box.size.width;
+    if (width <= 0) return;
+    final fraction = (dx / width).clamp(0.0, 1.0);
+    final target = Duration(
+      milliseconds: (fraction * widget.duration.inMilliseconds).round(),
+    );
+    setState(() => _scrubPosition = target);
+    unawaited(widget.controller.seek(target));
+  }
+
+  void _onScrubStart(double dx, BuildContext barContext) {
+    _scrubWasPlaying = widget.isPlaying;
+    _scrubbing = true;
+    if (_scrubWasPlaying) unawaited(widget.controller.pause());
+    _seekFromDx(dx, barContext);
+  }
+
+  void _onScrubEnd() {
+    _scrubbing = false;
+    if (_scrubWasPlaying) unawaited(widget.controller.play());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        SizedBox.expand(
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: _togglePlayPause,
+          ),
+        ),
+        if (!widget.isPlaying)
+          IconButton(
+            key: const ValueKey('videoInlinePlayButton'),
+            icon: const Icon(
+              Icons.play_arrow_rounded,
+              color: Colors.white,
+              size: 32,
+            ),
+            style: IconButton.styleFrom(
+              backgroundColor: Colors.black.withValues(alpha: 0.4),
+            ),
+            onPressed: _togglePlayPause,
+          ),
+        Positioned(
+          top: 6,
+          right: 6,
+          child: IconButton.filled(
+            onPressed: widget.onOpenFullscreen,
+            icon: const Icon(Icons.fullscreen_rounded, size: 20),
+            style: IconButton.styleFrom(
+              backgroundColor: Colors.black.withValues(alpha: 0.5),
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.all(4),
+              minimumSize: const Size(32, 32),
+            ),
+          ),
+        ),
+        Positioned(
+          left: 6,
+          right: 6,
+          bottom: 6,
+          child: _buildScrubBar(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildScrubBar() {
+    final fraction = _progressFraction;
+    return Row(
+      children: [
+        _timeLabel(formatDuration(_displayPosition)),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Builder(
+            builder: (barContext) {
+              void seekFromDx(double dx) => _seekFromDx(dx, barContext);
+
+              return GestureDetector(
+                key: const ValueKey('videoScrubBar'),
+                behavior: HitTestBehavior.opaque,
+                onTapDown: (d) => seekFromDx(d.localPosition.dx),
+                onHorizontalDragStart: (d) =>
+                    _onScrubStart(d.localPosition.dx, barContext),
+                onHorizontalDragUpdate: (d) => seekFromDx(d.localPosition.dx),
+                onHorizontalDragEnd: (_) => _onScrubEnd(),
+                child: CustomPaint(
+                  size: const Size(double.infinity, 6),
+                  painter: _ProgressBarPainter(
+                    progress: fraction,
+                    activeColor: Colors.white,
+                    inactiveColor: Colors.white.withValues(alpha: 0.35),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        const SizedBox(width: 6),
+        _timeLabel(formatDuration(widget.duration)),
+      ],
+    );
+  }
+
+  Widget _timeLabel(String text) {
+    return Text(
+      text,
+      style: const TextStyle(
+        color: Colors.white,
+        fontSize: 10,
+        fontWeight: FontWeight.w500,
+      ),
+    );
+  }
+}
+
+// ── Inline progress bar painter ───────────────────────────────
+
+class _ProgressBarPainter extends CustomPainter {
+  _ProgressBarPainter({
+    required this.progress,
+    required this.activeColor,
+    required this.inactiveColor,
+  });
+
+  final double progress;
+  final Color activeColor;
+  final Color inactiveColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final track = Paint()
+      ..color = inactiveColor
+      ..style = PaintingStyle.fill;
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(
+        Rect.fromLTWH(0, 0, size.width, size.height),
+        Radius.zero,
+      ),
+      track,
+    );
+    final filledWidth =
+        (size.width * progress.clamp(0.0, 1.0)).clamp(0.0, size.width);
+    final fill = Paint()
+      ..color = activeColor
+      ..style = PaintingStyle.fill;
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(
+        Rect.fromLTWH(0, 0, filledWidth, size.height),
+        Radius.zero,
+      ),
+      fill,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_ProgressBarPainter old) =>
+      old.progress != progress ||
+      old.activeColor != activeColor ||
+      old.inactiveColor != inactiveColor;
+}

--- a/lib/features/chat/widgets/video_bubble.dart
+++ b/lib/features/chat/widgets/video_bubble.dart
@@ -9,6 +9,7 @@ import 'package:kohera/core/utils/media_cache.dart';
 import 'package:kohera/features/chat/models/kohera_media_content.dart';
 import 'package:kohera/features/chat/services/media_playback_service.dart';
 import 'package:kohera/features/chat/widgets/full_video_view.dart';
+import 'package:kohera/features/chat/widgets/inline_video_controls.dart';
 import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/services/media_controller.dart';
 import 'package:provider/provider.dart';
@@ -44,6 +45,8 @@ class _VideoBubbleState extends State<VideoBubble> {
   String? _thumbUrl;
   KoheraVideoController? _videoController;
   bool _isPlaying = false;
+  Duration _position = Duration.zero;
+  Duration _duration = Duration.zero;
   late final MediaPlaybackService _playbackService;
   final List<StreamSubscription<dynamic>> _subs = [];
 
@@ -121,10 +124,20 @@ class _VideoBubbleState extends State<VideoBubble> {
       _subs.add(_videoController!.playing.listen((playing) {
         if (mounted) setState(() => _isPlaying = playing);
       }),);
+      _subs.add(_videoController!.position.listen((pos) {
+        if (mounted) setState(() => _position = pos);
+      }),);
+      _subs.add(_videoController!.duration.listen((dur) {
+        if (mounted) setState(() => _duration = dur);
+      }),);
       _subs.add(_videoController!.completed.listen((completed) {
         if (completed && mounted) {
           unawaited(_videoController!.seek(Duration.zero));
           unawaited(_videoController!.pause());
+          setState(() {
+            _isPlaying = false;
+            _position = Duration.zero;
+          });
         }
       }),);
 
@@ -172,7 +185,7 @@ class _VideoBubbleState extends State<VideoBubble> {
     }
 
     if (_state == _VideoState.playing && _videoController != null) {
-      return _buildInlinePlayer(cs);
+      return _buildInlinePlayer();
     }
 
     return _buildThumbnailPreview(cs, foreground);
@@ -266,64 +279,26 @@ class _VideoBubbleState extends State<VideoBubble> {
     );
   }
 
-  void _togglePlayPause() {
+  Widget _buildInlinePlayer() {
     final controller = _videoController;
-    if (controller == null) return;
-    if (_isPlaying) {
-      unawaited(controller.pause());
-    } else {
-      _playbackService.registerPlayer(widget.controller.eventId, controller);
-      unawaited(controller.play());
-    }
-  }
-
-  Widget _buildInlinePlayer(ColorScheme cs) {
+    if (controller == null) return const SizedBox.shrink();
     return ClipRRect(
       borderRadius: BorderRadius.circular(0), // Sharp corners for pixel theme
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 280, maxHeight: 260),
-        child: _videoController!.buildView(
-          controlsOverlay: GestureDetector(
-            onTap: _togglePlayPause,
-            behavior: HitTestBehavior.opaque,
-            child: Stack(
-              alignment: Alignment.center,
-              children: [
-                const SizedBox.expand(),
-                if (!_isPlaying)
-                  Container(
-                    decoration: BoxDecoration(
-                      color: Colors.black.withValues(alpha: 0.4),
-                      shape: BoxShape.circle,
-                    ),
-                    padding: const EdgeInsets.all(12),
-                    child: const Icon(
-                      Icons.play_arrow_rounded,
-                      color: Colors.white,
-                      size: 32,
-                    ),
-                  ),
-                Positioned(
-                  top: 6,
-                  right: 6,
-                  child: IconButton.filled(
-                    onPressed: _openFullscreen,
-                    icon: const Icon(Icons.fullscreen_rounded, size: 20),
-                    style: IconButton.styleFrom(
-                      backgroundColor: Colors.black.withValues(alpha: 0.5),
-                      foregroundColor: Colors.white,
-                      padding: const EdgeInsets.all(4),
-                      minimumSize: const Size(32, 32),
-                    ),
-                  ),
-                ),
-              ],
-            ),
+        child: controller.buildView(
+          controlsOverlay: InlineVideoControls(
+            controller: controller,
+            isPlaying: _isPlaying,
+            position: _position,
+            duration: _duration,
+            onOpenFullscreen: _openFullscreen,
           ),
         ),
       ),
     );
   }
+
 
   Widget _buildFileFallback(Color foreground, TextTheme tt) {
     final size = widget.media.fileSize;
@@ -366,5 +341,4 @@ class _VideoBubbleState extends State<VideoBubble> {
       child: const Center(child: Icon(Icons.videocam_rounded, size: 40)),
     );
   }
-
 }

--- a/test/widgets/chat/inline_video_controls_test.dart
+++ b/test/widgets/chat/inline_video_controls_test.dart
@@ -1,0 +1,159 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/media/kohera_media_source.dart';
+import 'package:kohera/core/media/kohera_video_controller.dart';
+import 'package:kohera/core/utils/format_duration.dart';
+import 'package:kohera/features/chat/widgets/inline_video_controls.dart';
+
+class _FakeVideoController implements KoheraVideoController {
+  final StreamController<bool> _playing = StreamController<bool>.broadcast();
+  final StreamController<Duration> _position =
+      StreamController<Duration>.broadcast();
+  final StreamController<Duration> _duration =
+      StreamController<Duration>.broadcast();
+  final StreamController<bool> _completed = StreamController<bool>.broadcast();
+
+  int playCount = 0;
+  int pauseCount = 0;
+  List<Duration> seeks = [];
+
+  @override
+  Future<void> open(KoheraMediaSource source) async {}
+
+  @override
+  Future<void> play() async => playCount++;
+
+  @override
+  Future<void> pause() async => pauseCount++;
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> seek(Duration position) async => seeks.add(position);
+
+  @override
+  Future<void> setLoop(bool loop) async {}
+
+  @override
+  Stream<bool> get playing => _playing.stream;
+
+  @override
+  Stream<Duration> get position => _position.stream;
+
+  @override
+  Stream<Duration> get duration => _duration.stream;
+
+  @override
+  Stream<bool> get completed => _completed.stream;
+
+  @override
+  Widget buildView({Widget? controlsOverlay}) =>
+      controlsOverlay ?? const SizedBox.shrink();
+
+  @override
+  Future<void> dispose() async {
+    await _playing.close();
+    await _position.close();
+    await _duration.close();
+    await _completed.close();
+  }
+}
+
+Widget _harness({
+  required _FakeVideoController controller,
+  required VoidCallback onOpenFullscreen,
+  bool isPlaying = false,
+  Duration position = Duration.zero,
+  Duration duration = const Duration(seconds: 30),
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width: 300,
+          height: 200,
+          child: InlineVideoControls(
+            controller: controller,
+            isPlaying: isPlaying,
+            position: position,
+            duration: duration,
+            onOpenFullscreen: onOpenFullscreen,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('InlineVideoControls', () {
+    testWidgets('shows scrub bar and time labels', (tester) async {
+      final fake = _FakeVideoController();
+      await tester.pumpWidget(_harness(
+        controller: fake,
+        onOpenFullscreen: () {},
+      ));
+      await tester.pump();
+
+      expect(find.byKey(const ValueKey('videoScrubBar')), findsOneWidget);
+      expect(find.text(formatDuration(Duration.zero)), findsOneWidget);
+      expect(find.text(formatDuration(const Duration(seconds: 30))),
+          findsOneWidget);
+    });
+
+    testWidgets('play button calls play through the controller',
+        (tester) async {
+      final fake = _FakeVideoController();
+      await tester.pumpWidget(_harness(
+        controller: fake,
+        onOpenFullscreen: () {},
+      ));
+      await tester.pump();
+
+      await tester.tap(find.byKey(const ValueKey('videoInlinePlayButton')));
+      await tester.pump();
+
+      expect(fake.playCount, 1);
+    });
+
+    testWidgets('scrubbing seeks and pauses then resumes', (tester) async {
+      final fake = _FakeVideoController();
+      await tester.pumpWidget(_harness(
+        controller: fake,
+        onOpenFullscreen: () {},
+        isPlaying: true,
+        position: const Duration(seconds: 5),
+      ));
+      await tester.pump();
+
+      await tester.drag(
+        find.byKey(const ValueKey('videoScrubBar')),
+        const Offset(40, 0),
+      );
+      await tester.pump();
+
+      expect(fake.seeks, isNotEmpty);
+      expect(fake.pauseCount, greaterThanOrEqualTo(1));
+      expect(fake.playCount, greaterThanOrEqualTo(1));
+    });
+
+    testWidgets('fullscreen button invokes callback', (tester) async {
+      final fake = _FakeVideoController();
+      var opened = false;
+      await tester.pumpWidget(_harness(
+        controller: fake,
+        onOpenFullscreen: () => opened = true,
+      ));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.fullscreen_rounded));
+      await tester.pump();
+
+      expect(opened, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the inline video player controls that were missing versus `AudioBubble`: a progress scrubber, current/total time labels, and a real play-button tap target. Drops the redundant player re-registration on every resume.

## Changes

- `lib/features/chat/widgets/inline_video_controls.dart` (new) — `InlineVideoControls`, a widget typed against `KoheraVideoController` that owns only scrub gesture state and renders: a compact sharp-cornered scrubber (`_ProgressBarPainter`), current/total time labels, a real play `IconButton`, and the fullscreen button. Display values (playing/position/duration) are pushed in as props.
- `lib/features/chat/widgets/video_bubble.dart`
  - Subscribed to `KoheraVideoController.position` and `.duration` (alongside `playing`/`completed`); the `completed` listener resets position to zero.
  - `_buildInlinePlayer` now just wraps `controller.buildView(controlsOverlay: InlineVideoControls(...))`.
  - Removed the redundant `_playbackService.registerPlayer(...)` from the resume path; the player is registered once in `_initPlayer`.
  - No test-only params added to `VideoBubble`.

## Testing

- [x] `flutter analyze` is clean
- [x] `flutter test` passes (ran `dart run build_runner build --delete-conflicting-outputs`)

New `test/widgets/chat/inline_video_controls_test.dart` targets `InlineVideoControls` directly with a fake `KoheraVideoController` — no `VideoBubble`, no `MediaCache`, no mocks. Covers: scrub bar + time labels render, play button calls `play`, scrubbing seeks and pauses-then-resumes, fullscreen button invokes callback.

Regression suites run (31 passing): `video_bubble_test.dart`, `inline_video_controls_test.dart`, `audio_bubble_test.dart`, `media_viewer_shell_test.dart`, `video_fullscreen_controls_test.dart`, `kohera_player_test.dart`, `media_cache_test.dart`.

## Linked issues

Closes #790
Refs #797

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master`