### PR TITLE
fix(#352): clear MatrixRTC membership on declineCall

### DIFF
--- a/lib/features/calling/services/call_service.dart
+++ b/lib/features/calling/services/call_service.dart
@@ -697,6 +697,18 @@ class CallService extends ChangeNotifier with WidgetsBindingObserver {
   void declineCall() {
     if (_callState != KoheraCallState.ringingIncoming) return;
 
+    // Capture roomId before resetIncomingCall() clears it.
+    final roomId = _ringing.incomingCall?.roomId;
+    if (roomId != null) {
+      unawaited(
+        _rtcMembership.removeMembershipEvent(roomId).catchError(
+          (Object e) => debugPrint(
+            '[Kohera] Failed to remove ring-phase membership on decline: $e',
+          ),
+        ),
+      );
+    }
+
     _ringing.stopRinging();
     _ringing.resetIncomingCall();
     _incomingCallerStateKey = null;

--- a/test/services/call_service_test.dart
+++ b/test/services/call_service_test.dart
@@ -549,9 +549,29 @@ void main() {
   });
 
   group('ringing actions', () {
-    test('declineCall resets state', () {
+    test('declineCall removes RTC membership and resets state', () {
+      setupMockRoom();
+      when(mockClient.setRoomStateWithKey(any, any, any, any))
+          .thenAnswer((_) async => 'event_id');
+
+      service.handlePushCallInvite(
+        roomId: '!room:example.com',
+        callId: 'call1',
+        callerName: 'Alice',
+        isVideo: false,
+        callKitAlreadyShown: true,
+      );
+      expect(service.callState, KoheraCallState.ringingIncoming);
+
       service.declineCall();
+
       expect(service.callState, KoheraCallState.idle);
+      verify(mockClient.setRoomStateWithKey(
+        '!room:example.com',
+        'org.matrix.msc3401.call.member',
+        any,
+        {},
+      )).called(1);
     });
 
     test('cancelOutgoingCall resets state', () {


### PR DESCRIPTION
## Summary

`declineCall()` resets local ringing state but never removed the callee's `m.call.member` state event, so the caller kept ringing until the ~30s `ringPhase` expiry instead of seeing an immediate hangup.

## Changes

- Capture `roomId` from `_ringing.incomingCall` before `resetIncomingCall()` clears it
- Call `_rtcMembership.removeMembershipEvent(roomId)` before transitioning to idle — mirroring `cancelOutgoingCall()`

## Tests

- Updated `declineCall` test to set up ringing state via `handlePushCallInvite` and verify `setRoomStateWithKey` is called with the incoming roomId and `org.matrix.msc3401.call.member` event type.

Closes #352