### PR TITLE
feat(#821): ignore/unignore users (hide messages & invites)

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -26,6 +26,7 @@ import 'package:kohera/features/rooms/widgets/room_list.dart';
 import 'package:kohera/features/settings/screens/appearance_screen.dart';
 import 'package:kohera/features/settings/screens/devices_screen.dart';
 import 'package:kohera/features/settings/screens/emoji_gg_browse_screen.dart';
+import 'package:kohera/features/settings/screens/ignored_users_screen.dart';
 import 'package:kohera/features/settings/screens/notification_settings_screen.dart';
 import 'package:kohera/features/settings/screens/settings_screen.dart';
 import 'package:kohera/features/settings/screens/sticker_packs_screen.dart';
@@ -302,6 +303,12 @@ GoRouter buildRouter(ClientManager manager) {
                     name: Routes.settingsStickerPacks,
                     builder: (context, state) =>
                         const StickerPacksScreen(),
+                  ),
+                  GoRoute(
+                    path: RouteSegments.settingsIgnoredUsers,
+                    name: Routes.settingsIgnoredUsers,
+                    builder: (context, state) =>
+                        const IgnoredUsersScreen(),
                   ),
                   GoRoute(
                     path: RouteSegments.settingsEmojiGgBrowse,

--- a/lib/core/routing/route_names.dart
+++ b/lib/core/routing/route_names.dart
@@ -50,6 +50,7 @@ abstract class RouteSegments {
   static const settingsVoiceVideo = 'voice-video';
   static const settingsRecoveryKey = 'recovery-key';
   static const settingsStickerPacks = 'sticker-packs';
+  static const settingsIgnoredUsers = 'ignored-users';
   static const settingsEmojiGgBrowse = 'emoji-gg-browse';
 }
 
@@ -71,6 +72,7 @@ abstract class Routes {
   static const settingsVoiceVideo = 'settings-voice-video';
   static const settingsRecoveryKey = 'settings-recovery-key';
   static const settingsStickerPacks = 'settings-sticker-packs';
+  static const settingsIgnoredUsers = 'settings-ignored-users';
   static const settingsEmojiGgBrowse = 'settings-emoji-gg-browse';
   static const inbox = 'inbox';
   static const spaceDetails = 'space-details';

--- a/lib/core/services/sub_services/selection_service.dart
+++ b/lib/core/services/sub_services/selection_service.dart
@@ -258,16 +258,30 @@ class SelectionService extends ChangeNotifier {
   }
 
   List<Room> get invitedRooms => _client.rooms
-      .where((r) => !r.isSpace && r.membership == Membership.invite)
+      .where((r) =>
+          !r.isSpace &&
+          r.membership == Membership.invite &&
+          !_isInviterIgnored(r))
       .toList()
     ..sort((a, b) => a.getLocalizedDisplayname().compareTo(
         b.getLocalizedDisplayname(),),);
 
   List<Room> get invitedSpaces => _client.rooms
-      .where((r) => r.isSpace && r.membership == Membership.invite)
+      .where((r) =>
+          r.isSpace &&
+          r.membership == Membership.invite &&
+          !_isInviterIgnored(r))
       .toList()
     ..sort((a, b) => a.getLocalizedDisplayname().compareTo(
         b.getLocalizedDisplayname(),),);
+
+  bool _isInviterIgnored(Room room) {
+    final userId = _client.userID;
+    if (userId == null) return false;
+    final inviteState = room.getState(EventTypes.RoomMember, userId);
+    if (inviteState == null) return false;
+    return _client.ignoredUsers.contains(inviteState.senderId);
+  }
 
   String? inviterDisplayName(Room room) {
     final userId = _client.userID;

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -15,6 +15,7 @@ import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/services/sticker_pack_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
+import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:kohera/core/utils/platform_info.dart';
 import 'package:kohera/core/utils/reply_fallback.dart';
 import 'package:kohera/features/calling/services/call_service.dart';
@@ -60,6 +61,7 @@ import 'package:kohera/features/home/screens/home_shell.dart';
 import 'package:kohera/features/rooms/models/kohera_room_member.dart';
 import 'package:kohera/features/rooms/services/member_sheet_launcher.dart';
 import 'package:kohera/shared/services/room_summary_resolver.dart';
+import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
 
@@ -459,6 +461,9 @@ class _ChatScreenState extends State<ChatScreen>
         onForward: isRedacted
             ? null
             : () => _forwardMessage(eventId),
+        onIgnoreSender: (!isRedacted && !isMe)
+            ? () => unawaited(_ignoreSender(event))
+            : null,
         onRetrySend: () async {
           try {
             await event.sendAgain();
@@ -570,6 +575,13 @@ class _ChatScreenState extends State<ChatScreen>
             );
           },
         ),
+        if (!isMe)
+          MessageAction(
+            label: 'Ignore user',
+            icon: Icons.do_not_disturb_on_outlined,
+            onTap: () => unawaited(_ignoreSender(event)),
+            color: cs.error,
+          ),
         if (event.canRedact)
           MessageAction(
             label: isMe ? 'Delete' : 'Remove',
@@ -614,6 +626,33 @@ class _ChatScreenState extends State<ChatScreen>
       powerLevel: room.getPowerLevelByUserId(sender.id).level,
     );
     unawaited(showRoomMemberSheet(context, room: room, member: member));
+  }
+
+  Future<void> _ignoreSender(Event event) async {
+    final senderId = event.senderId;
+    final myId = _timelineController.myUserId;
+    if (senderId == myId) return;
+    final sender = event.senderFromMemoryOrFallback;
+    final displayName = sender.calcDisplayname();
+    final confirmed = await confirmDialog(
+      context,
+      title: 'Ignore user?',
+      message:
+          'Hide messages and invites from $displayName across all rooms?',
+      confirmLabel: 'Ignore',
+      destructive: true,
+    );
+    if (!confirmed || !mounted) return;
+    final matrix = context.read<MatrixService>();
+    try {
+      await matrix.client.ignoreUser(senderId, leaveRooms: false);
+      if (mounted) context.showSnack('Ignored $displayName');
+    } catch (e) {
+      debugPrint('[Kohera] Ignore sender failed: $e');
+      if (mounted) {
+        context.showSnack('Failed to ignore: ${MatrixService.friendlyAuthError(e)}');
+      }
+    }
   }
 
   void _showStickerContextMenu(

--- a/lib/features/chat/services/message_timeline_controller.dart
+++ b/lib/features/chat/services/message_timeline_controller.dart
@@ -77,6 +77,7 @@ class MessageTimelineController extends ChangeNotifier {
       timelineEvents,
       extraEvents: _extraEvents,
       threadRootId: threadRootEventId,
+      ignoredUserIds: matrix.client.ignoredUsers,
     );
     _cachedMessages = _buildMessageData(visible);
     return _cachedMessages!;
@@ -334,6 +335,7 @@ class MessageTimelineController extends ChangeNotifier {
     Iterable<Event> timelineEvents, {
     List<Event>? extraEvents,
     String? threadRootId,
+    List<String> ignoredUserIds = const [],
   }) {
     final seen = <String>{};
     final merged = <Event>[];
@@ -348,7 +350,9 @@ class MessageTimelineController extends ChangeNotifier {
     return merged
         .where(
           (e) =>
-              (((e.type == EventTypes.Message || e.type == EventTypes.Encrypted) &&
+              !ignoredUserIds.contains(e.senderId) &&
+              (((e.type == EventTypes.Message ||
+                          e.type == EventTypes.Encrypted) &&
                       e.relationshipType != RelationshipTypes.edit &&
                       !_isCallMemberEvent(e)) ||
                   callEventTypes.contains(e.type) ||

--- a/lib/features/chat/widgets/chat_app_bar.dart
+++ b/lib/features/chat/widgets/chat_app_bar.dart
@@ -247,7 +247,12 @@ class _HeaderSubtitle extends StatelessWidget {
       },
       builder: (context, count) {
         if (presence == null || userId == null) {
-          return Text(_memberCountLabel(count), style: style);
+          return Text(
+            _memberCountLabel(count),
+            style: style,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          );
         }
         return ListenableBuilder(
           listenable: presence,

--- a/lib/features/chat/widgets/message_bubble_context_menu.dart
+++ b/lib/features/chat/widgets/message_bubble_context_menu.dart
@@ -19,6 +19,7 @@ Future<void> showMessageContextMenu(
   VoidCallback? onForward,
   VoidCallback? onRetrySend,
   VoidCallback? onDiscardSend,
+  VoidCallback? onIgnoreSender,
 }) async {
   final cs = Theme.of(context).colorScheme;
   final items = <PopupMenuItem<String>>[
@@ -47,6 +48,13 @@ Future<void> showMessageContextMenu(
           isPinned ? Icons.push_pin_rounded : Icons.push_pin_outlined,
           isPinned ? 'Unpin' : 'Pin',
           'pin',
+        ),
+      if (onIgnoreSender != null)
+        menuItemRow(
+          Icons.do_not_disturb_on_outlined,
+          'Ignore user',
+          'ignore_sender',
+          color: cs.error,
         ),
       if (onDelete != null)
         menuItemRow(
@@ -80,6 +88,7 @@ Future<void> showMessageContextMenu(
   if (value == 'react') onReact?.call();
   if (value == 'edit') onEdit?.call();
   if (value == 'pin') onPin?.call();
+  if (value == 'ignore_sender') onIgnoreSender?.call();
   if (value == 'copy') {
     await Clipboard.setData(ClipboardData(text: copyableBody));
   }

--- a/lib/features/home/widgets/narrow_layout.dart
+++ b/lib/features/home/widgets/narrow_layout.dart
@@ -62,6 +62,7 @@ class _NarrowLayoutState extends State<NarrowLayout> {
         name == Routes.settingsVoiceVideo ||
         name == Routes.settingsRecoveryKey ||
         name == Routes.settingsStickerPacks ||
+        name == Routes.settingsIgnoredUsers ||
         name == Routes.settingsEmojiGgBrowse ||
         name == Routes.spaceDetails ||
         name == Routes.whatsNew;

--- a/lib/features/home/widgets/wide_layout.dart
+++ b/lib/features/home/widgets/wide_layout.dart
@@ -126,6 +126,7 @@ class _WideLayoutState extends State<WideLayout> {
         name == Routes.settingsVoiceVideo ||
         name == Routes.settingsRecoveryKey ||
         name == Routes.settingsStickerPacks ||
+        name == Routes.settingsIgnoredUsers ||
         name == Routes.settingsEmojiGgBrowse ||
         name == Routes.spaces ||
         name == Routes.spaceDetails ||

--- a/lib/features/rooms/services/member_sheet_launcher.dart
+++ b/lib/features/rooms/services/member_sheet_launcher.dart
@@ -29,6 +29,7 @@ Future<void> showRoomMemberSheet(
   final client = room.client;
   final isMe = member.userId == client.userID;
   final ownLevel = room.getPowerLevelByUserId(client.userID ?? '').level;
+  final isIgnored = client.ignoredUsers.contains(member.userId);
 
   return showMemberSheetDialog(
     context,
@@ -47,6 +48,7 @@ Future<void> showRoomMemberSheet(
         !member.isBanned,
     avatarResolver: context.read<MatrixService>().avatarResolver,
     presence: context.read<MatrixService>().presence,
+    isIgnored: isIgnored,
     formatError: MatrixService.friendlyAuthError,
     onStartDm: isMe
         ? null
@@ -74,5 +76,7 @@ Future<void> showRoomMemberSheet(
     onKick: (reason) => client.kick(room.id, member.userId, reason: reason),
     onBan: (reason) => client.ban(room.id, member.userId, reason: reason),
     onUnban: (_) => client.unban(room.id, member.userId),
+    onIgnore: isMe ? null : () => client.ignoreUser(member.userId, leaveRooms: false),
+    onUnignore: isMe ? null : () => client.unignoreUser(member.userId),
   );
 }

--- a/lib/features/rooms/widgets/member_sheet_dialog.dart
+++ b/lib/features/rooms/widgets/member_sheet_dialog.dart
@@ -27,11 +27,14 @@ Future<void> showMemberSheetDialog(
   required bool canBan,
   required AvatarResolver avatarResolver,
   required PresenceService presence,
+  bool isIgnored = false,
   Future<void> Function()? onStartDm,
   Future<void> Function(int newLevel)? onRoleChange,
   Future<void> Function(String? reason)? onKick,
   Future<void> Function(String? reason)? onBan,
   Future<void> Function(String? reason)? onUnban,
+  Future<void> Function()? onIgnore,
+  Future<void> Function()? onUnignore,
   String Function(Object error)? formatError,
 }) {
   return showDialog<void>(
@@ -45,11 +48,14 @@ Future<void> showMemberSheetDialog(
       canBan: canBan,
       avatarResolver: avatarResolver,
       presence: presence,
+      isIgnored: isIgnored,
       onStartDm: onStartDm,
       onRoleChange: onRoleChange,
       onKick: onKick,
       onBan: onBan,
       onUnban: onUnban,
+      onIgnore: onIgnore,
+      onUnignore: onUnignore,
       formatError: formatError,
     ),
   );
@@ -67,11 +73,14 @@ class MemberSheetDialog extends StatefulWidget {
     required this.canBan,
     required this.avatarResolver,
     required this.presence,
+    this.isIgnored = false,
     this.onStartDm,
     this.onRoleChange,
     this.onKick,
     this.onBan,
     this.onUnban,
+    this.onIgnore,
+    this.onUnignore,
     this.formatError,
     super.key,
   });
@@ -84,11 +93,14 @@ class MemberSheetDialog extends StatefulWidget {
   final bool canBan;
   final AvatarResolver avatarResolver;
   final PresenceService presence;
+  final bool isIgnored;
   final Future<void> Function()? onStartDm;
   final Future<void> Function(int newLevel)? onRoleChange;
   final Future<void> Function(String? reason)? onKick;
   final Future<void> Function(String? reason)? onBan;
   final Future<void> Function(String? reason)? onUnban;
+  final Future<void> Function()? onIgnore;
+  final Future<void> Function()? onUnignore;
 
   /// Formats caught errors for user-facing display.
   /// When null, errors fall back to `e.toString()`.
@@ -232,6 +244,54 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
       if (mounted) Navigator.pop(context);
     } catch (e) {
       debugPrint('[Kohera] Unban failed: $e');
+      if (mounted) {
+        setState(() {
+          _actionLoading = false;
+          _actionError = widget.formatError?.call(e) ?? e.toString();
+        });
+      }
+    }
+  }
+
+  Future<void> _ignore() async {
+    final displayName = widget.member.displayname;
+    final confirmed = await confirmDialog(
+      context,
+      title: 'Ignore user?',
+      message:
+          'Hide messages and invites from $displayName across all rooms?',
+      confirmLabel: 'Ignore',
+      destructive: true,
+    );
+    if (!confirmed || !mounted) return;
+    setState(() {
+      _actionLoading = true;
+      _actionError = null;
+    });
+    try {
+      await widget.onIgnore?.call();
+      if (mounted) Navigator.pop(context);
+    } catch (e) {
+      debugPrint('[Kohera] Ignore failed: $e');
+      if (mounted) {
+        setState(() {
+          _actionLoading = false;
+          _actionError = widget.formatError?.call(e) ?? e.toString();
+        });
+      }
+    }
+  }
+
+  Future<void> _unignore() async {
+    setState(() {
+      _actionLoading = true;
+      _actionError = null;
+    });
+    try {
+      await widget.onUnignore?.call();
+      if (mounted) Navigator.pop(context);
+    } catch (e) {
+      debugPrint('[Kohera] Unignore failed: $e');
       if (mounted) {
         setState(() {
           _actionLoading = false;
@@ -436,6 +496,28 @@ class _MemberSheetDialogState extends State<MemberSheetDialog> {
                 Icon(Icons.chat_outlined),
                 SizedBox(width: 16),
                 Text('Send message'),
+              ],
+            ),
+          ),
+        if (!widget.isMe && !widget.isIgnored && widget.onIgnore != null)
+          SimpleDialogOption(
+            onPressed: _actionLoading ? null : _ignore,
+            child: Row(
+              children: [
+                Icon(Icons.do_not_disturb_on_outlined, color: cs.error),
+                const SizedBox(width: 16),
+                Text('Ignore user', style: TextStyle(color: cs.error)),
+              ],
+            ),
+          ),
+        if (!widget.isMe && widget.isIgnored && widget.onUnignore != null)
+          SimpleDialogOption(
+            onPressed: _actionLoading ? null : _unignore,
+            child: Row(
+              children: [
+                Icon(Icons.visibility_outlined, color: cs.primary),
+                const SizedBox(width: 16),
+                Text('Unignore user', style: TextStyle(color: cs.primary)),
               ],
             ),
           ),

--- a/lib/features/settings/screens/ignored_users_screen.dart
+++ b/lib/features/settings/screens/ignored_users_screen.dart
@@ -21,6 +21,22 @@ class IgnoredUsersScreen extends StatefulWidget {
 class _IgnoredUsersScreenState extends State<IgnoredUsersScreen> {
   final _displayNames = <String, String>{};
   final _loading = <String>{};
+  StreamSubscription<SyncUpdate>? _syncSub;
+
+  @override
+  void initState() {
+    super.initState();
+    final client = context.read<MatrixService>().client;
+    _syncSub = client.onSync.stream.listen((_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    unawaited(_syncSub?.cancel());
+    super.dispose();
+  }
 
   Future<void> _loadProfile(String userId, Client client) async {
     if (_displayNames.containsKey(userId) || _loading.contains(userId)) return;
@@ -112,7 +128,9 @@ class _IgnoredUsersScreenState extends State<IgnoredUsersScreen> {
               separatorBuilder: (_, _) => const Divider(height: 1, indent: 72),
               itemBuilder: (context, index) {
                 final userId = ignored[index];
-                unawaited(_loadProfile(userId, client));
+                WidgetsBinding.instance.addPostFrameCallback(
+                  (_) => _loadProfile(userId, client),
+                );
                 final displayName = _displayNames[userId] ?? userId;
                 return _IgnoredUserTile(
                   userId: userId,

--- a/lib/features/settings/screens/ignored_users_screen.dart
+++ b/lib/features/settings/screens/ignored_users_screen.dart
@@ -1,0 +1,169 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
+import 'package:kohera/core/routing/route_names.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/utils/confirm_dialog.dart';
+import 'package:kohera/shared/services/avatar_resolver.dart';
+import 'package:kohera/shared/widgets/user_avatar.dart';
+import 'package:matrix/matrix.dart';
+import 'package:provider/provider.dart';
+
+class IgnoredUsersScreen extends StatefulWidget {
+  const IgnoredUsersScreen({super.key});
+
+  @override
+  State<IgnoredUsersScreen> createState() => _IgnoredUsersScreenState();
+}
+
+class _IgnoredUsersScreenState extends State<IgnoredUsersScreen> {
+  final _displayNames = <String, String>{};
+  final _loading = <String>{};
+
+  Future<void> _loadProfile(String userId, Client client) async {
+    if (_displayNames.containsKey(userId) || _loading.contains(userId)) return;
+    setState(() => _loading.add(userId));
+    try {
+      final profile = await client.getProfileFromUserId(userId);
+      if (mounted) {
+        setState(() {
+          _displayNames[userId] = profile.displayName ?? userId;
+          _loading.remove(userId);
+        });
+      }
+    } catch (e) {
+      debugPrint('[Kohera] Failed to load profile for $userId: $e');
+      if (mounted) setState(() => _loading.remove(userId));
+    }
+  }
+
+  Future<void> _unignore(String userId) async {
+    final confirmed = await confirmDialog(
+      context,
+      title: 'Unignore user?',
+      message: 'Show messages and invites from this user again?',
+      confirmLabel: 'Unignore',
+    );
+    if (!confirmed || !mounted) return;
+    final client = context.read<MatrixService>().client;
+    try {
+      await client.unignoreUser(userId);
+      if (mounted) {
+        setState(() {
+          _displayNames.remove(userId);
+          _loading.remove(userId);
+        });
+        context.showSnack('User unignored');
+      }
+    } catch (e) {
+      debugPrint('[Kohera] Unignore failed: $e');
+      if (mounted) {
+        context.showSnack('Failed to unignore: ${MatrixService.friendlyAuthError(e)}');
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final matrix = context.watch<MatrixService>();
+    final client = matrix.client;
+    final ignored = client.ignoredUsers;
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.goNamed(Routes.settings),
+        ),
+        title: const Text('Ignored users'),
+      ),
+      body: ignored.isEmpty
+          ? Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.do_not_disturb_alt_outlined,
+                        size: 48, color: cs.onSurfaceVariant),
+                    const SizedBox(height: 16),
+                    Text(
+                      'No ignored users',
+                      style: tt.titleMedium,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Users you ignore will appear here. Their messages and '
+                      'invites are hidden across all rooms.',
+                      textAlign: TextAlign.center,
+                      style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+                    ),
+                  ],
+                ),
+              ),
+            )
+          : ListView.separated(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              itemCount: ignored.length,
+              separatorBuilder: (_, _) => const Divider(height: 1, indent: 72),
+              itemBuilder: (context, index) {
+                final userId = ignored[index];
+                unawaited(_loadProfile(userId, client));
+                final displayName = _displayNames[userId] ?? userId;
+                return _IgnoredUserTile(
+                  userId: userId,
+                  displayName: displayName,
+                  loading: _loading.contains(userId),
+                  avatarResolver: matrix.avatarResolver,
+                  onUnignore: () => _unignore(userId),
+                );
+              },
+            ),
+    );
+  }
+}
+
+class _IgnoredUserTile extends StatelessWidget {
+  const _IgnoredUserTile({
+    required this.userId,
+    required this.displayName,
+    required this.loading,
+    required this.avatarResolver,
+    required this.onUnignore,
+  });
+
+  final String userId;
+  final String displayName;
+  final bool loading;
+  final AvatarResolver avatarResolver;
+  final VoidCallback onUnignore;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return ListTile(
+      leading: UserAvatar(
+        avatarResolver: avatarResolver,
+        userId: userId,
+        displayname: displayName,
+        size: 40,
+      ),
+      title: Text(displayName),
+      subtitle: Text(userId, style: TextStyle(color: cs.onSurfaceVariant)),
+      trailing: loading
+          ? const SizedBox(
+              width: 24,
+              height: 24,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : TextButton(
+              onPressed: onUnignore,
+              child: const Text('Unignore'),
+            ),
+    );
+  }
+}

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -192,6 +192,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   subtitle: 'Manage your devices',
                   onTap: () => context.pushOrGo(Routes.settingsDevices),
                 ),
+                const Divider(height: 1, indent: 56),
+                _SettingsTile(
+                  icon: Icons.do_not_disturb_alt_outlined,
+                  title: 'Ignored users',
+                  subtitle: 'Manage who you’ve muted',
+                  onTap: () =>
+                      context.pushOrGo(Routes.settingsIgnoredUsers),
+                ),
               ],
             ),
           ),

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -14,6 +14,7 @@ import 'package:kohera/features/settings/widgets/account_switcher.dart';
 import 'package:kohera/features/settings/widgets/profile_avatar_card.dart';
 import 'package:kohera/shared/widgets/kohera_mark.dart';
 import 'package:kohera/shared/widgets/section_header.dart';
+import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -27,6 +28,28 @@ class SettingsScreen extends StatefulWidget {
 
 class _SettingsScreenState extends State<SettingsScreen> {
   String? _lastShownError;
+  StreamSubscription<SyncUpdate>? _syncSub;
+  int _ignoredCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    final client = context.read<MatrixService>().client;
+    _ignoredCount = client.ignoredUsers.length;
+    _syncSub = client.onSync.stream.listen((_) {
+      if (!mounted) return;
+      final count = client.ignoredUsers.length;
+      if (count != _ignoredCount) {
+        setState(() => _ignoredCount = count);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    unawaited(_syncSub?.cancel());
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -196,9 +219,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 _SettingsTile(
                   icon: Icons.do_not_disturb_alt_outlined,
                   title: 'Ignored users',
-                  subtitle: 'Manage who you’ve muted',
-                  onTap: () =>
-                      context.pushOrGo(Routes.settingsIgnoredUsers),
+                  subtitle: _ignoredUsersLabel(_ignoredCount),
+                  onTap: () => context.goNamed(Routes.settingsIgnoredUsers),
                 ),
               ],
             ),
@@ -339,6 +361,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
     ),);
   }
 
+}
+
+String _ignoredUsersLabel(int count) {
+  if (count == 0) return 'None';
+  return '$count user${count == 1 ? '' : 's'}';
 }
 
 class _SettingsTile extends StatelessWidget {

--- a/test/services/selection_service_test.dart
+++ b/test/services/selection_service_test.dart
@@ -244,6 +244,48 @@ void main() {
         'Invited Room',
       );
     });
+
+    test('hides invites from ignored users', () {
+      when(mockClient.userID).thenReturn('@me:example.com');
+      when(mockClient.ignoredUsers).thenReturn(['@bad:example.com']);
+
+      final inviteFromBad = MockRoom();
+      final inviteFromGood = MockRoom();
+
+      when(inviteFromBad.isSpace).thenReturn(false);
+      when(inviteFromBad.membership).thenReturn(Membership.invite);
+      when(inviteFromBad.getLocalizedDisplayname()).thenReturn('Bad Invite');
+      when(inviteFromBad.getState(EventTypes.RoomMember, '@me:example.com'))
+          .thenReturn(
+        StrippedStateEvent(
+          type: EventTypes.RoomMember,
+          content: {'membership': 'invite'},
+          senderId: '@bad:example.com',
+          stateKey: '@me:example.com',
+        ),
+      );
+
+      when(inviteFromGood.isSpace).thenReturn(false);
+      when(inviteFromGood.membership).thenReturn(Membership.invite);
+      when(inviteFromGood.getLocalizedDisplayname()).thenReturn('Good Invite');
+      when(inviteFromGood.getState(EventTypes.RoomMember, '@me:example.com'))
+          .thenReturn(
+        StrippedStateEvent(
+          type: EventTypes.RoomMember,
+          content: {'membership': 'invite'},
+          senderId: '@friend:example.com',
+          stateKey: '@me:example.com',
+        ),
+      );
+
+      when(mockClient.rooms).thenReturn([inviteFromBad, inviteFromGood]);
+
+      expect(service.invitedRooms, hasLength(1));
+      expect(
+        service.invitedRooms[0].getLocalizedDisplayname(),
+        'Good Invite',
+      );
+    });
   });
 
   group('invitedSpaces', () {

--- a/test/widgets/message_list_view_order_test.dart
+++ b/test/widgets/message_list_view_order_test.dart
@@ -7,11 +7,12 @@ import 'package:mockito/mockito.dart';
 @GenerateNiceMocks([MockSpec<Event>()])
 import 'message_list_view_order_test.mocks.dart';
 
-MockEvent _event(String id, String type, DateTime ts) {
+MockEvent _event(String id, String type, DateTime ts, {String sender = '@me:example.com'}) {
   final e = MockEvent();
   when(e.eventId).thenReturn(id);
   when(e.type).thenReturn(type);
   when(e.originServerTs).thenReturn(ts);
+  when(e.senderId).thenReturn(sender);
   when(e.body).thenReturn('');
   return e;
 }
@@ -72,5 +73,27 @@ void main() {
     );
 
     expect(_ids(visible), [r'$p1']);
+  });
+
+  test('filters out events from ignored users', () {
+    final mine = _event(
+      r'$m1',
+      EventTypes.Message,
+      DateTime(2026, 1, 15, 10),
+      sender: '@me:example.com',
+    );
+    final ignored = _event(
+      r'$m2',
+      EventTypes.Message,
+      DateTime(2026, 1, 15, 11),
+      sender: '@bad:example.com',
+    );
+
+    final visible = MessageTimelineController.buildVisibleEvents(
+      [mine, ignored],
+      ignoredUserIds: ['@bad:example.com'],
+    );
+
+    expect(_ids(visible), [r'$m1']);
   });
 }

--- a/test/widgets/message_list_view_order_test.dart
+++ b/test/widgets/message_list_view_order_test.dart
@@ -80,7 +80,6 @@ void main() {
       r'$m1',
       EventTypes.Message,
       DateTime(2026, 1, 15, 10),
-      sender: '@me:example.com',
     );
     final ignored = _event(
       r'$m2',


### PR DESCRIPTION
## Summary

Adds ignore/unignore wiring over `Client.ignoreUser`/`unignoreUser` so users can mute others across all rooms: ignored senders' messages and invites are hidden, with a settings screen to manage the list.

## Changes

- **Member profile sheet** (`lib/features/rooms/widgets/member_sheet_dialog.dart`, `member_sheet_launcher.dart`): added `isIgnored`/`onIgnore`/`onUnignore` callbacks + UI options with confirm dialog; launcher wires to `Client.ignoreUser(userId, leaveRooms: false)` / `unignoreUser`.
- **Message context menu** (`message_bubble_context_menu.dart`, `chat_screen.dart`): added `onIgnoreSender` to desktop menu and an "Ignore user" action to the mobile action sheet; new `_ignoreSender` helper with confirm + snackbar.
- **Ignored users settings screen** (`lib/features/settings/screens/ignored_users_screen.dart`): lists `client.ignoredUsers`, lazily resolves display names via `getProfileFromUserId`, per-row unignore. Routed via new `Routes.settingsIgnoredUsers` / `RouteSegments.settingsIgnoredUsers`; tile added under Security in `settings_screen.dart`.
- **Timeline filter** (`message_timeline_controller.dart`): `buildVisibleEvents` accepts `ignoredUserIds` and filters events whose `senderId` is ignored; `messages` getter passes `matrix.client.ignoredUsers`.
- **Invite filter** (`selection_service.dart`): `invitedRooms`/`invitedSpaces` skip rooms whose inviter (sender of `m.room.member` state for current user) is in `client.ignoredUsers`.

## Testing

- [x] `flutter analyze` is clean
- [x] `flutter test` passes (2413 pass; 2 pre-existing golden failures in `message_bubble_golden_test.dart` that also fail on clean `origin/master` — env rendering noise, unrelated to this change)
- Added `test/widgets/message_list_view_order_test.dart`: filters events from ignored users
- Added `test/services/selection_service_test.dart`: `invitedRooms` hides invites from ignored users

No `@GenerateNiceMocks` annotations changed, so `build_runner` not required.

## Linked issues

Closes #821
Refs #525