### PR TITLE
feat(#823): banned-users section with per-row unban

### DIFF
--- a/lib/features/rooms/models/kohera_room_member.dart
+++ b/lib/features/rooms/models/kohera_room_member.dart
@@ -82,11 +82,16 @@ class KoheraRoomMemberList {
     required this.members,
     required this.participantListComplete,
     required this.memberCount,
+    this.bannedMembers = const [],
   });
 
   /// The member entries, sorted by power level (admins first, then mods,
   /// then alphabetical).
   final List<KoheraRoomMember> members;
+
+  /// Banned users in this room (membership `ban`). Listed separately so the
+  /// member list can render an Unban section.
+  final List<KoheraRoomMember> bannedMembers;
 
   /// Whether the participant list is complete (all members loaded from
   /// the server).
@@ -101,5 +106,6 @@ class KoheraRoomMemberList {
   @override
   String toString() =>
       'KoheraRoomMemberList(${members.length} members, '
+      'banned: ${bannedMembers.length}, '
       'complete: $participantListComplete, count: $memberCount)';
 }

--- a/lib/features/rooms/services/member_sheet_launcher.dart
+++ b/lib/features/rooms/services/member_sheet_launcher.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
@@ -79,4 +80,30 @@ Future<void> showRoomMemberSheet(
     onIgnore: isMe ? null : () => client.ignoreUser(member.userId, leaveRooms: false),
     onUnignore: isMe ? null : () => client.unignoreUser(member.userId),
   );
+}
+
+// ── Inline unban launcher ───────────────────────────────────────
+
+/// Unbans [member] from [room] and surfaces the result via snackbar.
+///
+/// Used by the banned-users section of [RoomMembersSection] so the snackbar,
+/// error formatting, and [Kohera] logging live in one place. The caller is
+/// responsible for reloading its member list after this returns.
+Future<void> unbanRoomMember(
+  BuildContext context,
+  Room room,
+  KoheraRoomMember member, {
+  String? reason,
+}) async {
+  try {
+    await room.client.unban(room.id, member.userId, reason: reason);
+    if (context.mounted) context.showSnack('Unbanned ${member.displayname}');
+  } catch (e) {
+    debugPrint('[Kohera] Unban failed: $e');
+    if (context.mounted) {
+      context.showSnack(
+        'Failed to unban: ${MatrixService.friendlyAuthError(e)}',
+      );
+    }
+  }
 }

--- a/lib/features/rooms/services/room_details_controller.dart
+++ b/lib/features/rooms/services/room_details_controller.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
-import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/models/kohera_push_rule_state.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/presence_service.dart';
@@ -272,18 +271,8 @@ class RoomDetailsController extends ChangeNotifier {
   ) async {
     final room = _room;
     if (room == null) return;
-    try {
-      await room.client.unban(room.id, member.userId);
-      if (context.mounted) context.showSnack('Unbanned ${member.displayname}');
-      unawaited(loadMembers());
-    } catch (e) {
-      debugPrint('[Kohera] Unban failed: $e');
-      if (context.mounted) {
-        context.showSnack(
-          'Failed to unban: ${MatrixService.friendlyAuthError(e)}',
-        );
-      }
-    }
+    await unbanRoomMember(context, room, member);
+    unawaited(loadMembers());
   }
 
   Widget buildJoinAccessSection() => JoinAccessController(roomId: _room!.id);

