### PR TITLE
fix: strip reply fallback from OS notification body

### DIFF
--- a/lib/features/notifications/services/notification_service.dart
+++ b/lib/features/notifications/services/notification_service.dart
@@ -12,6 +12,7 @@ import 'package:kohera/core/utils/media_cache_io.dart'
     if (dart.library.js_interop) 'package:kohera/core/utils/media_cache_web.dart';
 import 'package:kohera/core/utils/notification_filter.dart';
 import 'package:kohera/core/utils/platform_info.dart';
+import 'package:kohera/core/utils/reply_fallback.dart';
 import 'package:kohera/features/notifications/models/notification_constants.dart';
 import 'package:kohera/features/notifications/services/web_notifications.dart';
 import 'package:kohera/features/notifications/services/windows_com_register.dart';
@@ -338,7 +339,8 @@ class NotificationService {
             event.parsedPollEventContent.pollStartContent.question.mText;
         body = question.isEmpty ? '📊 Poll' : '📊 Poll: $question';
       } else {
-        body = event.body;
+        body = stripReplyFallback(event.body).trim();
+        if (body.isEmpty) body = event.body;
       }
 
       if (!shouldNotifyForEvent(
@@ -424,7 +426,10 @@ class NotificationService {
       if (decrypted != null && callEventTypes.contains(decrypted.type)) {
         return _formatCallEvent(decrypted);
       }
-      return decrypted?.body ?? NotificationText.encryptedMessage;
+      final decryptedBody = decrypted?.body;
+      if (decryptedBody == null) return NotificationText.encryptedMessage;
+      final stripped = stripReplyFallback(decryptedBody).trim();
+      return stripped.isEmpty ? decryptedBody : stripped;
     } catch (e) {
       debugPrint('[Kohera] Decryption failed for notification: $e');
       return NotificationText.encryptedMessage;

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -436,6 +436,21 @@ void main() {
           .called(1);
     });
 
+    test('reply fallback is stripped from notification body', () async {
+      await skipFirstSync();
+
+      const replyBody = '> <@bob:example.com> original message\n\nmy reply';
+      final update = makeSyncUpdate(
+        roomId: roomId,
+        events: [makeMessageEvent(body: replyBody)],
+      );
+      mockClient.onSync.add(update);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      verify(mockPlugin.show(id: anyNamed('id'), title: 'General', body: 'Alice: my reply', notificationDetails: anyNamed('notificationDetails'), payload: roomId))
+          .called(1);
+    });
+
     test('multiple messages from same sender are grouped', () async {
       await skipFirstSync();
 


### PR DESCRIPTION
## Summary

OS notifications for reply messages displayed `<...` because the Matrix plaintext reply fallback (`> <@user:server> ...`) was passed through raw. The OS renderer treats `> ` as a blockquote, strips it, and leaves the `<@user:server>` MXID which truncates to `<...`.

## Changes

- `lib/features/notifications/services/notification_service.dart`: apply `stripReplyFallback` to both the plaintext `event.body` path and the decrypted (`_tryDecrypt`) path before showing the notification. Falls back to raw body when stripping yields empty.
- `test/services/notification_service_test.dart`: added test verifying reply fallback is stripped from the notification body.

## Testing

- [x] `flutter analyze` is clean (`lib/features/notifications/services/notification_service.dart` — no issues)
- [x] `flutter test` passes — `test/services/notification_service_test.dart` (27 tests) and `test/utils/reply_fallback_test.dart` (8 tests)

## Screenshots / recordings

N/A — notification text change only.

## Linked issues

Closes #

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master` (not another feature branch, unless an explicitly requested stacked PR)