### PR TITLE
feat(#815): BubbleVibeResolver + persisted vibe pref (foundation)

### DIFF
--- a/lib/core/services/preferences_service.dart
+++ b/lib/core/services/preferences_service.dart
@@ -102,6 +102,7 @@ class PreferencesService extends ChangeNotifier {
   static const _lastSeenVersionKey = 'last_seen_version';
   static const _lastDismissedUpdateKey = 'last_dismissed_update';
   static const _skinToneKey = 'emoji_skin_tone';
+  static const _bubbleVibeKey = 'bubble_vibe';
 
   /// Initialise the underlying [SharedPreferences] instance.
   /// Must be called (and awaited) before reading any values.
@@ -167,6 +168,22 @@ class PreferencesService extends ChangeNotifier {
   Future<void> setTimelineStyle(TimelineStyle style) async {
     await _prefs?.setString(_timelineStyleKey, style.name);
     debugPrint('[Kohera] Timeline style set to ${style.name}');
+    notifyListeners();
+  }
+
+  // ── Bubble vibe (retro ↔ modern) ──────────────────────────
+
+  /// Current bubble vibe. 0.0 = retro (pixel), 1.0 = modern (rounded soft
+  /// shadow). Default 0.0 produces no visual change.
+  double get bubbleVibe {
+    final stored = _prefs?.getDouble(_bubbleVibeKey);
+    return stored ?? 0.0;
+  }
+
+  Future<void> setBubbleVibe(double value) async {
+    final clamped = value.clamp(0.0, 1.0);
+    await _prefs?.setDouble(_bubbleVibeKey, clamped);
+    debugPrint('[Kohera] Bubble vibe set to $clamped');
     notifyListeners();
   }
 

--- a/lib/core/theme/bubble_vibe_resolver.dart
+++ b/lib/core/theme/bubble_vibe_resolver.dart
@@ -1,0 +1,92 @@
+import 'dart:ui' show lerpDouble;
+
+import 'package:flutter/material.dart';
+import 'package:kohera/core/theme/kohera_palette.dart';
+
+/// Effective bubble tokens after interpolating between the retro (vibe=0)
+/// and modern (vibe=1) endpoints.
+///
+/// At `vibe = 0.0` the values are bit-identical to the raw [KoheraPalette]
+/// tokens, so existing themes and goldens are unaffected.
+class EffectiveBubbleTokens {
+  const EffectiveBubbleTokens({
+    required this.radius,
+    required this.borderWidth,
+    required this.borderColor,
+    required this.shadowOffset,
+    required this.shadowBlur,
+    required this.shadowColor,
+    required this.highlightAlpha,
+  });
+
+  /// Corner radius for the bubble.
+  final double radius;
+
+  /// Border line width.
+  final double borderWidth;
+
+  /// Border color.
+  final Color borderColor;
+
+  /// Shadow displacement (already a full [Offset]).
+  final Offset shadowOffset;
+
+  /// Gaussian blur radius for the shadow (0 = hard offset shadow).
+  final double shadowBlur;
+
+  /// Shadow color.
+  final Color shadowColor;
+
+  /// Alpha for an optional top-edge highlight (bevel). 0 = none.
+  final double highlightAlpha;
+
+  @override
+  String toString() =>
+      'EffectiveBubbleTokens(radius=$radius, borderWidth=$borderWidth, '
+      'borderColor=$borderColor, shadowOffset=$shadowOffset, '
+      'shadowBlur=$shadowBlur, shadowColor=$shadowColor, '
+      'highlightAlpha=$highlightAlpha)';
+}
+
+/// Resolves effective bubble tokens by interpolating between the current
+/// pixel-retro palette (vibe = 0) and a rounded soft-shadow modern look
+/// (vibe = 1).
+///
+/// The palette's own identity colours (bubble fill, text) are never changed —
+/// only shape and shadow morph.
+class BubbleVibeResolver {
+  /// Modern endpoint constants.
+  static const modernRadius = 16.0;
+  static const modernBorderWidth = 0.0;
+  static const modernShadowBlur = 12.0;
+  static const modernShadowOffset = 0.0;
+  static const modernHighlightAlpha = 0.0;
+
+  /// Resolve [EffectiveBubbleTokens] for [palette] at [vibe] (0.0–1.0).
+  ///
+  /// At `vibe = 0.0` the result matches `palette` tokens exactly.
+  static EffectiveBubbleTokens resolve(
+    KoheraPalette palette,
+    double vibe,
+  ) {
+    final clamped = vibe.clamp(0.0, 1.0);
+
+    return EffectiveBubbleTokens(
+      radius: lerpDouble(palette.radius, modernRadius, clamped)!,
+      borderWidth: lerpDouble(palette.borderWidth, modernBorderWidth, clamped)!,
+      borderColor:
+          Color.lerp(palette.borderStrong, Colors.transparent, clamped)!,
+      shadowOffset: Offset(
+        lerpDouble(palette.shadowOffset, modernShadowOffset, clamped)!,
+        lerpDouble(palette.shadowOffset, modernShadowOffset, clamped)!,
+      ),
+      shadowBlur: lerpDouble(0.0, modernShadowBlur, clamped)!,
+      shadowColor: Color.lerp(
+        palette.shadowHard,
+        palette.shadowHard.withValues(alpha: 0.3),
+        clamped,
+      )!,
+      highlightAlpha: lerpDouble(0.0, modernHighlightAlpha, clamped)!,
+    );
+  }
+}

--- a/test/core/theme/bubble_vibe_resolver_test.dart
+++ b/test/core/theme/bubble_vibe_resolver_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/theme/bubble_vibe_resolver.dart';
+import 'package:kohera/core/theme/kohera_palette.dart';
+
+/// A minimal PICO-8-like palette for testing.
+KoheraPalette _testPalette() => const KoheraPalette(
+      borderStrong: Color(0xFF000000),
+      borderWidth: 2,
+      shadowHard: Color(0xFF7E2553),
+      shadowOffset: 3,
+      radius: 0,
+      online: Colors.green,
+      idle: Colors.amber,
+      unread: Colors.red,
+      onUnread: Colors.white,
+      mention: Colors.orange,
+      link: Colors.blue,
+      ownBubble: Color(0xFF0B2B3F),
+      onOwnBubble: Colors.white,
+      otherBubble: Color(0xFF0E1638),
+      onOtherBubble: Colors.white,
+      success: Colors.green,
+      warning: Colors.amber,
+      danger: Colors.red,
+      scanline: Colors.black12,
+      dither: Colors.black12,
+      accentRamp: [Colors.blue],
+    );
+
+void main() {
+  group('BubbleVibeResolver', () {
+    test('vibe 0.0 matches palette tokens exactly (retro)', () {
+      final palette = _testPalette();
+      final eff = BubbleVibeResolver.resolve(palette, 0);
+
+      expect(eff.radius, palette.radius);
+      expect(eff.borderWidth, palette.borderWidth);
+      expect(eff.borderColor, palette.borderStrong);
+      expect(eff.shadowOffset,
+          Offset(palette.shadowOffset, palette.shadowOffset));
+      expect(eff.shadowBlur, 0);
+      expect(eff.shadowColor, palette.shadowHard);
+      expect(eff.highlightAlpha, 0);
+    });
+
+    test('vibe 1.0 produces modern endpoint values', () {
+      final palette = _testPalette();
+      final eff = BubbleVibeResolver.resolve(palette, 1);
+
+      expect(eff.radius, BubbleVibeResolver.modernRadius);
+      expect(eff.borderWidth, BubbleVibeResolver.modernBorderWidth);
+      expect(eff.borderColor, Colors.transparent);
+      expect(eff.shadowOffset, Offset.zero);
+      expect(eff.shadowBlur, BubbleVibeResolver.modernShadowBlur);
+      expect(eff.shadowColor,
+          palette.shadowHard.withValues(alpha: 0.3));
+      expect(eff.highlightAlpha, BubbleVibeResolver.modernHighlightAlpha);
+    });
+
+    test('vibe 0.5 interpolates midway between retro and modern', () {
+      final palette = _testPalette();
+      final eff = BubbleVibeResolver.resolve(palette, 0.5);
+
+      // Midpoint of radius 0 and 16 = 8
+      expect(eff.radius, closeTo(8, 0.01));
+      // Midpoint of borderWidth 2 and 0 = 1
+      expect(eff.borderWidth, closeTo(1, 0.01));
+      // Midpoint of shadowBlur 0 and 12 = 6
+      expect(eff.shadowBlur, closeTo(6, 0.01));
+    });
+
+    test('clamps vibe below 0.0 to 0.0', () {
+      final palette = _testPalette();
+      final eff = BubbleVibeResolver.resolve(palette, -1);
+
+      expect(eff.radius, palette.radius);
+      expect(eff.shadowBlur, 0);
+    });
+
+    test('clamps vibe above 1.0 to 1.0', () {
+      final palette = _testPalette();
+      final eff = BubbleVibeResolver.resolve(palette, 2);
+
+      expect(eff.radius, BubbleVibeResolver.modernRadius);
+      expect(eff.shadowBlur, BubbleVibeResolver.modernShadowBlur);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Foundation slice for the Bubble vibe slider epic (#814). Adds a pure `BubbleVibeResolver` that interpolates bubble shape/shadow tokens between the current pixel-retro look (vibe=0) and a rounded soft-shadow modern look (vibe=1).

At `vibe = 0.0` the output is bit-identical to the raw `KoheraPalette` tokens, so existing themes and goldens stay safe.

## Changes

- **New `lib/core/theme/bubble_vibe_resolver.dart`** — `EffectiveBubbleTokens` immutable record (radius, borderWidth, borderColor, shadowOffset, shadowBlur, shadowColor, highlightAlpha) + `BubbleVibeResolver.resolve(palette, vibe)` static method with linear interpolation
- **`PreferencesService`** — added `bubbleVibe` getter (double, default 0.0) + `setBubbleVibe()` with SharedPreferences persistence
- **Tests** — 5 tests covering vibe=0 (bit-identical), vibe=1 (modern endpoints), vibe=0.5 (midpoint), and clamping

## Endpoint values

| Token | Retro (vibe=0) | Modern (vibe=1) |
|-------|----------------|-----------------|
| radius | palette.radius (0) | 16.0 |
| borderWidth | palette.borderWidth (2) | 0.0 |
| borderColor | palette.borderStrong | transparent |
| shadowOffset | (offset, offset) | (0, 0) |
| shadowBlur | 0.0 | 12.0 |
| shadowColor | palette.shadowHard | shadowHard @ 30% alpha |
| highlightAlpha | 0.0 | 0.0 (future bevel slot) |

Closes #815 — unblocks #816 (route MessageBubbleSkin through resolver) and #817 (settings vibe slider UI)