### PR TITLE
fix(#755): gate LaTeX markdown parsing behind enableLatexMarkdown flag

### DIFF
--- a/lib/core/services/client_factory_shared.dart
+++ b/lib/core/services/client_factory_shared.dart
@@ -29,6 +29,7 @@ Client buildClient(
       KeyVerificationMethod.qrScan,
     },
     enableDehydratedDevices: true,
+    enableLatexMarkdown: false,
     nativeImplementations: nativeImplementations,
   );
   client.roomPreviewLastEvents.removeAll(callPreviewTypes);


### PR DESCRIPTION
## Summary

Set `enableLatexMarkdown: false` on the Matrix client. Kohera does not render LaTeX in messages (no KaTeX/MathJax integration), so the default SDK behaviour of always-on LaTeX parsing adds unnecessary overhead when converting markdown message bodies to HTML.

## Changes

- `client_factory_shared.dart` — added `enableLatexMarkdown: false` to the `Client` constructor

## Context

The matrix-dart-sdk v7.1.0 added the `enableLatexMarkdown` flag (default `true`). The SDK's `Room` passes `enableLatex: client.enableLatexMarkdown` to `markdownToHtml()` when converting markdown message bodies to HTML for `formatted_body`. Disabling it avoids registering LaTeX block/inline syntaxes in the markdown parser for every message.

If LaTeX rendering is added in the future, flip this back to `true`.

Closes #755