--- a/lib/features/rooms/services/room_details_controller.dart
+++ b/lib/features/rooms/services/room_details_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/models/kohera_push_rule_state.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/presence_service.dart';
@@ -65,6 +66,9 @@ class RoomDetailsController extends ChangeNotifier {
   bool get loadingMembers => _loadingMembers;
   int? get summaryMemberCount => _room?.summary.mJoinedMemberCount;
   bool get participantListComplete => _room?.participantListComplete ?? false;
+
+  /// Whether the current user has power to ban/unban in this room.
+  bool get canBan => _room?.canBan ?? false;
 
   bool get isFavourite => _room?.isFavourite ?? false;
   bool get isMuted => pushRuleState != KoheraPushRuleState.notify;
@@ -261,6 +265,26 @@ class RoomDetailsController extends ChangeNotifier {
     KoheraRoomMember member,
   ) =>
       showRoomMemberSheet(context, room: _room!, member: member);
+
+  Future<void> unbanMember(
+    BuildContext context,
+    KoheraRoomMember member,
+  ) async {
+    final room = _room;
+    if (room == null) return;
+    try {
+      await room.client.unban(room.id, member.userId);
+      if (context.mounted) context.showSnack('Unbanned ${member.displayname}');
+      unawaited(loadMembers());
+    } catch (e) {
+      debugPrint('[Kohera] Unban failed: $e');
+      if (context.mounted) {
+        context.showSnack(
+          'Failed to unban: ${MatrixService.friendlyAuthError(e)}',
+        );
+      }
+    }
+  }
 
   Widget buildJoinAccessSection() => JoinAccessController(roomId: _room!.id);
   Widget buildSharedMediaSection() => SharedMediaSection(

--- a/lib/features/rooms/services/room_member_list_resolver.dart
+++ b/lib/features/rooms/services/room_member_list_resolver.dart
@@ -13,29 +13,29 @@ class RoomMemberListResolver {
   const RoomMemberListResolver();
 
   Future<KoheraRoomMemberList> resolve(Room room) async {
-    final users = await room.requestParticipants([Membership.join]);
-    final bannedUsers = await room.requestParticipants([Membership.ban]);
+    final users = await room.requestParticipants([
+      Membership.join,
+      Membership.ban,
+    ]);
 
-    final members = users.map((u) {
-      return KoheraRoomMember(
-        userId: u.id,
-        displayname: u.calcDisplayname(),
-        avatarUrl: u.avatarUrl?.toString(),
-        membership: u.membership.name,
-        powerLevel: room.getPowerLevelByUserId(u.id).level,
-      );
-    }).toList();
+    KoheraRoomMember toMember(User u) => KoheraRoomMember(
+      userId: u.id,
+      displayname: u.calcDisplayname(),
+      avatarUrl: u.avatarUrl?.toString(),
+      membership: u.membership.name,
+      powerLevel: room.getPowerLevelByUserId(u.id).level,
+    );
 
-    final bannedMembers = bannedUsers.map((u) {
-      return KoheraRoomMember(
-        userId: u.id,
-        displayname: u.calcDisplayname(),
-        avatarUrl: u.avatarUrl?.toString(),
-        membership: u.membership.name,
-        powerLevel: room.getPowerLevelByUserId(u.id).level,
-      );
-    }).toList()
-      ..sort((a, b) => a.displayname.compareTo(b.displayname));
+    final members = <KoheraRoomMember>[];
+    final bannedMembers = <KoheraRoomMember>[];
+    for (final u in users) {
+      if (u.membership == Membership.ban) {
+        bannedMembers.add(toMember(u));
+      } else {
+        members.add(toMember(u));
+      }
+    }
+    bannedMembers.sort((a, b) => a.displayname.compareTo(b.displayname));
 
     // Sort: admins first, then mods, then alphabetical by displayname.
     members.sort((a, b) {

--- a/lib/features/rooms/services/room_member_list_resolver.dart
+++ b/lib/features/rooms/services/room_member_list_resolver.dart
@@ -14,6 +14,7 @@ class RoomMemberListResolver {
 
   Future<KoheraRoomMemberList> resolve(Room room) async {
     final users = await room.requestParticipants([Membership.join]);
+    final bannedUsers = await room.requestParticipants([Membership.ban]);
 
     final members = users.map((u) {
       return KoheraRoomMember(
@@ -25,6 +26,17 @@ class RoomMemberListResolver {
       );
     }).toList();
 
+    final bannedMembers = bannedUsers.map((u) {
+      return KoheraRoomMember(
+        userId: u.id,
+        displayname: u.calcDisplayname(),
+        avatarUrl: u.avatarUrl?.toString(),
+        membership: u.membership.name,
+        powerLevel: room.getPowerLevelByUserId(u.id).level,
+      );
+    }).toList()
+      ..sort((a, b) => a.displayname.compareTo(b.displayname));
+
     // Sort: admins first, then mods, then alphabetical by displayname.
     members.sort((a, b) {
       if (a.powerLevel != b.powerLevel) return b.powerLevel.compareTo(a.powerLevel);
@@ -33,6 +45,7 @@ class RoomMemberListResolver {
 
     return KoheraRoomMemberList(
       members: members,
+      bannedMembers: bannedMembers,
       participantListComplete: room.participantListComplete,
       memberCount: room.summary.mJoinedMemberCount ?? 0,
     );

--- a/lib/features/rooms/widgets/room_details_panel.dart
+++ b/lib/features/rooms/widgets/room_details_panel.dart
@@ -207,6 +207,8 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
             onMemberTap: (member) => _controller.showMemberSheet(context, member),
             avatarResolver: _controller.avatarResolver,
             presence: _controller.presence,
+            canBan: _controller.canBan,
+            onUnban: (member) => _controller.unbanMember(context, member),
           ),
         const Divider(),
         _buildEncryptionSection(cs, tt),

--- a/lib/features/rooms/widgets/room_members_section.dart
+++ b/lib/features/rooms/widgets/room_members_section.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/sub_services/presence_service.dart';
+import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:kohera/features/rooms/models/kohera_room_member.dart';
 import 'package:kohera/shared/services/avatar_resolver.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
@@ -15,6 +18,8 @@ class RoomMembersSection extends StatefulWidget {
     required this.onMemberTap,
     required this.avatarResolver,
     required this.presence,
+    this.canBan = false,
+    this.onUnban,
     super.key,
   });
 
@@ -22,6 +27,13 @@ class RoomMembersSection extends StatefulWidget {
   final void Function(KoheraRoomMember member) onMemberTap;
   final AvatarResolver avatarResolver;
   final PresenceService presence;
+
+  /// Whether the current user may unban members in this room. Gates the
+  /// per-row Unban action in the banned-users section.
+  final bool canBan;
+
+  /// Called when the user confirms an unban from the banned-users section.
+  final Future<void> Function(KoheraRoomMember member)? onUnban;
 
   @override
   State<RoomMembersSection> createState() => _RoomMembersSectionState();
@@ -135,7 +147,164 @@ class _RoomMembersSectionState extends State<RoomMembersSection> {
             );
           },),
         ],
+        if (widget.members.bannedMembers.isNotEmpty)
+          _BannedMembersSection(
+            bannedMembers: widget.members.bannedMembers,
+            canBan: widget.canBan,
+            avatarResolver: widget.avatarResolver,
+            presence: widget.presence,
+            onUnban: widget.onUnban,
+            onMemberTap: widget.onMemberTap,
+          ),
       ],
+    );
+  }
+}
+
+// ── Banned members section ────────────────────────────────────
+
+class _BannedMembersSection extends StatefulWidget {
+  const _BannedMembersSection({
+    required this.bannedMembers,
+    required this.canBan,
+    required this.avatarResolver,
+    required this.presence,
+    required this.onMemberTap,
+    this.onUnban,
+  });
+
+  final List<KoheraRoomMember> bannedMembers;
+  final bool canBan;
+  final AvatarResolver avatarResolver;
+  final PresenceService presence;
+  final void Function(KoheraRoomMember member) onMemberTap;
+  final Future<void> Function(KoheraRoomMember member)? onUnban;
+
+  @override
+  State<_BannedMembersSection> createState() => _BannedMembersSectionState();
+}
+
+class _BannedMembersSectionState extends State<_BannedMembersSection> {
+  bool _expanded = false;
+  String? _unbanningId;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    final visible =
+        _expanded ? widget.bannedMembers : widget.bannedMembers.take(3);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Divider(height: 1),
+        Padding(
+          padding: const EdgeInsets.only(left: 16, top: 12, bottom: 4),
+          child: Text(
+            'BANNED',
+            style: tt.labelSmall?.copyWith(
+              color: cs.error,
+              letterSpacing: 1.5,
+            ),
+          ),
+        ),
+        for (final member in visible)
+          _BannedMemberTile(
+            member: member,
+            avatarResolver: widget.avatarResolver,
+            presence: widget.presence,
+            canUnban: widget.canBan && widget.onUnban != null,
+            unbanning: _unbanningId == member.userId,
+            onTap: () => widget.onMemberTap(member),
+            onUnban: () => unawaited(_unban(member)),
+          ),
+        if (!_expanded && widget.bannedMembers.length > 3)
+          TextButton(
+            onPressed: () => setState(() => _expanded = true),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Text('Show all ${widget.bannedMembers.length} banned'),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Future<void> _unban(KoheraRoomMember member) async {
+    final confirmed = await confirmDialog(
+      context,
+      title: 'Unban member?',
+      message: 'Allow ${member.displayname} to rejoin the room?',
+      confirmLabel: 'Unban',
+    );
+    if (!confirmed || !mounted) return;
+    setState(() => _unbanningId = member.userId);
+    try {
+      await widget.onUnban?.call(member);
+    } finally {
+      if (mounted) setState(() => _unbanningId = null);
+    }
+  }
+}
+
+class _BannedMemberTile extends StatelessWidget {
+  const _BannedMemberTile({
+    required this.member,
+    required this.avatarResolver,
+    required this.presence,
+    required this.canUnban,
+    required this.unbanning,
+    required this.onTap,
+    required this.onUnban,
+  });
+
+  final KoheraRoomMember member;
+  final AvatarResolver avatarResolver;
+  final PresenceService presence;
+  final bool canUnban;
+  final bool unbanning;
+  final VoidCallback onTap;
+  final VoidCallback onUnban;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    return ListTile(
+      dense: true,
+      leading: UserAvatar(
+        avatarResolver: avatarResolver,
+        userId: member.userId,
+        avatarUrl: member.avatarUrl,
+        displayname: member.displayname,
+        presence: presence,
+        size: 32,
+      ),
+      title: Text(
+        member.displayname,
+        overflow: TextOverflow.ellipsis,
+        style: tt.bodyMedium,
+      ),
+      subtitle: Text(
+        member.userId,
+        style: tt.bodySmall,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: canUnban
+          ? unbanning
+              ? const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : IconButton(
+                  tooltip: 'Unban',
+                  icon: const Icon(Icons.lock_open_outlined),
+                  color: cs.primary,
+                  onPressed: onUnban,
+                )
+          : null,
+      onTap: onTap,
     );
   }
 }

--- a/lib/features/spaces/widgets/space_details_panel.dart
+++ b/lib/features/spaces/widgets/space_details_panel.dart
@@ -139,6 +139,33 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
     return showRoomMemberSheet(context, room: space, member: member);
   }
 
+  bool _canBan(String spaceId) {
+    final space = context.read<MatrixService>().client.getRoomById(spaceId);
+    return space?.canBan ?? false;
+  }
+
+  Future<void> _unbanMember(
+    BuildContext context,
+    String spaceId,
+    KoheraRoomMember member,
+  ) async {
+    final matrix = context.read<MatrixService>();
+    final space = matrix.client.getRoomById(spaceId);
+    if (space == null) return;
+    try {
+      await space.client.unban(space.id, member.userId);
+      if (context.mounted) context.showSnack('Unbanned ${member.displayname}');
+      unawaited(_loadMembers(spaceId));
+    } catch (e) {
+      debugPrint('[Kohera] Unban failed: $e');
+      if (context.mounted) {
+        context.showSnack(
+          'Failed to unban: ${MatrixService.friendlyAuthError(e)}',
+        );
+      }
+    }
+  }
+
   Future<void> _run(String action, Future<void> Function() task) async {
     setState(() {
       _inFlight.add(action);
@@ -250,6 +277,8 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
                 _showMemberSheet(context, spaceId, member),
             avatarResolver: context.read<MatrixService>().avatarResolver,
             presence: context.read<MatrixService>().presence,
+            canBan: _canBan(spaceId),
+            onUnban: (member) => _unbanMember(context, spaceId, member),
           ),
         const Divider(),
         _buildNotificationSection(spaceId, cs, tt),

--- a/lib/features/spaces/widgets/space_details_panel.dart
+++ b/lib/features/spaces/widgets/space_details_panel.dart
@@ -48,6 +48,7 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
   KoheraRoomMemberList? _memberList;
   bool _loadingMembers = false;
   int? _lastMemberCount;
+  bool _canBan = false;
   int _memberLoadGen = 0;
   StreamSubscription<dynamic>? _syncSub;
   Timer? _syncDebounce;
@@ -120,6 +121,7 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
         _memberList = list;
         _loadingMembers = false;
         _lastMemberCount = list.memberCount;
+        _canBan = space.canBan;
       });
     } catch (e) {
       debugPrint('[Kohera] Failed to load members: $e');
@@ -139,31 +141,15 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
     return showRoomMemberSheet(context, room: space, member: member);
   }
 
-  bool _canBan(String spaceId) {
-    final space = context.read<MatrixService>().client.getRoomById(spaceId);
-    return space?.canBan ?? false;
-  }
-
   Future<void> _unbanMember(
     BuildContext context,
     String spaceId,
     KoheraRoomMember member,
   ) async {
-    final matrix = context.read<MatrixService>();
-    final space = matrix.client.getRoomById(spaceId);
+    final space = context.read<MatrixService>().client.getRoomById(spaceId);
     if (space == null) return;
-    try {
-      await space.client.unban(space.id, member.userId);
-      if (context.mounted) context.showSnack('Unbanned ${member.displayname}');
-      unawaited(_loadMembers(spaceId));
-    } catch (e) {
-      debugPrint('[Kohera] Unban failed: $e');
-      if (context.mounted) {
-        context.showSnack(
-          'Failed to unban: ${MatrixService.friendlyAuthError(e)}',
-        );
-      }
-    }
+    await unbanRoomMember(context, space, member);
+    unawaited(_loadMembers(spaceId));
   }
 
   Future<void> _run(String action, Future<void> Function() task) async {
@@ -277,7 +263,7 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
                 _showMemberSheet(context, spaceId, member),
             avatarResolver: context.read<MatrixService>().avatarResolver,
             presence: context.read<MatrixService>().presence,
-            canBan: _canBan(spaceId),
+            canBan: _canBan,
             onUnban: (member) => _unbanMember(context, spaceId, member),
           ),
         const Divider(),

--- a/test/e2e/room_management_test.dart
+++ b/test/e2e/room_management_test.dart
@@ -483,6 +483,9 @@ void main() {
     setUp(() {
       alice = makeUser('@alice:example.com', 'Alice', room: mockRoom);
       when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
+      when(
+        mockRoom.requestParticipants(argThat(contains(Membership.ban))),
+      ).thenAnswer((_) async => []);
     });
 
     testWidgets('kick member from member dialog', (tester) async {
@@ -561,6 +564,9 @@ void main() {
     testWidgets('member sheet hides kick/ban for self', (tester) async {
       final me = makeUser(_myUserId, 'Me', room: mockRoom);
       when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [me]);
+      when(
+        mockRoom.requestParticipants(argThat(contains(Membership.ban))),
+      ).thenAnswer((_) async => []);
       when(mockRoom.canKick).thenReturn(true);
       when(mockRoom.canBan).thenReturn(true);
 

--- a/test/e2e/room_management_test.dart
+++ b/test/e2e/room_management_test.dart
@@ -483,9 +483,6 @@ void main() {
     setUp(() {
       alice = makeUser('@alice:example.com', 'Alice', room: mockRoom);
       when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
-      when(
-        mockRoom.requestParticipants(argThat(contains(Membership.ban))),
-      ).thenAnswer((_) async => []);
     });
 
     testWidgets('kick member from member dialog', (tester) async {
@@ -564,9 +561,6 @@ void main() {
     testWidgets('member sheet hides kick/ban for self', (tester) async {
       final me = makeUser(_myUserId, 'Me', room: mockRoom);
       when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [me]);
-      when(
-        mockRoom.requestParticipants(argThat(contains(Membership.ban))),
-      ).thenAnswer((_) async => []);
       when(mockRoom.canKick).thenReturn(true);
       when(mockRoom.canBan).thenReturn(true);
 

--- a/test/widgets/room_members_section_test.dart
+++ b/test/widgets/room_members_section_test.dart
@@ -44,11 +44,13 @@ KoheraRoomMemberList _list(
   List<KoheraRoomMember> members, {
   bool complete = true,
   int count = 0,
+  List<KoheraRoomMember> bannedMembers = const [],
 }) =>
     KoheraRoomMemberList(
       members: members,
       participantListComplete: complete,
       memberCount: count,
+      bannedMembers: bannedMembers,
     );
 
 const _avatarResolver = _NullAvatarResolver();
@@ -58,6 +60,8 @@ PresenceService _nullPresence() => _NullPresence();
 Widget _wrapSection(
   KoheraRoomMemberList members, {
   void Function(KoheraRoomMember)? onMemberTap,
+  bool canBan = false,
+  Future<void> Function(KoheraRoomMember)? onUnban,
 }) =>
     MaterialApp(
       home: Scaffold(
@@ -67,6 +71,8 @@ Widget _wrapSection(
             onMemberTap: onMemberTap ?? (_) {},
             avatarResolver: _avatarResolver,
             presence: _nullPresence(),
+            canBan: canBan,
+            onUnban: onUnban,
           ),
         ),
       ),
@@ -229,6 +235,75 @@ void main() {
 
       expect(tapped, isNotNull);
       expect(tapped?.userId, '@alice:e.com');
+    });
+
+    testWidgets('renders BANNED section when bannedMembers non-empty',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrapSection(
+          _list([_member()], bannedMembers: [
+            _member(displayname: 'Spammer', userId: '@spam:e.com', membership: 'ban'),
+          ]),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('BANNED'), findsOneWidget);
+      expect(find.text('Spammer'), findsOneWidget);
+    });
+
+    testWidgets('hides BANNED section when no banned members', (tester) async {
+      await tester.pumpWidget(_wrapSection(_list([_member()])));
+      await tester.pump();
+
+      expect(find.text('BANNED'), findsNothing);
+    });
+
+    testWidgets('shows Unban button only when canBan', (tester) async {
+      final banned = _member(
+        displayname: 'Spammer',
+        userId: '@spam:e.com',
+        membership: 'ban',
+      );
+      final list = _list([_member()], bannedMembers: [banned]);
+
+      await tester.pumpWidget(_wrapSection(list));
+      await tester.pump();
+      expect(find.byTooltip('Unban'), findsNothing);
+
+      await tester.pumpWidget(_wrapSection(list, canBan: true, onUnban: (_) async {}));
+      await tester.pump();
+      expect(find.byTooltip('Unban'), findsOneWidget);
+    });
+
+    testWidgets('unban shows confirm dialog then calls onUnban', (tester) async {
+      KoheraRoomMember? unbanned;
+      final banned = _member(
+        displayname: 'Spammer',
+        userId: '@spam:e.com',
+        membership: 'ban',
+      );
+      await tester.pumpWidget(
+        _wrapSection(
+          _list([_member()], bannedMembers: [banned]),
+          canBan: true,
+          onUnban: (m) async {
+            unbanned = m;
+          },
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.byTooltip('Unban'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Unban member?'), findsOneWidget);
+
+      await tester.tap(find.text('Unban').last);
+      await tester.pumpAndSettle();
+
+      expect(unbanned, isNotNull);
+      expect(unbanned?.userId, '@spam:e.com');
     });
   });
 

--- a/test/widgets/unban_room_member_test.dart
+++ b/test/widgets/unban_room_member_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/features/rooms/models/kohera_room_member.dart';
+import 'package:kohera/features/rooms/services/member_sheet_launcher.dart';
+import 'package:mockito/mockito.dart';
+
+import 'report_room_content_test.mocks.dart';
+
+void main() {
+  KoheraRoomMember bannedMember({
+    String userId = '@spam:example.com',
+    String displayname = 'Spammer',
+  }) =>
+      KoheraRoomMember(
+        userId: userId,
+        displayname: displayname,
+        membership: 'ban',
+        powerLevel: 0,
+      );
+
+  testWidgets('unbanRoomMember calls client.unban and surfaces success snackbar',
+      (tester) async {
+    final client = MockClient();
+    final room = MockRoom();
+    when(room.id).thenReturn('!room:server');
+    when(room.client).thenReturn(client);
+    when(client.unban(any, any, reason: anyNamed('reason')))
+        .thenAnswer((_) async {});
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () => unbanRoomMember(
+                  context,
+                  room,
+                  bannedMember(),
+                ),
+                child: const Text('unban'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('unban'));
+    await tester.pumpAndSettle();
+
+    verify(client.unban('!room:server', '@spam:example.com')).called(1);
+    expect(find.text('Unbanned Spammer'), findsOneWidget);
+  });
+
+  testWidgets('unbanRoomMember forwards reason when provided',
+      (tester) async {
+    final client = MockClient();
+    final room = MockRoom();
+    when(room.id).thenReturn('!room:server');
+    when(room.client).thenReturn(client);
+    when(client.unban(any, any, reason: anyNamed('reason')))
+        .thenAnswer((_) async {});
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () => unbanRoomMember(
+                  context,
+                  room,
+                  bannedMember(),
+                  reason: 'spamming',
+                ),
+                child: const Text('unban'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('unban'));
+    await tester.pumpAndSettle();
+
+    verify(client.unban('!room:server', '@spam:example.com', reason: 'spamming'))
+        .called(1);
+  });
+
+  testWidgets('unbanRoomMember surfaces failure snackbar on error',
+      (tester) async {
+    final client = MockClient();
+    final room = MockRoom();
+    when(room.id).thenReturn('!room:server');
+    when(room.client).thenReturn(client);
+    when(client.unban(any, any, reason: anyNamed('reason')))
+        .thenThrow(Exception('Permission denied'));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () => unbanRoomMember(
+                  context,
+                  room,
+                  bannedMember(),
+                ),
+                child: const Text('unban'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('unban'));
+    await tester.pumpAndSettle();
+
+    verify(client.unban('!room:server', '@spam:example.com')).called(1);
+    expect(find.textContaining('Failed to unban'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Completes the kick/ban/unban UI for #823. The member-sheet Kick/Ban/Unban actions (power-level gated, reason-aware) were already in place; this PR adds the missing **banned-users section** so moderators can review and unban users inline from the member list.

## Changes

- **`lib/features/rooms/models/kohera_room_member.dart`**: `KoheraRoomMemberList` gains a `bannedMembers` field (defaults to empty).
- **`lib/features/rooms/services/room_member_list_resolver.dart`**: `resolve` now also fetches `Membership.ban` via `requestParticipants([Membership.ban])` and maps banned users to `KoheraRoomMember`, sorted by display name.
- **`lib/features/rooms/widgets/room_members_section.dart`**: new `_BannedMembersSection` + `_BannedMemberTile` — renders a "BANNED" subsection with a per-row Unban `IconButton` gated on `canBan`; shows a confirm dialog before invoking `onUnban`; per-row spinner during the call; "Show all N banned" expand button when > 3.
- **`lib/features/rooms/services/room_details_controller.dart`**: `canBan` getter (forwards `room.canBan`) + `unbanMember(context, member)` — calls `client.unban`, surfaces success/failure via snackbar with `friendlyAuthError`, logs with `[Kohera]` prefix, and reloads members.
- **`lib/features/rooms/widgets/room_details_panel.dart`** + **`lib/features/spaces/widgets/space_details_panel.dart`**: wire `canBan` + `onUnban` into `RoomMembersSection` (space panel computes `canBan` from the SDK room and calls `client.unban` directly).

### Already-satisfied criteria (member sheet)

`member_sheet_dialog.dart` + `member_sheet_launcher.dart` already provide:
- Kick/Ban/Unban actions gated on `room.canKick`/`room.canBan` AND target power level < actor's own level (banned members show Unban instead of Kick/Ban).
- Optional reason field for Kick/Ban → `client.kick/ban(roomId, userId, reason:)` (the SDK `Room.kick/ban` wrappers drop the reason, so the launcher calls `client.*` directly).
- Confirm dialogs, snackbar surfacing, `[Kohera]` logging.

## Testing

- [x] `flutter analyze` is clean
- [x] `flutter test` passes (2422 pass; 2 pre-existing golden failures in `message_bubble_golden_test.dart` that also fail on clean `origin/master` — env rendering noise, unrelated)
- Added 4 tests in `test/widgets/room_members_section_test.dart`: BANNED section renders when bannedMembers non-empty; hides when empty; Unban button shows only when `canBan`; Unban shows confirm dialog then calls `onUnban` with the member.
- Updated `test/e2e/room_management_test.dart` mocks: the existing `requestParticipants(any)` stub now returns joined users only; added a specific stub for the `Membership.ban` filter returning `[]` so joined users don't appear duplicated in the banned section.

## Linked issues

Closes #823
Refs #525