### PR TITLE
feat(#793): derive video bubble box from media dimensions

### DIFF
--- a/lib/features/chat/widgets/video_bubble.dart
+++ b/lib/features/chat/widgets/video_bubble.dart
@@ -18,6 +18,9 @@ import 'package:provider/provider.dart';
 // ── Video bubble (thumbnail → inline player) ──────────────────
 
 const _maxFileSizeBytes = 104857600;
+const double _maxBubbleWidth = 280;
+const double _maxBubbleHeight = 260;
+const double _defaultAspectRatio = 16 / 9;
 
 class VideoBubble extends StatefulWidget {
   const VideoBubble({
@@ -88,6 +91,24 @@ class _VideoBubbleState extends State<VideoBubble>
     return size != null && size > _maxFileSizeBytes;
   }
 
+  double get _aspectRatio {
+    final w = widget.media.width;
+    final h = widget.media.height;
+    if (w == null || h == null || w <= 0 || h <= 0) return _defaultAspectRatio;
+    return w / h;
+  }
+
+  Size get _boxSize {
+    final ratio = _aspectRatio;
+    var width = _maxBubbleWidth;
+    var height = _maxBubbleWidth / ratio;
+    if (height > _maxBubbleHeight) {
+      height = _maxBubbleHeight;
+      width = _maxBubbleHeight * ratio;
+    }
+    return Size(width, height);
+  }
+
   Future<void> _loadThumbnail() async {
     setState(() {
       _state = _VideoState.loadingThumb;
@@ -105,10 +126,11 @@ class _VideoBubbleState extends State<VideoBubble>
           });
         }
       } else {
+        final box = _boxSize;
         final uri = await widget.controller.getAttachmentUri(
           getThumbnail: true,
-          width: 280,
-          height: 260,
+          width: box.width.round(),
+          height: box.height.round(),
         );
         if (mounted) {
           setState(() {
@@ -219,6 +241,7 @@ class _VideoBubbleState extends State<VideoBubble>
         ? formatDuration(Duration(milliseconds: durationMs))
         : null;
 
+    final box = _boxSize;
     final Widget thumb;
     if (_state == _VideoState.loadingThumb) {
       thumb = _buildSkeleton(cs);
@@ -228,16 +251,12 @@ class _VideoBubbleState extends State<VideoBubble>
       thumb = Image.memory(
         _thumbBytes!,
         fit: BoxFit.cover,
-        width: 280,
-        height: 180,
         errorBuilder: (_, _, _) => _onImageError(cs),
       );
     } else if (_thumbUrl != null) {
       thumb = Image.network(
         _thumbUrl!,
         fit: BoxFit.cover,
-        width: 280,
-        height: 180,
         headers: widget.controller.authHeaders(_thumbUrl!),
         errorBuilder: (_, _, _) => _onImageError(cs),
       );
@@ -256,8 +275,9 @@ class _VideoBubbleState extends State<VideoBubble>
               : _initPlayer,
       child: ClipRRect(
         borderRadius: BorderRadius.circular(0), // Sharp corners for pixel theme
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 280, maxHeight: 260),
+        child: SizedBox(
+          width: box.width,
+          height: box.height,
           child: Stack(
             alignment: Alignment.center,
             children: [
@@ -326,10 +346,12 @@ class _VideoBubbleState extends State<VideoBubble>
   Widget _buildInlinePlayer() {
     final controller = _videoController;
     if (controller == null) return const SizedBox.shrink();
+    final box = _boxSize;
     return ClipRRect(
       borderRadius: BorderRadius.circular(0), // Sharp corners for pixel theme
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 280, maxHeight: 260),
+      child: SizedBox(
+        width: box.width,
+        height: box.height,
         child: controller.buildView(
           controlsOverlay: InlineVideoControls(
             controller: controller,
@@ -378,9 +400,7 @@ class _VideoBubbleState extends State<VideoBubble>
   }
 
   Widget _placeholderThumb(ColorScheme cs) {
-    return Container(
-      width: 280,
-      height: 180,
+    return ColoredBox(
       color: cs.surfaceContainerHighest,
       child: const Center(child: Icon(Icons.videocam_rounded, size: 40)),
     );
@@ -396,8 +416,6 @@ class _VideoBubbleState extends State<VideoBubble>
         final alpha = 0.35 + 0.30 * t;
         return Container(
           key: const ValueKey('videoSkeleton'),
-          width: 280,
-          height: 180,
           color: cs.surfaceContainerHighest.withValues(alpha: alpha),
         );
       },

--- a/test/widgets/chat/video_bubble_test.dart
+++ b/test/widgets/chat/video_bubble_test.dart
@@ -23,6 +23,8 @@ import 'video_bubble_test.mocks.dart';
 KoheraMediaContent _makeMedia({
   int? duration,
   int? fileSize,
+  int? width,
+  int? height,
   String fileName = 'video.mp4',
 }) =>
     KoheraMediaContent(
@@ -30,6 +32,8 @@ KoheraMediaContent _makeMedia({
       mxcUrl: 'mxc://server/video',
       mimeType: 'video/mp4',
       fileSize: fileSize ?? 5 * 1024 * 1024,
+      width: width,
+      height: height,
       duration: duration,
       fileName: fileName,
     );
@@ -291,6 +295,77 @@ void main() {
       final center = tester.getCenter(find.byType(VideoBubble));
       await tester.tapAt(center);
       expect(fullMediaCalls, 2);
+    });
+
+    testWidgets('portrait video renders a portrait aspect box',
+        (tester) async {
+      final media = _makeMedia(width: 1080, height: 1920, duration: 10000);
+      final controller = _makeController();
+
+      await tester.pumpWidget(_wrap(media, controller));
+      await tester.pump();
+
+      final box = tester.getSize(
+        find.descendant(
+          of: find.byType(VideoBubble),
+          matching: find.byType(Stack),
+        ),
+      );
+      expect(box.width, closeTo(260 * (1080 / 1920), 0.01));
+      expect(box.height, closeTo(260, 0.01));
+    });
+
+    testWidgets('landscape video renders a landscape aspect box',
+        (tester) async {
+      final media = _makeMedia(width: 1920, height: 1080, duration: 10000);
+      final controller = _makeController();
+
+      await tester.pumpWidget(_wrap(media, controller));
+      await tester.pump();
+
+      final box = tester.getSize(
+        find.descendant(
+          of: find.byType(VideoBubble),
+          matching: find.byType(Stack),
+        ),
+      );
+      expect(box.width, closeTo(280, 0.01));
+      expect(box.height, closeTo(280 / (1920 / 1080), 0.01));
+    });
+
+    testWidgets('missing dimensions fall back to default 16:9 box',
+        (tester) async {
+      final media = _makeMedia(duration: 10000);
+      final controller = _makeController();
+
+      await tester.pumpWidget(_wrap(media, controller));
+      await tester.pump();
+
+      final box = tester.getSize(
+        find.descendant(
+          of: find.byType(VideoBubble),
+          matching: find.byType(Stack),
+        ),
+      );
+      expect(box.width, closeTo(280, 0.01));
+      expect(box.height, closeTo(280 / (16 / 9), 0.01));
+    });
+
+    testWidgets('box never exceeds max bubble bounds', (tester) async {
+      final media = _makeMedia(width: 1080, height: 1920, duration: 10000);
+      final controller = _makeController();
+
+      await tester.pumpWidget(_wrap(media, controller));
+      await tester.pump();
+
+      final box = tester.getSize(
+        find.descendant(
+          of: find.byType(VideoBubble),
+          matching: find.byType(Stack),
+        ),
+      );
+      expect(box.width, lessThanOrEqualTo(280));
+      expect(box.height, lessThanOrEqualTo(260));
     });
   });
 }


### PR DESCRIPTION
## Summary

`VideoBubble` hardcoded a 280×180 landscape box for the thumbnail, skeleton, placeholder, and inline player, cropping portrait video. This PR derives the bubble box from `KoheraMediaContent.width`/`height` so portrait videos render portrait and landscape videos render landscape, within the existing max bubble bounds.

## Changes

- `lib/features/chat/widgets/video_bubble.dart`
  - Added `_maxBubbleWidth` / `_maxBubbleHeight` / `_defaultAspectRatio` consts.
  - Added `_aspectRatio` getter: uses `media.width`/`height` when both positive, else `16/9`.
  - Added `_boxSize` getter: fits the aspect ratio within max bounds preserving ratio (width-first, caps at maxHeight).
  - `_loadThumbnail`: `getAttachmentUri` now requests `box.width.round()` / `box.height.round()` so the server returns an aspect-correct thumbnail.
  - `_buildThumbnailPreview`: `Image.memory` / `Image.network` drop the fixed `280×180`, now `BoxFit.cover` inside a `SizedBox(_boxSize)`; outer `ConstrainedBox` replaced by the `SizedBox`.
  - `_buildInlinePlayer`: same `SizedBox(_boxSize)` around `buildView`.
  - `_placeholderThumb` / `_buildSkeleton`: removed hardcoded dims so they fill the computed box; placeholder switched to `ColoredBox`.
  - Removed a pre-existing broken duplicate `_aspectRatio` getter (referenced undefined `_defaultRatio`) left in the working tree.

## Testing

- `flutter analyze lib/features/chat/widgets/video_bubble.dart test/widgets/chat/video_bubble_test.dart` — clean.
- `flutter test test/widgets/chat/video_bubble_test.dart` — 11/11 pass.
- [x] `flutter analyze` is clean
- [x] `flutter test` passes (no `@GenerateNiceMocks` changes, so no `build_runner` rerun needed)

## Screenshots / recordings

N/A — layout box change; verified via widget tests asserting `Stack` size.

## Linked issues

Closes #793
Refs #797

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master` (not another feature branch, unless an explicitly requested stacked PR)