### PR TITLE
feat: join any room or space by address (alias, room ID, or matrix.to link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Kohera is a retro-pixel Matrix chat client — coherent threads for encrypted me
 - Discord/Slack-style vertical space rail
 - Create, edit, and manage spaces
 - Room creation, DM creation, and invite flows
+- Join any room or space by address (alias, room ID, or matrix.to link)
 - Room details panel with member list and shared media
 - Room admin controls
 

--- a/lib/core/utils/matrix_address_parser.dart
+++ b/lib/core/utils/matrix_address_parser.dart
@@ -1,0 +1,93 @@
+/// Utilities for parsing a user-entered Matrix room address.
+library;
+
+/// A parsed Matrix room address: a room ID or alias plus optional via servers.
+///
+/// [address] is always a room ID (`!id:server`) or alias (`#alias:server`).
+/// [via] is extracted from `?via=` query parameters on `matrix.to` links.
+class ParsedMatrixAddress {
+  const ParsedMatrixAddress({required this.address, this.via});
+
+  /// The room ID (`!id:server`) or alias (`#alias:server`) to join.
+  final String address;
+
+  /// Via server names to use when joining (from `?via=` params), if any.
+  final List<String>? via;
+}
+
+/// Parses a raw user-entered Matrix address into a [ParsedMatrixAddress].
+///
+/// Accepts:
+/// - A room alias: `#alias:server.org`
+/// - A room ID: `!id:server.org`
+/// - A `matrix.to` link: `https://matrix.to/#/#alias:server.org?via=s1&via=s2`
+///   or `https://matrix.to/#/!id:server.org/$eventId`
+///
+/// Returns `null` if [input] is empty or not a recognised room/space address.
+/// User identifiers (`@user:server`) are rejected — only rooms and spaces.
+ParsedMatrixAddress? parseMatrixAddress(String input) {
+  final trimmed = input.trim();
+  if (trimmed.isEmpty) return null;
+
+  // Strip the matrix.to prefix, leaving the identifier (and any query/path).
+  var body = trimmed;
+  if (trimmed.startsWith('https://matrix.to/#/') ||
+      trimmed.startsWith('http://matrix.to/#/')) {
+    body = trimmed.substring(trimmed.indexOf('#/') + 2);
+  }
+
+  // Split off a query string (via params) — only meaningful for matrix.to links.
+  String? query;
+  final q = body.indexOf('?');
+  if (q >= 0) {
+    query = body.substring(q + 1);
+    body = body.substring(0, q);
+  }
+
+  // Strip an event-id path segment if present (e.g. "!room:server/$eventId").
+  final slash = body.indexOf('/');
+  if (slash >= 0) {
+    body = body.substring(0, slash);
+  }
+
+  final identifier = Uri.decodeComponent(body);
+  if (!_isRoomIdOrAlias(identifier)) return null;
+
+  List<String>? via;
+  if (query != null && query.isNotEmpty) {
+    final extracted = _extractVia(query);
+    via = extracted.isEmpty ? null : extracted;
+  }
+  return ParsedMatrixAddress(address: identifier, via: via);
+}
+
+/// Whether [s] looks like a Matrix room ID (`!…:server`) or alias (`#…:server`).
+bool _isRoomIdOrAlias(String s) {
+  if (s.length < 3) return false;
+  final sigil = s[0];
+  if (sigil != '#' && sigil != '!') return false;
+  final colon = s.indexOf(':');
+  if (colon <= 1) return false; // need a localpart and a server part
+  return _idCharRegex.hasMatch(s);
+}
+
+// Room ID/alias localpart + server. Permissive but rejects whitespace, sigils
+// in the middle, and query/fragment characters. The SDK performs the real
+// validation when joining.
+final _idCharRegex = RegExp(r'^[#!][A-Za-z0-9._=\-+/]+:[A-Za-z0-9.:\-]+$');
+
+/// Extracts all `via=…` values from a query string, preserving order and
+/// repeated keys (`?via=s1&via=s2` → `['s1', 's2']`).
+List<String> _extractVia(String queryString) {
+  final result = <String>[];
+  for (final pair in queryString.split('&')) {
+    final eq = pair.indexOf('=');
+    if (eq < 0) continue;
+    final key = pair.substring(0, eq);
+    final value = pair.substring(eq + 1);
+    if (key == 'via' && value.isNotEmpty) {
+      result.add(Uri.decodeComponent(value));
+    }
+  }
+  return result;
+}

--- a/lib/features/rooms/widgets/room_list.dart
+++ b/lib/features/rooms/widgets/room_list.dart
@@ -530,6 +530,20 @@ class _RoomListState extends State<RoomList> with TickerProviderStateMixin {
                               );
                             },
                           ),
