### PR TITLE
fix: do not crash on malformed MSC3381 poll-start events

### DIFF
--- a/lib/core/utils/poll_body.dart
+++ b/lib/core/utils/poll_body.dart
@@ -1,9 +1,15 @@
+import 'package:kohera/core/utils/poll_content.dart';
 import 'package:matrix/matrix.dart';
 
 /// Returns a readable notification/preview body for a poll-start event,
 /// or `null` when [event] is not a poll-start event.
+///
+/// Parses safely: a malformed poll (e.g. missing the `org.matrix.msc1767.text`
+/// fallback) yields a generic body instead of throwing.
 String? pollStartBody(Event event) {
   if (event.type != PollEventContent.startType) return null;
-  final question = event.parsedPollEventContent.pollStartContent.question.mText;
+  final parsed = safePollStart(event);
+  if (parsed == null) return '📊 Poll';
+  final question = parsed.question;
   return question.isEmpty ? '📊 Poll' : '📊 Poll: $question';
 }

--- a/lib/core/utils/poll_content.dart
+++ b/lib/core/utils/poll_content.dart
@@ -1,0 +1,87 @@
+import 'package:matrix/matrix.dart';
+
+/// A null-safe view over an MSC3381 poll-start event's content.
+///
+/// The SDK's `Event.parsedPollEventContent` throws
+/// `type 'Null' is not a subtype of type 'String'` when a poll-start event is
+/// missing the `org.matrix.msc1767.text` fallback (or an answer label), which
+/// crashes the chat screen. This helper parses the same fields directly from
+/// the raw event content with safe fallbacks, so a malformed poll degrades
+/// gracefully instead of throwing.
+class SafePollStart {
+  const SafePollStart({
+    required this.question,
+    required this.answers,
+    required this.maxSelections,
+    required this.disclosed,
+  });
+
+  /// The poll question text (empty string when absent).
+  final String question;
+
+  /// Answer options in their original order. Answers without a usable `id`
+  /// are dropped.
+  final List<SafePollAnswer> answers;
+
+  /// Maximum number of selections a voter may make (defaults to 1).
+  final int maxSelections;
+
+  /// Whether the poll tally is disclosed (public) while open.
+  final bool disclosed;
+}
+
+/// One selectable answer option in a poll, parsed safely.
+class SafePollAnswer {
+  const SafePollAnswer({required this.id, required this.label});
+
+  /// The stable answer id.
+  final String id;
+
+  /// A human-readable label, falling back to the `body` or the id.
+  final String label;
+}
+
+const String _startKey = 'org.matrix.msc3381.poll.start';
+const String _textKey = 'org.matrix.msc1767.text';
+
+/// Parses a poll-start [event] safely, or returns `null` if it is not a
+/// poll-start event with usable start content.
+///
+/// Unlike the SDK's `Event.parsedPollEventContent`, this never throws on
+/// missing text fields.
+SafePollStart? safePollStart(Event event) {
+  if (event.type != PollEventContent.startType) return null;
+  final start = event.content.tryGetMap<String, Object?>(_startKey);
+  if (start == null) return null;
+
+  final kind = start.tryGet<String>('kind');
+  final disclosed = kind == PollKind.disclosed.name;
+
+  final maxSelections = start.tryGet<int>('max_selections') ?? 1;
+
+  final questionMap = start.tryGetMap<String, Object?>('question');
+  final question =
+      questionMap?.tryGet<String>(_textKey) ??
+      questionMap?.tryGet<String>('body') ??
+      '';
+
+  final answersRaw = start.tryGetList<Object?>('answers') ?? const [];
+  final answers = <SafePollAnswer>[];
+  for (final entry in answersRaw) {
+    if (entry is! Map) continue;
+    final id = entry['id'];
+    if (id is! String || id.isEmpty) continue;
+    final label =
+        (entry[_textKey] as String?) ??
+        (entry['body'] as String?) ??
+        id;
+    answers.add(SafePollAnswer(id: id, label: label));
+  }
+
+  return SafePollStart(
+    question: question,
+    answers: answers,
+    maxSelections: maxSelections,
+    disclosed: disclosed,
+  );
+}

