### PR TITLE
feat(android): enable R8 minification and resource shrinking

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -48,6 +48,12 @@ android {
 
     buildTypes {
         release {
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
             signingConfig = if (keystorePropertiesFile.exists()) {
                 signingConfigs.getByName("release")
             } else {

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,71 @@
+# ── Flutter ──────────────────────────────────────────────────
+# GeneratedPluginRegistrant is annotated @Keep but be explicit.
+-keep class io.flutter.plugins.** { *; }
+-keep class io.flutter.app.** { *; }
+-keep class io.flutter.embedding.** { *; }
+
+# ── Dart-JNI bridge (reflection-heavy) ──────────────────────
+-keep class com.github.dart_lang.jni.** { *; }
+-keep class com.github.dart_lang.jni_flutter.** { *; }
+-keep class com.github.dart_lang.** { *; }
+
+# ── Flutter plugins (registered via reflection) ─────────────
+# Keep all plugin entry-point classes so R8 doesn't strip them
+# before GeneratedPluginRegistrant can add them.
+-keep class com.ryanheise.audio_session.** { *; }
+-keep class dev.fluttercommunity.plus.connectivity.** { *; }
+-keep class one.mixin.desktop.drop.** { *; }
+-keep class dev.fluttercommunity.plus.device_info.** { *; }
+-keep class io.material.plugins.dynamic_color.** { *; }
+-keep class com.mr.flutter.plugin.filepicker.** { *; }
+-keep class de.julianassmann.flutter_background.** { *; }
+-keep class com.hiennv.flutter_callkit_incoming.** { *; }
+-keep class com.dexterous.flutterlocalnotifications.** { *; }
+-keep class io.flutter.plugins.flutter_plugin_android_lifecycle.** { *; }
+-keep class com.it_nomads.fluttersecurestorage.** { *; }
+-keep class com.cloudwebrtc.webrtc.** { *; }
+-keep class io.flutter.plugins.imagepicker.** { *; }
+-keep class com.ryanheise.just_audio.** { *; }
+-keep class io.livekit.plugin.** { *; }
+-keep class com.alexmercerind.media_kit_video.** { *; }
+-keep class dev.steenbakker.mobile_scanner.** { *; }
+-keep class dev.fluttercommunity.plus.packageinfo.** { *; }
+-keep class one.mixin.pasteboard.** { *; }
+-keep class com.baseflow.permissionhandler.** { *; }
+-keep class com.llfbandit.record.** { *; }
+-keep class io.flutter.plugins.sharedpreferences.** { *; }
+-keep class com.tekartik.sqflite.** { *; }
+-keep class eu.simonbinder.sqlite3_flutter_libs.** { *; }
+-keep class org.unifiedpush.flutter.connector.** { *; }
+-keep class io.flutter.plugins.urllauncher.** { *; }
+-keep class io.flutter.plugins.videoplayer.** { *; }
+-keep class dev.fluttercommunity.plus.wakelock.** { *; }
+-keep class com.example.webcrypto.** { *; }
+
+# ── WebRTC native bridge (JNI calls via reflection) ─────────
+-keep class org.webrtc.** { *; }
+-keepclassmembers class org.webrtc.** {
+    native <methods>;
+}
+
+# ── Native method preservation ──────────────────────────────
+# Any class with native methods must be kept.
+-keepclasseswithmembers class * {
+    native <methods>;
+}
+
+# ── Serialization / Gson / Parcelable ───────────────────────
+# Some plugins use Gson/Parcelable for serializing data across
+# the platform channel boundary.
+-keepclassmembers,allowobfuscation class * {
+    @com.google.gson.annotations.SerializedName <fields>;
+}
+-keep class * implements android.os.Parcelable {
+    public static final android.os.Parcelable$Creator *;
+}
+
+# ── Enums (plugin channels often pass enum names) ──────────
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}


### PR DESCRIPTION
## Summary

Enable R8 code shrinking (`isMinifyEnabled`) and resource shrinking (`isShrinkResources`) on the Android release build type. This strips unused Java/Kotlin code from plugin transitive dependencies and removes unused resources, reducing the release APK size by an estimated **5–15 MB**.

## Changes

### `android/app/build.gradle.kts`
Added to the `release` build type:
- `isMinifyEnabled = true` — enables R8 code shrinking/optimization
- `isShrinkResources = true` — removes unused resources
- `proguardFiles(...)` — references the new ProGuard rules file

### `android/app/proguard-rules.pro` (new)
Keep rules to prevent R8 from stripping classes that are loaded via reflection:
- Flutter embedding and `GeneratedPluginRegistrant` classes
- All 30 registered plugin entry-point classes
- Dart-JNI bridge classes (`com.github.dart_lang.jni.**`)
- WebRTC native method bindings (`org.webrtc.**`)
- Any class containing `native` methods
- Parcelable creators and Gson `@SerializedName` fields
- Enum `valueOf()`/`values()` (used by platform channels)

## Rationale

The release build type had no shrinking configured — all transitive AndroidX/plugin Java and Kotlin code shipped verbatim. R8 with the `proguard-android-optimize.txt` baseline removes unused classes/methods and shrinks the DEX output.

The ProGuard keep rules are intentionally conservative — every plugin in `GeneratedPluginRegistrant.java` is explicitly kept, plus JNI and reflection-sensitive patterns. This ensures no runtime crashes from stripped plugin classes while still allowing R8 to remove truly unused transitive code.

## Testing

- [x] `flutter build apk --release --split-per-abi --target-platform android-arm64` succeeds
- [x] App launches and all plugins function normally on arm64 device
- [x] APK size is reduced compared to pre-R8 build
- [x] No `MissingClassException` or `ClassNotFoundException` at runtime