+                          const SizedBox(height: 8),
+                          SpeedDialItem(
+                            label: 'Join with address',
+                            icon: Icons.tag_rounded,
+                            onTap: () {
+                              _closeFab();
+                              unawaited(
+                                JoinWithAddressDialog.show(
+                                  context,
+                                  matrixService: matrix,
+                                ),
+                              );
+                            },
+                          ),
                         ],
                       ),
                     ),

--- a/lib/features/spaces/services/space_menu_actions.dart
+++ b/lib/features/spaces/services/space_menu_actions.dart
@@ -285,16 +285,31 @@ class SpaceMenuActions {
     return roomId;
   }
 
-  /// Joins a space by address (room ID or alias).
-  /// Returns the joined room ID, or null if the room is not a space.
-  Future<String?> joinSpace(String address) async {
+  /// Joins a room or space by address (room ID or alias), with optional via
+  /// servers (e.g. extracted from a `matrix.to` link).
+  ///
+  /// Returns the joined room ID and whether the room is a space.
+  Future<JoinByAddressResult> joinByAddress(
+    String address, {
+    List<String>? via,
+  }) async {
     final client = _matrix.client;
-    final roomId = await client.joinRoom(address);
+    final roomId = await client.joinRoom(address, via: via);
     await client
         .waitForRoomInSync(roomId, join: true)
         .timeout(const Duration(seconds: 30));
     final room = client.getRoomById(roomId);
-    return (room != null && room.isSpace) ? roomId : null;
+    return JoinByAddressResult(
+      roomId: roomId,
+      isSpace: room?.isSpace ?? false,
+    );
+  }
+
+  /// Joins a space by address (room ID or alias).
+  /// Returns the joined room ID, or null if the room is not a space.
+  Future<String?> joinSpace(String address) async {
+    final result = await joinByAddress(address);
+    return result.isSpace ? result.roomId : null;
   }
 
   /// Whether [e] is a Matrix `M_FORBIDDEN` exception.
@@ -331,4 +346,15 @@ class SpaceMenuActions {
       KoheraPushRuleState.dontNotify => PushRuleState.dontNotify,
     };
   }
+}
+
+/// Result of joining a room by address.
+class JoinByAddressResult {
+  const JoinByAddressResult({required this.roomId, required this.isSpace});
+
+  /// The joined room ID.
+  final String roomId;
+
+  /// Whether the joined room is a space.
+  final bool isSpace;
 }

--- a/lib/features/spaces/widgets/space_action_dialog.dart
+++ b/lib/features/spaces/widgets/space_action_dialog.dart
@@ -1,10 +1,13 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart' hide Visibility;
+import 'package:go_router/go_router.dart';
+import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/utils/confirm_dialog.dart';
+import 'package:kohera/core/utils/matrix_address_parser.dart';
 import 'package:kohera/features/home/screens/home_shell.dart';
 import 'package:kohera/features/spaces/services/space_discovery_data_source.dart';
 import 'package:kohera/features/spaces/services/space_menu_actions.dart';
@@ -52,7 +55,7 @@ Future<void> runSpaceAction(BuildContext context, SpaceAction action) async {
     case SpaceAction.create:
       await CreateSpaceDialog.show(context, matrixService: matrix);
     case SpaceAction.join:
-      await JoinSpaceDialog.show(context, matrixService: matrix);
+      await JoinWithAddressDialog.show(context, matrixService: matrix);
     case SpaceAction.discover:
       await SpaceDiscoveryDialog.show(context, matrixService: matrix);
   }
@@ -257,10 +260,13 @@ class _CreateSpaceDialogState extends State<CreateSpaceDialog> {
   }
 }
 
-// ── Join Space dialog ───────────────────────────────────────────
+// ── Join with address dialog ────────────────────────────────────
 
