### PR TITLE
style: scrub orphaned SNES spec references and inline comment

### DIFF
--- a/lib/core/theme/kohera_palette.dart
+++ b/lib/core/theme/kohera_palette.dart
@@ -371,11 +371,11 @@ class KoheraPalette extends ThemeExtension<KoheraPalette> {
   }
 
   /// Creates a SNES-inspired palette — 16-bit soft-beveled pixel theme
-  /// (snes.css inspired, revised spec). Grey #e5e5e5 light surface (snes.css
-  /// default canvas), aged-yellow #fcf4d9 as an elevated accent + dark
-  /// onSurface text, phantom purple #9b5de5 primary, dusk #2c3e50 text/border,
-  /// 9-color snes.css accent ramp. radius 4 (soft-pixel), shadowOffset 6
-  /// (wide grid), translucent shadowHard rgba(#000,0.2).
+  /// (snes.css inspired). Grey #e5e5e5 light surface (snes.css default
+  /// canvas), aged-yellow #fcf4d9 as an elevated accent + dark onSurface
+  /// text, phantom purple #9b5de5 primary, dusk #2c3e50 text/border, 9-color
+  /// snes.css accent ramp. radius 4 (soft-pixel), shadowOffset 6 (wide
+  /// grid), translucent shadowHard rgba(#000,0.2).
   factory KoheraPalette.snes(Brightness brightness) {
     const phantomPurple = Color(0xFF9b5de5);
     const oceanBlue = Color(0xFF4eb6d9);
@@ -438,7 +438,7 @@ class KoheraPalette extends ThemeExtension<KoheraPalette> {
       onUnread: Color(0xFFFFFFFF),
       mention: Color(0xFFb8900f),
       link: Color(0xFF2a6d8a),
-      ownBubble: Color(0xFF7b3dc4),             // deeper phantom purple — light-mode contrast + brightness adaptation
+      ownBubble: Color(0xFF7b3dc4),
       onOwnBubble: Color(0xFFFFFFFF),
       otherBubble: secondaryPurple,
       onOtherBubble: dusk,

--- a/lib/core/theme/theme_presets.dart
+++ b/lib/core/theme/theme_presets.dart
@@ -532,9 +532,10 @@ const _presets = <ThemePreset>[
     ),
   ),
 
-  // SNES — 16-bit soft-beveled pixel theme (snes.css inspired, revised spec)
-  // grey #e5e5e5 light surface (snes.css default canvas), aged-yellow #fcf4d9
-  // as surfaceContainerHighest elevated accent + dark onSurface text accent,
+  // ── SNES ─────────────────────────────────────────────────────────────
+  // 16-bit soft-beveled pixel theme (snes.css inspired). grey #e5e5e5
+  // light surface (snes.css default canvas), aged-yellow #fcf4d9 as
+  // surfaceContainerHighest elevated accent + dark onSurface text accent,
   // phantom purple #9b5de5 primary, dusk #2c3e50 text/border, 9-color ramp.
   ThemePreset(
     id: 'snes',


### PR DESCRIPTION
## Summary

Cleanup follow-up to the merged `docs: remove SNES theme spec` commit. The deletion left two orphaned references to "revised spec" and one inline comment that violated the project's no-comments convention. This PR scrubs both so the SNES theme code is self-describing without pointing at a doc that no longer exists.

## Changes

- `lib/core/theme/kohera_palette.dart`
  - `KoheraPalette.snes` dartdoc: drop "(snes.css inspired, revised spec)" → "(snes.css inspired)".
  - Remove inline `// deeper phantom purple — light-mode contrast + brightness adaptation` comment on the light-mode `ownBubble` constant (the const already conveys intent).
- `lib/core/theme/theme_presets.dart`
  - SNES preset header: replace free-form `// SNES — ...` comment with a proper `// ── SNES ──` section marker per the section-marker convention; drop "revised spec" phrasing.

## Testing

- `flutter analyze lib/core/theme/` → No issues found.
- No runtime behavior change; theme tokens unchanged.
- Existing PICO-8/SNES golden tests unaffected (decoration code path untouched).

## Linked issues

Refs #814 (Bubble vibe slider epic — resolver consumes these tokens).

## Checklist

- [x] Commit message follows `style:` convention
- [x] `flutter analyze` clean on touched files
- [x] No behavior change — comment-only diff
- [x] Branch targets `master`