--- a/lib/features/chat/services/poll_resolver.dart
+++ b/lib/features/chat/services/poll_resolver.dart
@@ -1,3 +1,4 @@
+import 'package:kohera/core/utils/poll_content.dart';
 import 'package:kohera/features/chat/models/kohera_poll.dart';
 import 'package:matrix/matrix.dart';
 
@@ -6,6 +7,10 @@ import 'package:matrix/matrix.dart';
 ///
 /// This is the SDK conversion boundary for poll rendering. Display widgets
 /// below consume [KoheraPoll] and never import `package:matrix/matrix.dart`.
+///
+/// Parsing is null-safe: a malformed poll-start event (e.g. missing the
+/// `org.matrix.msc1767.text` fallback) degrades to an empty poll instead of
+/// throwing and crashing the message list.
 class PollResolver {
   const PollResolver();
 
@@ -13,15 +18,15 @@ class PollResolver {
       {required String myUserId, required bool canRedact}) {
     assert(event.type == PollEventContent.startType, 'PollResolver requires a poll-start event');
 
-    final content = event.parsedPollEventContent.pollStartContent;
-    final kind = content.kind == PollKind.disclosed
+    final parsed = safePollStart(event);
+    final kind = (parsed?.disclosed ?? false)
         ? KoheraPollKind.disclosed
         : KoheraPollKind.undisclosed;
 
     final ended = event.getPollHasBeenEnded(timeline);
 
-    final answers = content.answers
-        .map((a) => KoheraPollAnswer(id: a.id, label: a.mText))
+    final answers = (parsed?.answers ?? const <SafePollAnswer>[])
+        .map((a) => KoheraPollAnswer(id: a.id, label: a.label))
         .toList(growable: false);
 
     final tallies = <String, int>{for (final a in answers) a.id: 0};
@@ -42,10 +47,10 @@ class PollResolver {
     }
 
     return KoheraPoll(
-      question: content.question.mText,
+      question: parsed?.question ?? '',
       answers: answers,
       kind: kind,
-      maxSelections: content.maxSelections,
+      maxSelections: parsed?.maxSelections ?? 1,
       ended: ended,
       responseCount: responseCount,
       tallies: tallies,

--- a/test/features/chat/services/poll_resolver_test.dart
+++ b/test/features/chat/services/poll_resolver_test.dart
@@ -208,5 +208,55 @@ void main() {
       );
       expect(redactPoll.canEnd, isTrue);
     });
+
+    test('does not throw on a malformed poll missing org.matrix.msc1767.text', () {
+      // Reproduces the crash: `type 'Null' is not a subtype of type 'String'
+      // from PollEventContent.fromJson when the top-level msc1767 text and an
+      // answer label are absent.
+      final content = <String, Object?>{
+        // Note: no PollEventContent.mTextJsonKey at the top level.
+        _startType: {
+          'kind': PollKind.disclosed.name,
+          'max_selections': 2,
+          'question': {'body': 'Tea or coffee?'},
+          'answers': [
+            {'id': 'a1'}, // no msc1767 text label
+            {'id': 'a2', 'body': 'No'},
+          ],
+        },
+      };
+      final event = _startEvent(eventId: r'$malformed', content: content);
+      final timeline = _emptyTimeline(r'$malformed');
+
+      final poll = const PollResolver()(
+        event,
+        timeline,
+        myUserId: '@me:example.com',
+        canRedact: false,
+      );
+
+      expect(poll.kind, KoheraPollKind.disclosed);
+      expect(poll.question, 'Tea or coffee?');
+      expect(poll.answers.map((a) => a.label), ['a1', 'No']);
+      expect(poll.maxSelections, 2);
+      expect(poll.tallies, {'a1': 0, 'a2': 0});
+    });
+
+    test('degrades to an empty poll when start content is missing entirely', () {
+      final content = <String, Object?>{}; // redacted / no start map
+      final event = _startEvent(eventId: r'$empty', content: content);
+      final timeline = _emptyTimeline(r'$empty');
+
+      final poll = const PollResolver()(
+        event,
+        timeline,
+        myUserId: '@me:example.com',
+        canRedact: false,
+      );
+
+      expect(poll.question, '');
+      expect(poll.answers, isEmpty);
+      expect(poll.maxSelections, 1);
+    });
   });
 }

--- a/test/utils/poll_body_test.dart
+++ b/test/utils/poll_body_test.dart
@@ -44,5 +44,31 @@ void main() {
       when(event.type).thenReturn(EventTypes.Message);
       expect(pollStartBody(event), isNull);
     });
