### PR TITLE
fix(#287): retry auto-unlock backup on subsequent syncs

### DIFF
--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -65,6 +65,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
       onPostSyncBackup: () async {
         await chatBackup.tryAutoUnlockBackup();
       },
+      shouldRetryBackup: () => chatBackup.chatBackupNeeded != false,
     );
     auth = AuthService(
       client: _client,

--- a/lib/core/services/sub_services/sync_service.dart
+++ b/lib/core/services/sub_services/sync_service.dart
@@ -7,11 +7,17 @@ class SyncService extends ChangeNotifier {
   SyncService({
     required Client client,
     required Future<void> Function() onPostSyncBackup,
+    bool Function()? shouldRetryBackup,
+    Duration retryDebounce = const Duration(seconds: 5),
   })  : _client = client,
-        _onPostSyncBackup = onPostSyncBackup;
+        _onPostSyncBackup = onPostSyncBackup,
+        _shouldRetryBackup = shouldRetryBackup,
+        _retryDebounceDuration = retryDebounce;
 
   final Client _client;
   final Future<void> Function() _onPostSyncBackup;
+  final bool Function()? _shouldRetryBackup;
+  final Duration _retryDebounceDuration;
 
   // ── Sync ─────────────────────────────────────────────────────
   bool _syncing = false;
@@ -21,11 +27,13 @@ class SyncService extends ChangeNotifier {
   String? get autoUnlockError => _autoUnlockError;
 
   StreamSubscription<SyncUpdate>? _syncSub;
+  Timer? _retryDebounce;
   bool _disposed = false;
 
   @override
   void dispose() {
     _disposed = true;
+    _retryDebounce?.cancel();
     super.dispose();
   }
 
@@ -38,6 +46,7 @@ class SyncService extends ChangeNotifier {
     unawaited(_syncSub?.cancel());
     _syncSub = _client.onSync.stream.listen((_) {
       if (!firstSync.isCompleted) firstSync.complete();
+      _maybeRetryBackup();
     });
 
     unawaited(firstSync.future.then((_) {
@@ -61,6 +70,25 @@ class SyncService extends ChangeNotifier {
     } else {
       await firstSync.future;
     }
+  }
+
+  /// Retry auto-unlock backup on subsequent syncs, debounced, when the
+  /// [shouldRetryBackup] predicate says the backup is still needed.
+  /// Stops retrying once the predicate returns false.
+  void _maybeRetryBackup() {
+    final check = _shouldRetryBackup;
+    if (check == null || !check()) return;
+
+    _retryDebounce?.cancel();
+    _retryDebounce = Timer(_retryDebounceDuration, () {
+      if (_disposed) return;
+      if (!check()) return;
+      unawaited(
+        _onPostSyncBackup().catchError((Object e) {
+          debugPrint('[Kohera] Background E2EE auto-unlock retry error: $e');
+        }),
+      );
+    });
   }
 
   Future<void> pause() async {

--- a/test/services/sync_service_test.dart
+++ b/test/services/sync_service_test.dart
@@ -95,6 +95,90 @@ void main() {
     });
   });
 
+  group('retry auto-unlock backup', () {
+    late int retryCount;
+    late SyncService retryService;
+
+    setUp(() {
+      retryCount = 0;
+      retryService = SyncService(
+        client: mockClient,
+        onPostSyncBackup: () async {
+          retryCount++;
+        },
+        shouldRetryBackup: () => true,
+        retryDebounce: const Duration(milliseconds: 100),
+      );
+    });
+
+    tearDown(() => retryService.dispose());
+
+    test('retries on subsequent syncs when backup still needed', () async {
+      Future<void>.delayed(
+        Duration.zero,
+        () => syncController.add(SyncUpdate(nextBatch: 'b1')),
+      );
+
+      await retryService.startSync();
+      await Future<void>.delayed(Duration.zero);
+      expect(retryCount, 1);
+
+      // Simulate a second sync — should trigger a retry after debounce.
+      syncController.add(SyncUpdate(nextBatch: 'b2'));
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(retryCount, 2);
+    });
+
+    test('does not retry when shouldRetryBackup returns false', () async {
+      const backupNeeded = false;
+      final noRetryService = SyncService(
+        client: mockClient,
+        onPostSyncBackup: () async {
+          retryCount++;
+        },
+        shouldRetryBackup: () => backupNeeded,
+        retryDebounce: const Duration(milliseconds: 100),
+      );
+
+      Future<void>.delayed(
+        Duration.zero,
+        () => syncController.add(SyncUpdate(nextBatch: 'b1')),
+      );
+
+      await noRetryService.startSync();
+      await Future<void>.delayed(Duration.zero);
+      expect(retryCount, 1);
+
+      syncController.add(SyncUpdate(nextBatch: 'b2'));
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(retryCount, 1);
+      noRetryService.dispose();
+    });
+
+    test('debounces rapid syncs into one retry', () async {
+      Future<void>.delayed(
+        Duration.zero,
+        () => syncController.add(SyncUpdate(nextBatch: 'b1')),
+      );
+
+      await retryService.startSync();
+      await Future<void>.delayed(Duration.zero);
+      expect(retryCount, 1);
+
+      // Fire several syncs in quick succession.
+      syncController.add(SyncUpdate(nextBatch: 'b2'));
+      syncController.add(SyncUpdate(nextBatch: 'b3'));
+      syncController.add(SyncUpdate(nextBatch: 'b4'));
+
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      // Only one retry should have happened despite 3 syncs.
+      expect(retryCount, 2);
+    });
+  });
+
   group('cancelSyncSub', () {
     test('cancels the sync subscription', () async {
       Future<void>.delayed(


### PR DESCRIPTION
## Summary

Previously `tryAutoUnlockBackup()` was called only once after the first sync. If it failed (server unreachable, peer key request unanswered, transient error), the user was left with undecrypted messages until the next app restart.

Now the sync listener retries `tryAutoUnlockBackup()` on subsequent syncs, debounced (5s default), stopping once `chatBackupNeeded == false`.

## Changes

- `SyncService` — added `shouldRetryBackup` predicate and `retryDebounce` duration params; sync listener now calls `_maybeRetryBackup()` on each sync event
- `MatrixService` — wires `shouldRetryBackup: () => chatBackup.chatBackupNeeded != false`
- Tests — 3 new tests covering retry-on-subsequent-sync, no-retry-when-not-needed, and debounce behavior

Closes #287