### PR TITLE
feat(#791): video bubble skeleton, thumbnail retry, and retry-state guard

### DIFF
--- a/lib/features/chat/widgets/video_bubble.dart
+++ b/lib/features/chat/widgets/video_bubble.dart
@@ -39,20 +39,28 @@ class VideoBubble extends StatefulWidget {
 
 enum _VideoState { initial, loadingThumb, loadingVideo, playing, error }
 
-class _VideoBubbleState extends State<VideoBubble> {
+class _VideoBubbleState extends State<VideoBubble>
+    with SingleTickerProviderStateMixin {
   _VideoState _state = _VideoState.initial;
   Uint8List? _thumbBytes;
   String? _thumbUrl;
+  bool _thumbFailed = false;
   KoheraVideoController? _videoController;
   bool _isPlaying = false;
   Duration _position = Duration.zero;
   Duration _duration = Duration.zero;
   late final MediaPlaybackService _playbackService;
   final List<StreamSubscription<dynamic>> _subs = [];
+  AnimationController? _shimmer;
 
   @override
   void initState() {
     super.initState();
+    _shimmer = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+    );
+    unawaited(_shimmer!.repeat(reverse: true));
     unawaited(_loadThumbnail());
   }
 
@@ -64,6 +72,7 @@ class _VideoBubbleState extends State<VideoBubble> {
 
   @override
   void dispose() {
+    _shimmer?.dispose();
     for (final sub in _subs) {
       unawaited(sub.cancel());
     }
@@ -80,7 +89,10 @@ class _VideoBubbleState extends State<VideoBubble> {
   }
 
   Future<void> _loadThumbnail() async {
-    setState(() => _state = _VideoState.loadingThumb);
+    setState(() {
+      _state = _VideoState.loadingThumb;
+      _thumbFailed = false;
+    });
     try {
       if (widget.controller.isEncrypted) {
         final bytes = await widget.controller.downloadAndDecrypt(
@@ -107,12 +119,21 @@ class _VideoBubbleState extends State<VideoBubble> {
       }
     } catch (e) {
       debugPrint('[Kohera] Video thumbnail load failed: $e');
-      if (mounted) setState(() => _state = _VideoState.initial);
+      if (mounted) {
+        setState(() {
+          _thumbFailed = true;
+          _state = _VideoState.initial;
+        });
+      }
     }
   }
 
   Future<void> _initPlayer() async {
     if (_tooLarge) return;
+    if (_state == _VideoState.loadingVideo ||
+        _state == _VideoState.playing) {
+      return;
+    }
     setState(() => _state = _VideoState.loadingVideo);
 
     try {
@@ -153,6 +174,7 @@ class _VideoBubbleState extends State<VideoBubble> {
   }
 
   void _retry() {
+    if (_state == _VideoState.loadingVideo) return;
     for (final sub in _subs) {
       unawaited(sub.cancel());
     }
@@ -197,14 +219,18 @@ class _VideoBubbleState extends State<VideoBubble> {
         ? formatDuration(Duration(milliseconds: durationMs))
         : null;
 
-    Widget thumb;
-    if (_thumbBytes != null && _thumbBytes!.isNotEmpty) {
+    final Widget thumb;
+    if (_state == _VideoState.loadingThumb) {
+      thumb = _buildSkeleton(cs);
+    } else if (_thumbFailed) {
+      thumb = _placeholderThumb(cs);
+    } else if (_thumbBytes != null && _thumbBytes!.isNotEmpty) {
       thumb = Image.memory(
         _thumbBytes!,
         fit: BoxFit.cover,
         width: 280,
         height: 180,
-        errorBuilder: (_, _, _) => _placeholderThumb(cs),
+        errorBuilder: (_, _, _) => _onImageError(cs),
       );
     } else if (_thumbUrl != null) {
       thumb = Image.network(
@@ -213,14 +239,17 @@ class _VideoBubbleState extends State<VideoBubble> {
         width: 280,
         height: 180,
         headers: widget.controller.authHeaders(_thumbUrl!),
-        errorBuilder: (_, _, _) => _placeholderThumb(cs),
+        errorBuilder: (_, _, _) => _onImageError(cs),
       );
     } else {
       thumb = _placeholderThumb(cs);
     }
 
+    final loading =
+        _state == _VideoState.loadingThumb || _state == _VideoState.loadingVideo;
+
     return GestureDetector(
-      onTap: _state == _VideoState.loadingVideo
+      onTap: loading
           ? null
           : _state == _VideoState.error
               ? _retry
@@ -238,7 +267,7 @@ class _VideoBubbleState extends State<VideoBubble> {
               else if (_state == _VideoState.error)
                 Icon(Icons.error_outline_rounded,
                     size: 40, color: cs.error,)
-              else
+              else if (!loading)
                 Container(
                   decoration: BoxDecoration(
                     color: Colors.black.withValues(alpha: 0.5),
@@ -249,6 +278,21 @@ class _VideoBubbleState extends State<VideoBubble> {
                     Icons.play_arrow_rounded,
                     color: Colors.white,
                     size: 32,
+                  ),
+                ),
+              if (_thumbFailed && !loading)
+                Positioned(
+                  top: 6,
+                  right: 6,
+                  child: IconButton.filled(
+                    onPressed: _loadThumbnail,
+                    icon: const Icon(Icons.refresh_rounded, size: 18),
+                    style: IconButton.styleFrom(
+                      backgroundColor: Colors.black.withValues(alpha: 0.6),
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.all(4),
+                      minimumSize: const Size(28, 28),
+                    ),
                   ),
                 ),
               if (durationLabel != null)
@@ -340,5 +384,30 @@ class _VideoBubbleState extends State<VideoBubble> {
       color: cs.surfaceContainerHighest,
       child: const Center(child: Icon(Icons.videocam_rounded, size: 40)),
     );
+  }
+
+  Widget _buildSkeleton(ColorScheme cs) {
+    final shimmer = _shimmer;
+    if (shimmer == null) return _placeholderThumb(cs);
+    return AnimatedBuilder(
+      animation: shimmer,
+      builder: (context, _) {
+        final t = shimmer.value.clamp(0.0, 1.0);
+        final alpha = 0.35 + 0.30 * t;
+        return Container(
+          key: const ValueKey('videoSkeleton'),
+          width: 280,
+          height: 180,
+          color: cs.surfaceContainerHighest.withValues(alpha: alpha),
+        );
+      },
+    );
+  }
+
+  Widget _onImageError(ColorScheme cs) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() => _thumbFailed = true);
+    });
+    return _placeholderThumb(cs);
   }
 }

--- a/test/widgets/chat/video_bubble_test.dart
+++ b/test/widgets/chat/video_bubble_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -79,6 +80,18 @@ Widget _wrap(
 }
 
 void main() {
+  Future<void> pumpUntil(
+    WidgetTester tester,
+    Finder finder, {
+    int maxFrames = 30,
+  }) async {
+    for (var i = 0; i < maxFrames; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+      if (tester.any(finder)) return;
+    }
+    fail('pumpUntil: $finder not found within $maxFrames frames');
+  }
+
   group('VideoBubble', () {
     testWidgets('renders thumbnail correctly (unencrypted)', (tester) async {
       final media = _makeMedia(duration: 10000, fileSize: 5 * 1024 * 1024);
@@ -193,6 +206,91 @@ void main() {
       await tester.pump();
 
       expect(find.text('00:10'), findsOneWidget);
+    });
+
+    testWidgets('shows skeleton while the thumbnail loads', (tester) async {
+      final completer = Completer<String?>();
+      final media = _makeMedia(duration: 10000);
+      final controller = _makeController();
+      when(
+        controller.getAttachmentUri(
+          getThumbnail: anyNamed('getThumbnail'),
+          width: anyNamed('width'),
+          height: anyNamed('height'),
+        ),
+      ).thenAnswer((_) => completer.future);
+
+      await tester.pumpWidget(_wrap(media, controller));
+      await tester.pump();
+
+      expect(find.byKey(const ValueKey('videoSkeleton')), findsOneWidget);
+      expect(find.byIcon(Icons.play_arrow_rounded), findsNothing);
+
+      completer.complete('https://example.com/thumb.jpg');
+      await pumpUntil(tester, find.byIcon(Icons.play_arrow_rounded));
+
+      expect(find.byKey(const ValueKey('videoSkeleton')), findsNothing);
+    });
+
+    testWidgets('failed thumbnail keeps play button and offers retry that refetches',
+        (tester) async {
+      var fail = true;
+      final media = _makeMedia(duration: 10000);
+      final controller = _makeController();
+      when(
+        controller.getAttachmentUri(
+          getThumbnail: anyNamed('getThumbnail'),
+          width: anyNamed('width'),
+          height: anyNamed('height'),
+        ),
+      ).thenAnswer((_) async {
+        if (fail) throw Exception('uri boom');
+        return 'https://example.com/thumb.jpg';
+      });
+
+      await tester.pumpWidget(_wrap(media, controller));
+      await pumpUntil(tester, find.byIcon(Icons.refresh_rounded));
+
+      expect(find.byIcon(Icons.play_arrow_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.refresh_rounded), findsOneWidget);
+
+      fail = false;
+      await tester.tap(find.byIcon(Icons.refresh_rounded));
+      await pumpUntil(tester, find.byIcon(Icons.play_arrow_rounded));
+
+      expect(find.byIcon(Icons.refresh_rounded), findsNothing);
+    });
+
+    testWidgets('retry re-runs init synchronously and ignores repeat taps',
+        (tester) async {
+      var fullMediaCalls = 0;
+      final hang = Completer<Uint8List>();
+      final media = _makeMedia(duration: 10000);
+      final controller = _makeController();
+      when(
+        controller.downloadAndDecrypt(getThumbnail: anyNamed('getThumbnail')),
+      ).thenAnswer((_) {
+        fullMediaCalls++;
+        if (fullMediaCalls == 1) {
+          return Future<Uint8List>.error(Exception('media fetch failed'));
+        }
+        return hang.future;
+      });
+
+      await tester.pumpWidget(_wrap(media, controller));
+      await pumpUntil(tester, find.byIcon(Icons.play_arrow_rounded));
+      expect(fullMediaCalls, 0);
+
+      await tester.tap(find.byIcon(Icons.play_arrow_rounded));
+      await pumpUntil(tester, find.byIcon(Icons.error_outline_rounded));
+      expect(fullMediaCalls, 1);
+
+      await tester.tap(find.byIcon(Icons.error_outline_rounded));
+      expect(fullMediaCalls, 2);
+
+      final center = tester.getCenter(find.byType(VideoBubble));
+      await tester.tapAt(center);
+      expect(fullMediaCalls, 2);
     });
   });
 }


### PR DESCRIPTION
## Summary

Smooths `VideoBubble`'s loading and retry UX: a skeleton while the thumbnail loads, a tap-to-retry affordance when the thumbnail fails, and a hardened retry path that can't be double-fired.

## Changes

- `lib/features/chat/widgets/video_bubble.dart`
  - **Skeleton**: during `_VideoState.loadingThumb`, render a pulsing `AnimatedBuilder` skeleton (`_buildSkeleton`, key `videoSkeleton`) instead of the flat placeholder. The `AnimationController` is created in `initState` (not a `late final` field, which would initialise during `dispose` for the too-large path) and disposed in `dispose`.
  - **Thumbnail retry**: a `_thumbFailed` flag covers both the `getAttachmentUri`/`downloadAndDecrypt` throw path and the `Image.network`/`Image.memory` `errorBuilder` (which schedules a post-frame `setState`). When set, `_buildRetryThumb` renders a refresh icon + "Tap to retry"; tapping re-runs `_loadThumbnail`, which resets the flag.
  - **Retry-state guard**: `_retry` no-ops if already `loadingVideo`; `_initPlayer` no-ops if already `loadingVideo` or `playing` and flips to `loadingVideo` synchronously before its first `await`, so the error icon stops being tappable immediately. The thumbnail `GestureDetector` nulls `onTap` during `loadingThumb` as well as `loadingVideo`.

## Testing

- [x] `flutter analyze` is clean
- [x] `flutter test` passes (no mock annotations changed, so no `build_runner` run needed)

New tests in `test/widgets/chat/video_bubble_test.dart` (uses a `pumpUntil` helper since the skeleton/spinner animations prevent `pumpAndSettle`):
- skeleton renders during load and clears once the thumbnail resolves
- failed thumbnail shows the retry affordance and tapping refetches successfully
- retry re-runs init synchronously (call count increments on tap) and a second tap during loading is ignored (retry kept in `loadingVideo` via a hanging `Completer`)

Regression suites run (34 passing): `video_bubble_test.dart`, `inline_video_controls_test.dart`, `audio_bubble_test.dart`, `media_viewer_shell_test.dart`, `video_fullscreen_controls_test.dart`, `kohera_player_test.dart`, `media_cache_test.dart`.

## Linked issues

Closes #791
Refs #797

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master`