+
+    test('does not throw on a malformed poll missing org.matrix.msc1767.text', () {
+      // Reproduces the crash where PollEventContent.fromJson did
+      // `mText: json[mTextJsonKey]` with a null value.
+      final event = MockEvent();
+      when(event.type).thenReturn(_startType);
+      when(event.content).thenReturn({
+        // No top-level PollEventContent.mTextJsonKey.
+        _startType: {
+          'kind': 'org.matrix.msc3381.poll.disclosed',
+          'max_selections': 1,
+          'question': {'body': 'Tea or coffee?'},
+          'answers': [
+            {'id': 'a1'},
+          ],
+        },
+      });
+      expect(pollStartBody(event), '📊 Poll: Tea or coffee?');
+    });
+
+    test('returns generic body when start content is missing entirely', () {
+      final event = MockEvent();
+      when(event.type).thenReturn(_startType);
+      when(event.content).thenReturn(<String, Object?>{});
+      expect(pollStartBody(event), '📊 Poll');
+    });
   });
 }


### PR DESCRIPTION
## Problem

The chat screen crashes with:

```
type 'Null' is not a subtype of type 'String'
… new PollEventContent.fromJson (package:matrix/.../poll_event_content.dart:19:20)
… PollEventExtension.parsedPollEventContent
… PollResolver.call (package:kohera/features/chat/services/poll_resolver.dart:16:27)
```

when rendering a poll-start event that omits the `org.matrix.msc1767.text` fallback (or an answer label). The SDK's `Event.parsedPollEventContent` does `mText: json[mTextJsonKey]` with no null guard, so the missing field throws during the build of `MessageListView` and takes the whole timeline down. The same throwing path is used by `pollStartBody` for notifications/previews, so a malformed poll could crash there too.

## Root cause

`PollEventContent.fromJson` (matrix 6.1.1):
- top-level `mText: json[mTextJsonKey]` → null cast when the MSC1767 text fallback is absent
- `PollAnswer.fromJson`: `mText: json[mTextJsonKey] as String` → null cast for an answer with no label

`PollQuestion.fromJson` is already safe (`?? json['body']`). The SDK getters `getPollHasBeenEnded` / `getPollResponses` use `tryGet*` and are safe — only the content parse throws.

## Fix

Add a null-safe Kohera-side parser (`safePollStart`) that reads the poll fields directly from the raw `event.content` with safe fallbacks, and use it at **both** Kohera boundaries instead of the throwing SDK getter. A malformed poll now degrades to an empty/generic poll instead of throwing.

- **`lib/core/utils/poll_content.dart`** (new) — `safePollStart(Event)` returning `SafePollStart?`: question falls back to `body` then `''`; answer labels fall back to `body` then the answer `id`; answers with no usable `id` are dropped; `kind`/`max_selections` defaults applied. Never throws.
- **`PollResolver.call`** — parses via `safePollStart`; on a malformed/redacted poll (start content missing) it returns an empty `KoheraPoll` instead of crashing. Tally/response logic unchanged (still uses the safe SDK getters).
- **`pollStartBody`** — parses via `safePollStart`; returns a generic `📊 Poll` body for a malformed poll instead of throwing. Fixes the notification path too.

## Tests

- `test/features/chat/services/poll_resolver_test.dart` — adds:
  - "does not throw on a malformed poll missing org.matrix.msc1767.text" (the exact crash: no top-level text, an answer with no label) — verifies the question/labels fall back correctly and no exception.
  - "degrades to an empty poll when start content is missing entirely" (redacted/empty content).
- `test/utils/poll_body_test.dart` — adds the same two malformed cases for `pollStartBody`.
- Existing poll tests unchanged and still pass.

## Verification

- `flutter analyze` — no issues (whole project).
- `flutter test` — **2456 tests pass** (4 new). Includes the existing `PollResolver`, `pollStartBody`, and `poll_message_item` tests.

## Notes

This is a Kohera-side defensive fix; the underlying unsafe cast is in the `matrix` SDK (`PollEventContent.fromJson`). An upstream fix (nullable `mText` or `?? body` fallbacks) would be the ideal long-term, but this guards Kohera regardless of SDK version.