-class JoinSpaceDialog extends StatefulWidget {
-  const JoinSpaceDialog._({required this.matrixService});
+/// A dialog that joins any room or space by address (room ID, alias, or
+/// `matrix.to` link). After joining it routes to the space rail if the result
+/// is a space, or to the room screen if it is a regular room.
+class JoinWithAddressDialog extends StatefulWidget {
+  const JoinWithAddressDialog._({required this.matrixService});
 
   final MatrixService matrixService;
 
@@ -270,15 +276,15 @@ class JoinSpaceDialog extends StatefulWidget {
   }) {
     return showDialog(
       context: context,
-      builder: (_) => JoinSpaceDialog._(matrixService: matrixService),
+      builder: (_) => JoinWithAddressDialog._(matrixService: matrixService),
     );
   }
 
   @override
-  State<JoinSpaceDialog> createState() => _JoinSpaceDialogState();
+  State<JoinWithAddressDialog> createState() => _JoinWithAddressDialogState();
 }
 
-class _JoinSpaceDialogState extends State<JoinSpaceDialog> {
+class _JoinWithAddressDialogState extends State<JoinWithAddressDialog> {
   final _addressController = TextEditingController();
   bool _loading = false;
   String? _addressError;
@@ -291,10 +297,20 @@ class _JoinSpaceDialogState extends State<JoinSpaceDialog> {
   }
 
   Future<void> _submit() async {
-    final address = _addressController.text.trim();
-    if (address.isEmpty) {
+    final raw = _addressController.text.trim();
+    if (raw.isEmpty) {
       setState(() {
         _addressError = 'Address is required';
+        _networkError = null;
+      });
+      return;
+    }
+
+    final parsed = parseMatrixAddress(raw);
+    if (parsed == null) {
+      setState(() {
+        _addressError =
+            'Enter a room alias (#alias:server), room ID (!id:server), or matrix.to link';
         _networkError = null;
       });
       return;
@@ -308,13 +324,29 @@ class _JoinSpaceDialogState extends State<JoinSpaceDialog> {
 
     try {
       final actions = SpaceMenuActions(widget.matrixService);
-      final roomId = await actions.joinSpace(address);
+      final result = await actions.joinByAddress(
+        parsed.address,
+        via: parsed.via,
+      );
 
       if (!mounted) return;
-      if (roomId != null) {
-        context.read<SelectionService>().selectSpace(roomId);
+      final selection = context.read<SelectionService>();
+      if (result.isSpace) {
+        selection.selectSpace(result.roomId);
+      } else {
+        selection.selectRoom(result.roomId);
       }
+
+      // Pop the dialog, then navigate (for regular rooms). Spaces only need
+      // the selection update above; the room list reacts to selectedSpaceIds.
+      final router = GoRouter.of(context);
       Navigator.pop(context);
+      if (!result.isSpace) {
+        router.goNamed(
+          Routes.room,
+          pathParameters: {RouteParams.roomId: result.roomId},
+        );
+      }
     } catch (e) {
       if (!mounted) return;
       setState(() => _networkError = MatrixService.friendlyAuthError(e));
@@ -328,7 +360,7 @@ class _JoinSpaceDialogState extends State<JoinSpaceDialog> {
     final cs = Theme.of(context).colorScheme;
 
     return SimpleDialog(
-      title: const Text('Join Space'),
+      title: const Text('Join with address'),
       contentPadding: const EdgeInsets.fromLTRB(24, 20, 24, 16),
       children: [
         ConstrainedBox(
@@ -342,8 +374,9 @@ class _JoinSpaceDialogState extends State<JoinSpaceDialog> {
                 autofocus: true,
                 enabled: !_loading,
                 decoration: InputDecoration(
-                  labelText: 'Space address',
+                  labelText: 'Room or space address',
                   hintText: '#space:example.com',
+                  helperText: 'Alias, room ID, or matrix.to link',
                   border: const OutlineInputBorder(),
                   errorText: _addressError,
                 ),

--- a/test/utils/matrix_address_parser_test.dart
+++ b/test/utils/matrix_address_parser_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/utils/matrix_address_parser.dart';
+
+void main() {
+  group('parseMatrixAddress', () {
+    test('parses a room alias', () {
+      final result = parseMatrixAddress('#general:example.com');
+      expect(result, isNotNull);
+      expect(result!.address, '#general:example.com');
+      expect(result.via, isNull);
+    });
+
+    test('parses a room ID', () {
+      final result = parseMatrixAddress('!abc123:example.com');
+      expect(result, isNotNull);
+      expect(result!.address, '!abc123:example.com');
+      expect(result.via, isNull);
+    });
+
+    test('parses a matrix.to link with an alias', () {
+      final result = parseMatrixAddress('https://matrix.to/#/#space:example.com');
+      expect(result, isNotNull);
+      expect(result!.address, '#space:example.com');
+      expect(result.via, isNull);
+    });
+
+    test('parses a matrix.to link with a room ID', () {
+      final result = parseMatrixAddress('https://matrix.to/#/!room:example.com');
+      expect(result, isNotNull);
+      expect(result!.address, '!room:example.com');
+    });
+
+    test('extracts multiple via servers from a matrix.to link', () {
+      final result = parseMatrixAddress(
+        'https://matrix.to/#/#room:example.com?via=s1.org&via=s2.org',
+      );
+      expect(result, isNotNull);
+      expect(result!.address, '#room:example.com');
+      expect(result.via, ['s1.org', 's2.org']);
+    });
+
+    test('extracts a single via server', () {
+      final result = parseMatrixAddress(
+        'https://matrix.to/#/!room:example.com?via=via.example.org',
+      );
+      expect(result, isNotNull);
+      expect(result!.address, '!room:example.com');
+      expect(result.via, ['via.example.org']);
+    });
+
+    test('strips an event-id path segment from a matrix.to link', () {
+      final result = parseMatrixAddress(
+        r'https://matrix.to/#/!room:example.com/$event:example.com',
+      );
+      expect(result, isNotNull);
+      expect(result!.address, '!room:example.com');
+    });
+
+    test('strips an event-id path segment from a raw room ID permalink', () {
+      final result = parseMatrixAddress(
+        r'!room:example.com/$event:example.com',
+      );
+      expect(result, isNotNull);
+      expect(result!.address, '!room:example.com');
+    });
+
+    test('accepts http matrix.to links', () {
+      final result = parseMatrixAddress('http://matrix.to/#/#room:example.com');
+      expect(result, isNotNull);
+      expect(result!.address, '#room:example.com');
+    });
+
+    test('trims surrounding whitespace', () {
+      final result = parseMatrixAddress('  #room:example.com  ');
+      expect(result, isNotNull);
+      expect(result!.address, '#room:example.com');
+    });
+
+    test('rejects empty input', () {
+      expect(parseMatrixAddress(''), isNull);
+      expect(parseMatrixAddress('   '), isNull);
+    });
+
+    test('rejects a user identifier (@user:server)', () {
+      expect(parseMatrixAddress('@alice:example.com'), isNull);
+      expect(
+        parseMatrixAddress('https://matrix.to/#/@alice:example.com'),
+        isNull,
+      );
+    });
+
+    test('rejects arbitrary text', () {
+      expect(parseMatrixAddress('hello world'), isNull);
+      expect(parseMatrixAddress('https://example.com'), isNull);
+    });
+
+    test('rejects an identifier without a server part', () {
+      expect(parseMatrixAddress('#nocolon'), isNull);
+      expect(parseMatrixAddress('!nocolon'), isNull);
+    });
+
+    test('returns null via when query has no via params', () {
+      final result = parseMatrixAddress(
+        'https://matrix.to/#/#room:example.com?other=foo',
+      );
+      expect(result, isNotNull);
+      expect(result!.address, '#room:example.com');
+      expect(result.via, isNull);
+    });
+  });
+}

--- a/test/widgets/space_action_dialog_test.dart
+++ b/test/widgets/space_action_dialog_test.dart
@@ -1,5 +1,7 @@
 ﻿import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/spaces/services/space_discovery_data_source.dart';
@@ -167,7 +169,7 @@ void main() {
     });
   });
 
-  group('JoinSpaceDialog', () {
+  group('JoinWithAddressDialog', () {
     Widget buildTestWidget() {
       return MultiProvider(
         providers: [
@@ -179,7 +181,7 @@ void main() {
           home: Builder(
             builder: (context) => Scaffold(
               body: ElevatedButton(
-                onPressed: () => JoinSpaceDialog.show(
+                onPressed: () => JoinWithAddressDialog.show(
                   context,
                   matrixService: mockMatrixService,
                 ),
@@ -196,8 +198,27 @@ void main() {
       await tester.tap(find.text('Open'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Join Space'), findsOneWidget);
-      expect(find.widgetWithText(TextField, 'Space address'), findsOneWidget);
+      expect(find.text('Join with address'), findsOneWidget);
+      expect(
+        find.widgetWithText(TextField, 'Room or space address'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('rejects a non-matrix address', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Room or space address'),
+        'not a room',
+      );
+      await tester.tap(find.widgetWithText(FilledButton, 'Join'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Enter a room alias'), findsOneWidget);
+      verifyNever(mockClient.joinRoom(any, via: anyNamed('via')));
     });
 
     testWidgets('validates empty address', (tester) async {
@@ -211,11 +232,11 @@ void main() {
       expect(find.text('Address is required'), findsOneWidget);
     });
 
-    testWidgets('submitting calls client.joinRoom', (tester) async {
+    testWidgets('submitting a space selects the space', (tester) async {
       final mockSpace = MockRoom();
       when(mockSpace.isSpace).thenReturn(true);
 
-      when(mockClient.joinRoom(any))
+      when(mockClient.joinRoom(any, via: anyNamed('via')))
           .thenAnswer((_) async => '!space:example.com');
       when(mockClient.waitForRoomInSync(any, join: anyNamed('join')))
           .thenAnswer((_) async => SyncUpdate(nextBatch: ''));
@@ -226,25 +247,140 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.enterText(
-        find.widgetWithText(TextField, 'Space address'),
+        find.widgetWithText(TextField, 'Room or space address'),
         '#myspace:example.com',
       );
       await tester.tap(find.widgetWithText(FilledButton, 'Join'));
       await tester.pumpAndSettle();
 
-      verify(mockClient.joinRoom('#myspace:example.com')).called(1);
+      verify(
+        mockClient.joinRoom('#myspace:example.com', via: anyNamed('via')),
+      ).called(1);
       expect(selectionService.selectedSpaceIds, contains('!space:example.com'));
     });
 
-    testWidgets('shows error on join failure', (tester) async {
-      when(mockClient.joinRoom(any)).thenThrow(Exception('Room not found'));
+    testWidgets('submitting a regular room navigates to the room',
+        (tester) async {
+      final mockRoom = MockRoom();
+      when(mockRoom.isSpace).thenReturn(false);
+
+      when(mockClient.joinRoom(any, via: anyNamed('via')))
+          .thenAnswer((_) async => '!room:example.com');
+      when(mockClient.waitForRoomInSync(any, join: anyNamed('join')))
+          .thenAnswer((_) async => SyncUpdate(nextBatch: ''));
+      when(mockClient.getRoomById('!room:example.com')).thenReturn(mockRoom);
+
+      String? navigatedRoom;
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => Scaffold(
+              body: ElevatedButton(
+                onPressed: () => JoinWithAddressDialog.show(
+                  context,
+                  matrixService: mockMatrixService,
+                ),
+                child: const Text('Open'),
+              ),
+            ),
+            routes: [
+              GoRoute(
+                path: RouteSegments.room,
+                name: Routes.room,
+                builder: (context, state) {
+                  navigatedRoom = state.pathParameters[RouteParams.roomId];
+                  return Scaffold(
+                    body: Text(
+                      'Room ${state.pathParameters[RouteParams.roomId]}',
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        MultiProvider(
+          providers: [
+            ChangeNotifierProvider<MatrixService>.value(
+              value: mockMatrixService,
+            ),
+            ChangeNotifierProvider<SelectionService>.value(
+              value: selectionService,
+            ),
+          ],
+          child: MaterialApp.router(
+            theme: ThemeData(splashFactory: InkRipple.splashFactory),
+            routerConfig: router,
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Room or space address'),
+        '#general:example.com',
+      );
+      await tester.tap(find.widgetWithText(FilledButton, 'Join'));
+      await tester.pumpAndSettle();
+
+      verify(
+        mockClient.joinRoom('#general:example.com', via: anyNamed('via')),
+      ).called(1);
+      // A regular room is selected as a room (not a space)…
+      expect(selectionService.selectedRoomId, '!room:example.com');
+      expect(
+        selectionService.selectedSpaceIds,
+        isNot(contains('!room:example.com')),
+      );
+      // …and the router navigated to the room screen.
+      expect(navigatedRoom, '!room:example.com');
+      expect(find.text('Room !room:example.com'), findsOneWidget);
+    });
+
+    testWidgets('passes via servers from a matrix.to link', (tester) async {
+      final mockSpace = MockRoom();
+      when(mockSpace.isSpace).thenReturn(true);
+      when(mockClient.joinRoom(any, via: anyNamed('via')))
+          .thenAnswer((_) async => '!space:example.com');
+      when(mockClient.waitForRoomInSync(any, join: anyNamed('join')))
+          .thenAnswer((_) async => SyncUpdate(nextBatch: ''));
+      when(mockClient.getRoomById('!space:example.com')).thenReturn(mockSpace);
 
       await tester.pumpWidget(buildTestWidget());
       await tester.tap(find.text('Open'));
       await tester.pumpAndSettle();
 
       await tester.enterText(
-        find.widgetWithText(TextField, 'Space address'),
+        find.widgetWithText(TextField, 'Room or space address'),
+        'https://matrix.to/#/#space:example.com?via=s1.org&via=s2.org',
+      );
+      await tester.tap(find.widgetWithText(FilledButton, 'Join'));
+      await tester.pumpAndSettle();
+
+      verify(
+        mockClient.joinRoom(
+          '#space:example.com',
+          via: argThat(equals(['s1.org', 's2.org']), named: 'via'),
+        ),
+      ).called(1);
+    });
+
+    testWidgets('shows error on join failure', (tester) async {
+      when(mockClient.joinRoom(any, via: anyNamed('via')))
+          .thenThrow(Exception('Room not found'));
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Room or space address'),
         '#bad:example.com',
       );
       await tester.tap(find.widgetWithText(FilledButton, 'Join'));
@@ -258,12 +394,12 @@ void main() {
       await tester.tap(find.text('Open'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Join Space'), findsOneWidget);
+      expect(find.text('Join with address'), findsOneWidget);
 
       await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Join Space'), findsNothing);
+      expect(find.text('Join with address'), findsNothing);
     });
   });
 


### PR DESCRIPTION
Closes #844.

## What

Generalizes the spaces-only **"Join Space"** dialog into a **"Join with address"** dialog that works for *any* room — a regular room alias/ID **or** a space — and navigates into it. Also adds a room-list entry point and `matrix.to` link parsing.

## Why

Today the only "join by address" UI is scoped to spaces: `SpaceMenuActions.joinSpace()` returns `null` for non-space rooms, so joining an ordinary room by alias silently dead-ends (the SDK joins it server-side but the dialog just closes without navigating). There was no entry point for joining an ordinary room by alias/ID or via a `matrix.to` link — which also affects users handed a `matrix.to` link to an upgraded replacement room.

## Changes

- **`lib/core/utils/matrix_address_parser.dart`** (new) — pure `parseMatrixAddress()` accepting `#alias:server`, `!id:server`, and `https://matrix.to/#/…?via=…` links. Extracts repeated `via=` servers; strips event-id path segments; rejects user (`@`) identifiers.
- **`space_menu_actions.dart`** — adds `joinByAddress(address, {via})` returning a `JoinByAddressResult { roomId, isSpace }`. `joinSpace()` is kept as a thin spaces-only wrapper so existing callers are unaffected.
- **`space_action_dialog.dart`** — renames `JoinSpaceDialog` → `JoinWithAddressDialog`; parses input, validates, and routes: spaces → `selectSpace`, regular rooms → `selectRoom` + `router.goNamed(Routes.room, …)` (mirrors the tombstone-replacement pattern in `state_event_tile.dart`).
- **`room_list.dart`** — adds a "Join with address" item to the compose FAB speed dial so users not using spaces can reach it.
- **README** — lists the new feature under "Spaces & Rooms".

## Tests

- `test/utils/matrix_address_parser_test.dart` — 15 unit tests (alias, room ID, matrix.to, multi-via, event-path stripping, http, whitespace, rejections).
- `test/widgets/space_action_dialog_test.dart` — updated existing dialog tests for new labels and adds: rejects-non-matrix-address, **regular-room navigates to `Routes.room`** (GoRouter), and **passes via servers from a matrix.to link**.

## Verification

- `flutter analyze` — no issues (whole project).
- `flutter test` — **2452 tests pass** (incl. the new ones).
- `dart run build_runner build --delete-conflicting-outputs` — mock outputs unchanged (no `@GenerateMocks` annotations changed).

## Out of scope

Room directory browsing (#113), OS-level deep-linking of external `matrix.to` URLs into Kohera.
