### PR TITLE
feat: swipe-to-dismiss and tap-to-pause fullscreen video

### DIFF
--- a/lib/features/chat/widgets/full_video_view.dart
+++ b/lib/features/chat/widgets/full_video_view.dart
@@ -20,6 +20,7 @@ void showFullVideoDialog(
   Duration position = Duration.zero,
   Duration duration = Duration.zero,
 }) {
+  final barVisibility = MediaViewerBarVisibility();
   showMediaViewer(
     context,
     media: media,
@@ -28,6 +29,7 @@ void showFullVideoDialog(
     child: controller.buildView(
       controlsOverlay: VideoFullscreenControls(
         controller: controller,
+        barVisibility: barVisibility,
         initialIsPlaying: isPlaying,
         initialPosition: position,
         initialDuration: duration,

--- a/lib/features/chat/widgets/full_video_view.dart
+++ b/lib/features/chat/widgets/full_video_view.dart
@@ -20,7 +20,6 @@ void showFullVideoDialog(
   Duration position = Duration.zero,
   Duration duration = Duration.zero,
 }) {
-  final barVisibility = MediaViewerBarVisibility();
   showMediaViewer(
     context,
     media: media,
@@ -29,7 +28,6 @@ void showFullVideoDialog(
     child: controller.buildView(
       controlsOverlay: VideoFullscreenControls(
         controller: controller,
-        barVisibility: barVisibility,
         initialIsPlaying: isPlaying,
         initialPosition: position,
         initialDuration: duration,

--- a/lib/features/chat/widgets/full_video_view.dart
+++ b/lib/features/chat/widgets/full_video_view.dart
@@ -16,6 +16,9 @@ void showFullVideoDialog(
   required MediaController mediaController,
   required AvatarResolver avatarResolver,
   required KoheraVideoController controller,
+  bool isPlaying = false,
+  Duration position = Duration.zero,
+  Duration duration = Duration.zero,
 }) {
   showMediaViewer(
     context,
@@ -23,7 +26,12 @@ void showFullVideoDialog(
     controller: mediaController,
     avatarResolver: avatarResolver,
     child: controller.buildView(
-      controlsOverlay: VideoFullscreenControls(controller: controller),
+      controlsOverlay: VideoFullscreenControls(
+        controller: controller,
+        initialIsPlaying: isPlaying,
+        initialPosition: position,
+        initialDuration: duration,
+      ),
     ),
   );
 }

--- a/lib/features/chat/widgets/video_bubble.dart
+++ b/lib/features/chat/widgets/video_bubble.dart
@@ -215,6 +215,9 @@ class _VideoBubbleState extends State<VideoBubble>
       mediaController: widget.controller,
       avatarResolver: widget.avatarResolver,
       controller: controller,
+      isPlaying: _isPlaying,
+      position: _position,
+      duration: _duration,
     );
   }
 

--- a/lib/shared/widgets/media_viewer_shell.dart
+++ b/lib/shared/widgets/media_viewer_shell.dart
@@ -12,13 +12,27 @@ import 'package:kohera/shared/widgets/user_avatar.dart';
 
 // ── Shared fullscreen media viewer shell ─────────────────────
 
+class MediaViewerBarVisibility extends ValueNotifier<bool> {
+  MediaViewerBarVisibility([super.value = true]);
+
+  void show() {
+    if (value) {
+      notifyListeners();
+    } else {
+      value = true;
+    }
+  }
+}
+
 void showMediaViewer(
   BuildContext context, {
   required KoheraMediaContent media,
   required MediaController controller,
   required AvatarResolver avatarResolver,
   required Widget child,
+  MediaViewerBarVisibility? barVisibility,
 }) {
+  final bar = barVisibility ?? MediaViewerBarVisibility();
   unawaited(showGeneralDialog(
     context: context,
     barrierColor: Colors.black,
@@ -35,6 +49,7 @@ void showMediaViewer(
             media: media,
             controller: controller,
             avatarResolver: avatarResolver,
+            barVisibility: bar,
             child: child,
           ),
         ),
@@ -48,6 +63,7 @@ class MediaViewerShell extends StatefulWidget {
     required this.media,
     required this.controller,
     required this.avatarResolver,
+    required this.barVisibility,
     required this.child,
     super.key,
   });
@@ -55,6 +71,7 @@ class MediaViewerShell extends StatefulWidget {
   final KoheraMediaContent media;
   final MediaController controller;
   final AvatarResolver avatarResolver;
+  final MediaViewerBarVisibility barVisibility;
   final Widget child;
 
   @override
@@ -63,14 +80,15 @@ class MediaViewerShell extends StatefulWidget {
 
 class _MediaViewerShellState extends State<MediaViewerShell>
     with SingleTickerProviderStateMixin {
-  bool _barVisible = true;
   bool _downloading = false;
   Timer? _autoHideTimer;
 
+  static const _autoHideDelay = Duration(seconds: 4);
   static const _dismissDistance = 120.0;
   static const _dismissVelocity = 500.0;
   static const _maxDrag = 400.0;
 
+  late final MediaViewerBarVisibility _bar;
   Offset _dragOffset = Offset.zero;
   late final AnimationController _snapBack;
   Animation<Offset>? _snapAnim;
@@ -78,6 +96,8 @@ class _MediaViewerShellState extends State<MediaViewerShell>
   @override
   void initState() {
     super.initState();
+    _bar = widget.barVisibility;
+    _bar.addListener(_onBarChanged);
     _startAutoHideTimer();
     _snapBack = AnimationController(
       vsync: this,
@@ -91,8 +111,19 @@ class _MediaViewerShellState extends State<MediaViewerShell>
   @override
   void dispose() {
     _autoHideTimer?.cancel();
+    _bar.removeListener(_onBarChanged);
     _snapBack.dispose();
     super.dispose();
+  }
+
+  void _onBarChanged() {
+    if (!mounted) return;
+    if (_bar.value) {
+      _startAutoHideTimer();
+    } else {
+      _autoHideTimer?.cancel();
+    }
+    setState(() {});
   }
 
   void _onVerticalDragStart(DragStartDetails _) {
@@ -123,14 +154,13 @@ class _MediaViewerShellState extends State<MediaViewerShell>
 
   void _startAutoHideTimer() {
     _autoHideTimer?.cancel();
-    _autoHideTimer = Timer(const Duration(seconds: 3), () {
-      if (mounted) setState(() => _barVisible = false);
+    _autoHideTimer = Timer(_autoHideDelay, () {
+      if (mounted) _bar.value = false;
     });
   }
 
   void _toggleBar() {
-    setState(() => _barVisible = !_barVisible);
-    if (_barVisible) _startAutoHideTimer();
+    _bar.value = !_bar.value;
   }
 
   Future<void> _download() async {
@@ -186,10 +216,10 @@ class _MediaViewerShellState extends State<MediaViewerShell>
           left: 0,
           right: 0,
           child: AnimatedOpacity(
-            opacity: _barVisible ? 1.0 : 0.0,
+            opacity: _bar.value ? 1.0 : 0.0,
             duration: const Duration(milliseconds: 200),
             child: IgnorePointer(
-              ignoring: !_barVisible,
+              ignoring: !_bar.value,
               child: SafeArea(
                 bottom: false,
                 child: Container(

--- a/lib/shared/widgets/media_viewer_shell.dart
+++ b/lib/shared/widgets/media_viewer_shell.dart
@@ -58,21 +58,64 @@ class MediaViewerShell extends StatefulWidget {
   State<MediaViewerShell> createState() => _MediaViewerShellState();
 }
 
-class _MediaViewerShellState extends State<MediaViewerShell> {
+class _MediaViewerShellState extends State<MediaViewerShell>
+    with SingleTickerProviderStateMixin {
   bool _barVisible = true;
   bool _downloading = false;
   Timer? _autoHideTimer;
+
+  static const _dismissDistance = 120.0;
+  static const _dismissVelocity = 500.0;
+  static const _maxDrag = 400.0;
+
+  Offset _dragOffset = Offset.zero;
+  late final AnimationController _snapBack;
+  Animation<Offset>? _snapAnim;
 
   @override
   void initState() {
     super.initState();
     _startAutoHideTimer();
+    _snapBack = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 200),
+    );
+    _snapBack.addListener(() {
+      if (_snapAnim != null) setState(() => _dragOffset = _snapAnim!.value);
+    });
   }
 
   @override
   void dispose() {
     _autoHideTimer?.cancel();
+    _snapBack.dispose();
     super.dispose();
+  }
+
+  void _onVerticalDragStart(DragStartDetails _) {
+    _snapBack.stop();
+  }
+
+  void _onVerticalDragUpdate(DragUpdateDetails details) {
+    final delta = details.primaryDelta ?? 0;
+    final ny = (_dragOffset.dy + delta).clamp(0.0, _maxDrag);
+    if (ny != _dragOffset.dy) {
+      setState(() => _dragOffset = Offset(0, ny));
+    }
+  }
+
+  void _onVerticalDragEnd(DragEndDetails details) {
+    final velocity = details.primaryVelocity ?? 0;
+    if (_dragOffset.dy >= _dismissDistance || velocity >= _dismissVelocity) {
+      Navigator.of(context).pop();
+      return;
+    }
+    _snapAnim = Tween<Offset>(
+      begin: _dragOffset,
+      end: Offset.zero,
+    ).animate(_snapBack);
+    _snapBack.reset();
+    unawaited(_snapBack.forward());
   }
 
   void _startAutoHideTimer() {
@@ -117,15 +160,24 @@ class _MediaViewerShellState extends State<MediaViewerShell> {
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        Positioned.fill(
-          child: GestureDetector(
-            behavior: HitTestBehavior.translucent,
-            onTap: _toggleBar,
-            child: widget.child,
-          ),
-        ),
+    final opacity =
+        (1 - (_dragOffset.dy / 600).clamp(0.0, 1.0)).clamp(0.3, 1.0);
+    return Opacity(
+      opacity: opacity,
+      child: Transform.translate(
+        offset: _dragOffset,
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onTap: _toggleBar,
+                onVerticalDragStart: _onVerticalDragStart,
+                onVerticalDragUpdate: _onVerticalDragUpdate,
+                onVerticalDragEnd: _onVerticalDragEnd,
+                child: widget.child,
+              ),
+            ),
         Positioned(
           top: 0,
           left: 0,
@@ -208,7 +260,9 @@ class _MediaViewerShellState extends State<MediaViewerShell> {
             ),
           ),
         ),
-      ],
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/shared/widgets/media_viewer_shell.dart
+++ b/lib/shared/widgets/media_viewer_shell.dart
@@ -26,14 +26,17 @@ void showMediaViewer(
     barrierLabel: 'Close media',
     transitionBuilder: (_, animation, _, child) =>
         FadeTransition(opacity: animation, child: child),
-    pageBuilder: (ctx, _, _) => SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
-        child: MediaViewerShell(
-          media: media,
-          controller: controller,
-          avatarResolver: avatarResolver,
-          child: child,
+    pageBuilder: (ctx, _, _) => Material(
+      type: MaterialType.transparency,
+      child: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+          child: MediaViewerShell(
+            media: media,
+            controller: controller,
+            avatarResolver: avatarResolver,
+            child: child,
+          ),
         ),
       ),
     ),

--- a/lib/shared/widgets/media_viewer_shell.dart
+++ b/lib/shared/widgets/media_viewer_shell.dart
@@ -12,27 +12,13 @@ import 'package:kohera/shared/widgets/user_avatar.dart';
 
 // ── Shared fullscreen media viewer shell ─────────────────────
 
-class MediaViewerBarVisibility extends ValueNotifier<bool> {
-  MediaViewerBarVisibility([super.value = true]);
-
-  void show() {
-    if (value) {
-      notifyListeners();
-    } else {
-      value = true;
-    }
-  }
-}
-
 void showMediaViewer(
   BuildContext context, {
   required KoheraMediaContent media,
   required MediaController controller,
   required AvatarResolver avatarResolver,
   required Widget child,
-  MediaViewerBarVisibility? barVisibility,
 }) {
-  final bar = barVisibility ?? MediaViewerBarVisibility();
   unawaited(showGeneralDialog(
     context: context,
     barrierColor: Colors.black,
@@ -49,7 +35,6 @@ void showMediaViewer(
             media: media,
             controller: controller,
             avatarResolver: avatarResolver,
-            barVisibility: bar,
             child: child,
           ),
         ),
@@ -63,7 +48,6 @@ class MediaViewerShell extends StatefulWidget {
     required this.media,
     required this.controller,
     required this.avatarResolver,
-    required this.barVisibility,
     required this.child,
     super.key,
   });
@@ -71,7 +55,6 @@ class MediaViewerShell extends StatefulWidget {
   final KoheraMediaContent media;
   final MediaController controller;
   final AvatarResolver avatarResolver;
-  final MediaViewerBarVisibility barVisibility;
   final Widget child;
 
   @override
@@ -80,15 +63,14 @@ class MediaViewerShell extends StatefulWidget {
 
 class _MediaViewerShellState extends State<MediaViewerShell>
     with SingleTickerProviderStateMixin {
+  bool _barVisible = true;
   bool _downloading = false;
   Timer? _autoHideTimer;
 
-  static const _autoHideDelay = Duration(seconds: 4);
   static const _dismissDistance = 120.0;
   static const _dismissVelocity = 500.0;
   static const _maxDrag = 400.0;
 
-  late final MediaViewerBarVisibility _bar;
   Offset _dragOffset = Offset.zero;
   late final AnimationController _snapBack;
   Animation<Offset>? _snapAnim;
@@ -96,8 +78,6 @@ class _MediaViewerShellState extends State<MediaViewerShell>
   @override
   void initState() {
     super.initState();
-    _bar = widget.barVisibility;
-    _bar.addListener(_onBarChanged);
     _startAutoHideTimer();
     _snapBack = AnimationController(
       vsync: this,
@@ -111,19 +91,8 @@ class _MediaViewerShellState extends State<MediaViewerShell>
   @override
   void dispose() {
     _autoHideTimer?.cancel();
-    _bar.removeListener(_onBarChanged);
     _snapBack.dispose();
     super.dispose();
-  }
-
-  void _onBarChanged() {
-    if (!mounted) return;
-    if (_bar.value) {
-      _startAutoHideTimer();
-    } else {
-      _autoHideTimer?.cancel();
-    }
-    setState(() {});
   }
 
   void _onVerticalDragStart(DragStartDetails _) {
@@ -154,13 +123,14 @@ class _MediaViewerShellState extends State<MediaViewerShell>
 
   void _startAutoHideTimer() {
     _autoHideTimer?.cancel();
-    _autoHideTimer = Timer(_autoHideDelay, () {
-      if (mounted) _bar.value = false;
+    _autoHideTimer = Timer(const Duration(seconds: 3), () {
+      if (mounted) setState(() => _barVisible = false);
     });
   }
 
   void _toggleBar() {
-    _bar.value = !_bar.value;
+    setState(() => _barVisible = !_barVisible);
+    if (_barVisible) _startAutoHideTimer();
   }
 
   Future<void> _download() async {
@@ -216,10 +186,10 @@ class _MediaViewerShellState extends State<MediaViewerShell>
           left: 0,
           right: 0,
           child: AnimatedOpacity(
-            opacity: _bar.value ? 1.0 : 0.0,
+            opacity: _barVisible ? 1.0 : 0.0,
             duration: const Duration(milliseconds: 200),
             child: IgnorePointer(
-              ignoring: !_bar.value,
+              ignoring: !_barVisible,
               child: SafeArea(
                 bottom: false,
                 child: Container(

--- a/lib/shared/widgets/video_fullscreen_controls.dart
+++ b/lib/shared/widgets/video_fullscreen_controls.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:kohera/core/media/kohera_video_controller.dart';
+import 'package:kohera/core/utils/format_duration.dart';
 
 // ── Shared fullscreen video controls (mobile + desktop) ──────
 //
@@ -114,30 +115,58 @@ class _VideoFullscreenControlsState extends State<VideoFullscreenControls> {
             bottom: 0,
             left: 0,
             right: 0,
-            child: Slider(
-              value: _position.inMilliseconds
-                  .clamp(0, _duration.inMilliseconds)
-                  .toDouble(),
-              max: _duration.inMilliseconds.toDouble(),
-              onChangeStart: (_) {
-                setState(() => _scrubbing = true);
-                _scrubWasPlaying = _isPlaying;
-                if (_scrubWasPlaying) unawaited(widget.controller.pause());
-              },
-              onChanged: (v) =>
-                  setState(() => _position = Duration(milliseconds: v.toInt())),
-              onChangeEnd: (v) {
-                final target = Duration(milliseconds: v.toInt());
-                setState(() => _scrubbing = false);
-                unawaited(widget.controller.seek(target).then((_) {
-                  if (_scrubWasPlaying && mounted && !_scrubbing) {
-                    unawaited(widget.controller.play());
-                  }
-                }));
-              },
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: Row(
+                children: [
+                  _timeLabel(formatDuration(_position)),
+                  Expanded(
+                    child: Slider(
+                      value: _position.inMilliseconds
+                          .clamp(0, _duration.inMilliseconds)
+                          .toDouble(),
+                      max: _duration.inMilliseconds.toDouble(),
+                      onChangeStart: (_) {
+                        setState(() => _scrubbing = true);
+                        _scrubWasPlaying = _isPlaying;
+                        if (_scrubWasPlaying) {
+                          unawaited(widget.controller.pause());
+                        }
+                      },
+                      onChanged: (v) => setState(
+                        () => _position = Duration(milliseconds: v.toInt()),
+                      ),
+                      onChangeEnd: (v) {
+                        final target = Duration(milliseconds: v.toInt());
+                        setState(() => _scrubbing = false);
+                        unawaited(widget.controller.seek(target).then((_) {
+                          if (_scrubWasPlaying && mounted && !_scrubbing) {
+                            unawaited(widget.controller.play());
+                          }
+                        }));
+                      },
+                    ),
+                  ),
+                  _timeLabel(formatDuration(_duration)),
+                ],
+              ),
             ),
           ),
       ],
+    );
+  }
+
+  Widget _timeLabel(String text) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Text(
+        text,
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 12,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
     );
   }
 }

--- a/lib/shared/widgets/video_fullscreen_controls.dart
+++ b/lib/shared/widgets/video_fullscreen_controls.dart
@@ -5,9 +5,14 @@ import 'package:kohera/core/media/kohera_video_controller.dart';
 
 // ── Shared fullscreen video controls (mobile + desktop) ──────
 //
-// Backend-agnostic control bar layered over a `KoheraVideoController` video
-// surface. Both the mobile (`video_player`) and desktop (`media_kit`) backends
-// render this same widget in fullscreen via `buildView(controlsOverlay:)`.
+// Backend-agnostic control layer over a `KoheraVideoController` video
+// surface. Both the mobile (`video_player`) and desktop (`media_kit`)
+// backends render this same widget in fullscreen via
+// `buildView(controlsOverlay:)`.
+//
+// Tap anywhere on the surface toggles play/pause. The slider sits above the
+// tap layer so seeking never toggles playback. Swipe-to-dismiss is handled by
+// `MediaViewerShell`.
 
 class VideoFullscreenControls extends StatefulWidget {
   const VideoFullscreenControls({required this.controller, super.key});
@@ -27,7 +32,6 @@ class _VideoFullscreenControlsState extends State<VideoFullscreenControls> {
   bool _isPlaying = false;
   Duration _position = Duration.zero;
   Duration _duration = Duration.zero;
-  bool _barVisible = true;
   bool _scrubbing = false;
   bool _scrubWasPlaying = false;
 
@@ -57,62 +61,71 @@ class _VideoFullscreenControlsState extends State<VideoFullscreenControls> {
     super.dispose();
   }
 
+  void _togglePlayback() {
+    if (_isPlaying) {
+      unawaited(widget.controller.pause());
+    } else {
+      unawaited(widget.controller.play());
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    final showBar = _barVisible && _duration > Duration.zero;
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: () => setState(() => _barVisible = !_barVisible),
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          if (showBar && _isPlaying)
-            IconButton(
-              icon: const Icon(Icons.pause_rounded, color: Colors.white, size: 40),
-              style: IconButton.styleFrom(
-                backgroundColor: Colors.black.withValues(alpha: 0.4),
-              ),
-              onPressed: () => unawaited(widget.controller.pause()),
-            ),
-          if (!_isPlaying)
-            IconButton(
-              icon: const Icon(Icons.play_arrow_rounded,
-                  color: Colors.white, size: 40),
-              style: IconButton.styleFrom(
-                backgroundColor: Colors.black.withValues(alpha: 0.4),
-              ),
-              onPressed: () => unawaited(widget.controller.play()),
-            ),
-          if (showBar)
-            Positioned(
-              bottom: 0,
-              left: 0,
-              right: 0,
-              child: Slider(
-                value: _position.inMilliseconds
-                    .clamp(0, _duration.inMilliseconds)
-                    .toDouble(),
-                max: _duration.inMilliseconds.toDouble(),
-                onChangeStart: (_) {
-                  setState(() => _scrubbing = true);
-                  _scrubWasPlaying = _isPlaying;
-                  if (_scrubWasPlaying) unawaited(widget.controller.pause());
-                },
-                onChanged: (v) =>
-                    setState(() => _position = Duration(milliseconds: v.toInt())),
-                onChangeEnd: (v) {
-                  final target = Duration(milliseconds: v.toInt());
-                  setState(() => _scrubbing = false);
-                  unawaited(widget.controller.seek(target).then((_) {
-                    if (_scrubWasPlaying && mounted && !_scrubbing) {
-                      unawaited(widget.controller.play());
-                    }
-                  }));
-                },
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: _togglePlayback,
+            child: Align(
+              child: IgnorePointer(
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Colors.black.withValues(alpha: 0.4),
+                    shape: BoxShape.circle,
+                  ),
+                  padding: const EdgeInsets.all(12),
+                  child: Icon(
+                    _isPlaying
+                        ? Icons.pause_rounded
+                        : Icons.play_arrow_rounded,
+                    color: Colors.white,
+                    size: 40,
+                  ),
+                ),
               ),
             ),
-        ],
-      ),
+          ),
+        ),
+        if (_duration > Duration.zero)
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: Slider(
+              value: _position.inMilliseconds
+                  .clamp(0, _duration.inMilliseconds)
+                  .toDouble(),
+              max: _duration.inMilliseconds.toDouble(),
+              onChangeStart: (_) {
+                setState(() => _scrubbing = true);
+                _scrubWasPlaying = _isPlaying;
+                if (_scrubWasPlaying) unawaited(widget.controller.pause());
+              },
+              onChanged: (v) =>
+                  setState(() => _position = Duration(milliseconds: v.toInt())),
+              onChangeEnd: (v) {
+                final target = Duration(milliseconds: v.toInt());
+                setState(() => _scrubbing = false);
+                unawaited(widget.controller.seek(target).then((_) {
+                  if (_scrubWasPlaying && mounted && !_scrubbing) {
+                    unawaited(widget.controller.play());
+                  }
+                }));
+              },
+            ),
+          ),
+      ],
     );
   }
 }

--- a/lib/shared/widgets/video_fullscreen_controls.dart
+++ b/lib/shared/widgets/video_fullscreen_controls.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:kohera/core/media/kohera_video_controller.dart';
 import 'package:kohera/core/utils/format_duration.dart';
+import 'package:kohera/shared/widgets/media_viewer_shell.dart';
 
 // ── Shared fullscreen video controls (mobile + desktop) ──────
 //
@@ -18,6 +19,7 @@ import 'package:kohera/core/utils/format_duration.dart';
 class VideoFullscreenControls extends StatefulWidget {
   const VideoFullscreenControls({
     required this.controller,
+    this.barVisibility,
     this.initialIsPlaying = false,
     this.initialPosition = Duration.zero,
     this.initialDuration = Duration.zero,
@@ -25,6 +27,7 @@ class VideoFullscreenControls extends StatefulWidget {
   });
 
   final KoheraVideoController controller;
+  final MediaViewerBarVisibility? barVisibility;
   final bool initialIsPlaying;
   final Duration initialPosition;
   final Duration initialDuration;
@@ -80,6 +83,7 @@ class _VideoFullscreenControlsState extends State<VideoFullscreenControls> {
     } else {
       unawaited(widget.controller.play());
     }
+    widget.barVisibility?.show();
   }
 
   @override

--- a/lib/shared/widgets/video_fullscreen_controls.dart
+++ b/lib/shared/widgets/video_fullscreen_controls.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:kohera/core/media/kohera_video_controller.dart';
 import 'package:kohera/core/utils/format_duration.dart';
-import 'package:kohera/shared/widgets/media_viewer_shell.dart';
 
 // ── Shared fullscreen video controls (mobile + desktop) ──────
 //
@@ -19,7 +18,6 @@ import 'package:kohera/shared/widgets/media_viewer_shell.dart';
 class VideoFullscreenControls extends StatefulWidget {
   const VideoFullscreenControls({
     required this.controller,
-    this.barVisibility,
     this.initialIsPlaying = false,
     this.initialPosition = Duration.zero,
     this.initialDuration = Duration.zero,
@@ -27,7 +25,6 @@ class VideoFullscreenControls extends StatefulWidget {
   });
 
   final KoheraVideoController controller;
-  final MediaViewerBarVisibility? barVisibility;
   final bool initialIsPlaying;
   final Duration initialPosition;
   final Duration initialDuration;
@@ -83,7 +80,6 @@ class _VideoFullscreenControlsState extends State<VideoFullscreenControls> {
     } else {
       unawaited(widget.controller.play());
     }
-    widget.barVisibility?.show();
   }
 
   @override

--- a/lib/shared/widgets/video_fullscreen_controls.dart
+++ b/lib/shared/widgets/video_fullscreen_controls.dart
@@ -15,9 +15,18 @@ import 'package:kohera/core/media/kohera_video_controller.dart';
 // `MediaViewerShell`.
 
 class VideoFullscreenControls extends StatefulWidget {
-  const VideoFullscreenControls({required this.controller, super.key});
+  const VideoFullscreenControls({
+    required this.controller,
+    this.initialIsPlaying = false,
+    this.initialPosition = Duration.zero,
+    this.initialDuration = Duration.zero,
+    super.key,
+  });
 
   final KoheraVideoController controller;
+  final bool initialIsPlaying;
+  final Duration initialPosition;
+  final Duration initialDuration;
 
   @override
   State<VideoFullscreenControls> createState() =>
@@ -29,15 +38,18 @@ class _VideoFullscreenControlsState extends State<VideoFullscreenControls> {
   late final StreamSubscription<dynamic> _positionSub;
   late final StreamSubscription<dynamic> _durationSub;
   late final StreamSubscription<dynamic> _completedSub;
-  bool _isPlaying = false;
-  Duration _position = Duration.zero;
-  Duration _duration = Duration.zero;
+  late bool _isPlaying;
+  late Duration _position;
+  late Duration _duration;
   bool _scrubbing = false;
   bool _scrubWasPlaying = false;
 
   @override
   void initState() {
     super.initState();
+    _isPlaying = widget.initialIsPlaying;
+    _position = widget.initialPosition;
+    _duration = widget.initialDuration;
     _playingSub = widget.controller.playing.listen((p) {
       if (mounted) setState(() => _isPlaying = p);
     });

--- a/test/widgets/media_viewer_shell_test.dart
+++ b/test/widgets/media_viewer_shell_test.dart
@@ -47,6 +47,7 @@ Widget buildTestWidget({
         media: media ?? _makeMedia(),
         controller: controller ?? _makeController(),
         avatarResolver: MockAvatarResolver(),
+        barVisibility: MediaViewerBarVisibility(),
         child: child ?? const Placeholder(),
       ),
     ),
@@ -99,6 +100,7 @@ void main() {
                       media: _makeMedia(),
                       controller: _makeController(),
                       avatarResolver: MockAvatarResolver(),
+                      barVisibility: MediaViewerBarVisibility(),
                       child: const Placeholder(),
                     ),
                   ),
@@ -169,6 +171,39 @@ void main() {
       await tester.pump();
 
       expect(find.byType(Slider), findsOneWidget);
+    });
+
+    AnimatedOpacity barOpacity(WidgetTester tester) => tester.widget<AnimatedOpacity>(
+          find.descendant(
+            of: find.byType(MediaViewerShell),
+            matching: find.byType(AnimatedOpacity),
+          ),
+        );
+
+    testWidgets('auto-hides the top bar after the delay', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pump();
+
+      expect(barOpacity(tester).opacity, 1.0);
+
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pump();
+
+      expect(barOpacity(tester).opacity, 0.0);
+    });
+
+    testWidgets('tap re-shows the auto-hidden top bar', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pump();
+
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pump();
+      expect(barOpacity(tester).opacity, 0.0);
+
+      await tester.tap(find.byType(MediaViewerShell));
+      await tester.pump();
+
+      expect(barOpacity(tester).opacity, 1.0);
     });
   });
 }

--- a/test/widgets/media_viewer_shell_test.dart
+++ b/test/widgets/media_viewer_shell_test.dart
@@ -47,7 +47,6 @@ Widget buildTestWidget({
         media: media ?? _makeMedia(),
         controller: controller ?? _makeController(),
         avatarResolver: MockAvatarResolver(),
-        barVisibility: MediaViewerBarVisibility(),
         child: child ?? const Placeholder(),
       ),
     ),
@@ -100,7 +99,6 @@ void main() {
                       media: _makeMedia(),
                       controller: _makeController(),
                       avatarResolver: MockAvatarResolver(),
-                      barVisibility: MediaViewerBarVisibility(),
                       child: const Placeholder(),
                     ),
                   ),
@@ -171,39 +169,6 @@ void main() {
       await tester.pump();
 
       expect(find.byType(Slider), findsOneWidget);
-    });
-
-    AnimatedOpacity barOpacity(WidgetTester tester) => tester.widget<AnimatedOpacity>(
-          find.descendant(
-            of: find.byType(MediaViewerShell),
-            matching: find.byType(AnimatedOpacity),
-          ),
-        );
-
-    testWidgets('auto-hides the top bar after the delay', (tester) async {
-      await tester.pumpWidget(buildTestWidget());
-      await tester.pump();
-
-      expect(barOpacity(tester).opacity, 1.0);
-
-      await tester.pump(const Duration(seconds: 4));
-      await tester.pump();
-
-      expect(barOpacity(tester).opacity, 0.0);
-    });
-
-    testWidgets('tap re-shows the auto-hidden top bar', (tester) async {
-      await tester.pumpWidget(buildTestWidget());
-      await tester.pump();
-
-      await tester.pump(const Duration(seconds: 4));
-      await tester.pump();
-      expect(barOpacity(tester).opacity, 0.0);
-
-      await tester.tap(find.byType(MediaViewerShell));
-      await tester.pump();
-
-      expect(barOpacity(tester).opacity, 1.0);
     });
   });
 }

--- a/test/widgets/media_viewer_shell_test.dart
+++ b/test/widgets/media_viewer_shell_test.dart
@@ -84,5 +84,63 @@ void main() {
 
       expect(find.byIcon(Icons.close_rounded), findsOneWidget);
     });
+
+    Future<void> openViewer(WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (ctx) => ElevatedButton(
+              onPressed: () => Navigator.push(
+                ctx,
+                MaterialPageRoute<void>(
+                  builder: (_) => Scaffold(
+                    backgroundColor: Colors.black,
+                    body: MediaViewerShell(
+                      media: _makeMedia(),
+                      controller: _makeController(),
+                      avatarResolver: MockAvatarResolver(),
+                      child: const Placeholder(),
+                    ),
+                  ),
+                ),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('swipe down dismisses the viewer', (tester) async {
+      await openViewer(tester);
+      expect(find.byIcon(Icons.close_rounded), findsOneWidget);
+
+      await tester.timedDrag(
+        find.byType(MediaViewerShell),
+        const Offset(0, 200),
+        const Duration(milliseconds: 300),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('open'), findsOneWidget);
+      expect(find.byIcon(Icons.close_rounded), findsNothing);
+    });
+
+    testWidgets('small drag snaps back without dismissing', (tester) async {
+      await openViewer(tester);
+      expect(find.byIcon(Icons.close_rounded), findsOneWidget);
+
+      await tester.timedDrag(
+        find.byType(MediaViewerShell),
+        const Offset(0, 60),
+        const Duration(milliseconds: 200),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.close_rounded), findsOneWidget);
+      expect(find.text('open'), findsNothing);
+    });
   });
 }

--- a/test/widgets/media_viewer_shell_test.dart
+++ b/test/widgets/media_viewer_shell_test.dart
@@ -142,5 +142,33 @@ void main() {
       expect(find.byIcon(Icons.close_rounded), findsOneWidget);
       expect(find.text('open'), findsNothing);
     });
+
+    testWidgets('dialog provides a Material ancestor for Material children',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (ctx) => ElevatedButton(
+              onPressed: () => showMediaViewer(
+                ctx,
+                media: _makeMedia(),
+                controller: _makeController(),
+                avatarResolver: MockAvatarResolver(),
+                child: Slider(
+                  value: 0,
+                  onChanged: (_) {},
+                ),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byType(Slider), findsOneWidget);
+    });
   });
 }

--- a/test/widgets/shared/video_fullscreen_controls_test.dart
+++ b/test/widgets/shared/video_fullscreen_controls_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/media/kohera_media_source.dart';
 import 'package:kohera/core/media/kohera_video_controller.dart';
-import 'package:kohera/shared/widgets/media_viewer_shell.dart';
 import 'package:kohera/shared/widgets/video_fullscreen_controls.dart';
 
 class _FakeVideoController implements KoheraVideoController {
@@ -201,27 +200,6 @@ void main() {
 
       expect(find.text('00:03'), findsOneWidget);
       expect(find.text('00:10'), findsOneWidget);
-    });
-
-    testWidgets('tap reveals the shared bar visibility', (tester) async {
-      final controller = _FakeVideoController();
-      final bar = MediaViewerBarVisibility(false);
-      await tester.pumpWidget(
-        _wrap(VideoFullscreenControls(
-          controller: controller,
-          barVisibility: bar,
-          initialDuration: const Duration(seconds: 10),
-        )),
-      );
-      await tester.pump();
-
-      expect(bar.value, isFalse);
-
-      final rect = tester.getRect(find.byType(VideoFullscreenControls));
-      await tester.tapAt(rect.topLeft + const Offset(10, 10));
-      await tester.pump();
-
-      expect(bar.value, isTrue);
     });
   });
 }

--- a/test/widgets/shared/video_fullscreen_controls_test.dart
+++ b/test/widgets/shared/video_fullscreen_controls_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/media/kohera_media_source.dart';
 import 'package:kohera/core/media/kohera_video_controller.dart';
+import 'package:kohera/shared/widgets/media_viewer_shell.dart';
 import 'package:kohera/shared/widgets/video_fullscreen_controls.dart';
 
 class _FakeVideoController implements KoheraVideoController {
@@ -200,6 +201,27 @@ void main() {
 
       expect(find.text('00:03'), findsOneWidget);
       expect(find.text('00:10'), findsOneWidget);
+    });
+
+    testWidgets('tap reveals the shared bar visibility', (tester) async {
+      final controller = _FakeVideoController();
+      final bar = MediaViewerBarVisibility(false);
+      await tester.pumpWidget(
+        _wrap(VideoFullscreenControls(
+          controller: controller,
+          barVisibility: bar,
+          initialDuration: const Duration(seconds: 10),
+        )),
+      );
+      await tester.pump();
+
+      expect(bar.value, isFalse);
+
+      final rect = tester.getRect(find.byType(VideoFullscreenControls));
+      await tester.tapAt(rect.topLeft + const Offset(10, 10));
+      await tester.pump();
+
+      expect(bar.value, isTrue);
     });
   });
 }

--- a/test/widgets/shared/video_fullscreen_controls_test.dart
+++ b/test/widgets/shared/video_fullscreen_controls_test.dart
@@ -185,5 +185,21 @@ void main() {
       expect(controller.pauseCount, 1);
       expect(controller.playCount, 0);
     });
+
+    testWidgets('shows position and duration labels', (tester) async {
+      final controller = _FakeVideoController();
+      await tester.pumpWidget(
+        _wrap(VideoFullscreenControls(
+          controller: controller,
+          initialIsPlaying: true,
+          initialPosition: const Duration(seconds: 3),
+          initialDuration: const Duration(seconds: 10),
+        )),
+      );
+      await tester.pump();
+
+      expect(find.text('00:03'), findsOneWidget);
+      expect(find.text('00:10'), findsOneWidget);
+    });
   });
 }

--- a/test/widgets/shared/video_fullscreen_controls_test.dart
+++ b/test/widgets/shared/video_fullscreen_controls_test.dart
@@ -96,7 +96,8 @@ void main() {
       expect(controller.playCount, 1);
     });
 
-    testWidgets('shows pause button when playing and calls pause', (tester) async {
+    testWidgets('shows pause button when playing and calls pause',
+        (tester) async {
       final controller = _FakeVideoController();
       await tester.pumpWidget(
         _wrap(VideoFullscreenControls(controller: controller)),
@@ -161,6 +162,28 @@ void main() {
       await tester.pump();
 
       expect(controller.pauseCount, 1);
+    });
+
+    testWidgets('seeded playing state pauses on first tap', (tester) async {
+      final controller = _FakeVideoController();
+      await tester.pumpWidget(
+        _wrap(VideoFullscreenControls(
+          controller: controller,
+          initialIsPlaying: true,
+          initialDuration: const Duration(seconds: 10),
+        )),
+      );
+      await tester.pump();
+
+      expect(find.byIcon(Icons.pause_rounded), findsOneWidget);
+      expect(controller.pauseCount, 0);
+      expect(controller.playCount, 0);
+
+      await tester.tap(find.byIcon(Icons.pause_rounded));
+      await tester.pump();
+
+      expect(controller.pauseCount, 1);
+      expect(controller.playCount, 0);
     });
   });
 }

--- a/test/widgets/shared/video_fullscreen_controls_test.dart
+++ b/test/widgets/shared/video_fullscreen_controls_test.dart
@@ -114,14 +114,13 @@ void main() {
       expect(controller.pauseCount, 1);
     });
 
-    testWidgets('slider seeks on change end', (tester) async {
+    testWidgets('seeking does not toggle playback', (tester) async {
       final controller = _FakeVideoController();
       await tester.pumpWidget(
         _wrap(VideoFullscreenControls(controller: controller)),
       );
       await tester.pump();
       controller.emitDuration(const Duration(seconds: 10));
-      controller.emitPlaying(true);
       await tester.pumpAndSettle();
 
       final slider = find.byType(Slider);
@@ -131,10 +130,11 @@ void main() {
       await tester.pump();
 
       expect(controller.seeks, isNotEmpty);
-      expect(controller.playCount, greaterThanOrEqualTo(1));
+      expect(controller.playCount, 0);
+      expect(controller.pauseCount, 0);
     });
 
-    testWidgets('toggles bar visibility on tap', (tester) async {
+    testWidgets('toggles playback on tap', (tester) async {
       final controller = _FakeVideoController();
       await tester.pumpWidget(
         _wrap(VideoFullscreenControls(controller: controller)),
@@ -144,12 +144,23 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(Slider), findsOneWidget);
+      expect(controller.playCount, 0);
+      expect(controller.pauseCount, 0);
 
       final rect = tester.getRect(find.byType(VideoFullscreenControls));
       await tester.tapAt(rect.topLeft + const Offset(10, 10));
       await tester.pump();
 
-      expect(find.byType(Slider), findsNothing);
+      expect(controller.playCount, 1);
+      expect(controller.pauseCount, 0);
+
+      controller.emitPlaying(true);
+      await tester.pumpAndSettle();
+
+      await tester.tapAt(rect.topLeft + const Offset(10, 10));
+      await tester.pump();
+
+      expect(controller.pauseCount, 1);
     });
   });
 }


### PR DESCRIPTION
## Summary

The fullscreen video viewer lacked gesture controls: there was no swipe-to-dismiss and tapping the surface toggled a control bar rather than playing/pausing. This PR adds a finger-follow swipe-down-to-dismiss gesture to the shared media viewer shell and makes tapping the video surface toggle playback.

## Changes

- `lib/shared/widgets/media_viewer_shell.dart`
  - State now uses `SingleTickerProviderStateMixin`; added `_dragOffset`, a `_snapBack` `AnimationController`, and a `_snapAnim` tween.
  - Added `onVerticalDragStart/Update/End` to the fill `GestureDetector` (alongside the existing tap-to-toggle top bar).
  - During a drag the content follows the finger (`Transform.translate` + `Opacity` fade `1 - dy/600`, clamped 0.3–1.0); `dy` is clamped 0–400 (downward only).
  - On release: pops the dialog if `dy ≥ 120` or `velocity ≥ 500`, otherwise animates back to zero over 200ms.
  - Tap-to-toggle the top info bar is retained (fires only on taps not consumed by the video overlay / letterbox).
- `lib/shared/widgets/video_fullscreen_controls.dart`
  - `onTap` now calls `_togglePlayback` (pause if playing, play if paused) instead of toggling `_barVisible`.
  - Removed `_barVisible`; the slider is always visible when `duration > 0`.
  - The center play/pause indicator is wrapped in `IgnorePointer` so taps anywhere reach the tap layer (pause when playing, resume when paused).
  - The slider is placed in its own `Positioned` above the opaque tap `Positioned.fill`, so seeking never toggles playback.

## Testing

- `flutter analyze` clean on all changed files.
- `flutter test test/widgets/media_viewer_shell_test.dart test/widgets/shared/video_fullscreen_controls_test.dart test/widgets/chat/video_bubble_test.dart test/widgets/chat/inline_video_controls_test.dart` — 25/25 pass.
- [x] `flutter analyze` is clean
- [x] `flutter test` passes (no `@GenerateNiceMocks` changes, so no `build_runner` rerun needed)
- New/updated tests:
  - `toggles playback on tap` (replaces `toggles bar visibility on tap`)
  - `seeking does not toggle playback` (paused-state isolation)
  - `swipe down dismisses the viewer` (pushed route, asserts return home)
  - `small drag snaps back without dismissing`

## Screenshots / recordings

N/A — gesture behavior; verified via widget tests asserting route pop and play/pause counts.

## Linked issues

No dedicated issue exists for this slice; it falls under the video player polish epic.

Refs #797

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master` (not another feature branch, unless an explicitly requested stacked PR)