### PR TITLE
ci(release): attach build artifacts to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+  release:
+    types: [published]
   workflow_dispatch:
 
 concurrency:
@@ -18,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Verify tag is on master
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'release'
         run: |
           if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/master; then
             echo "::error::Tag must point to a commit on master"
@@ -190,13 +192,15 @@ jobs:
             -t ios \
             --apiKey "$APPSTORE_CONNECT_KEY_ID" \
             --apiIssuer "$APPSTORE_CONNECT_ISSUER_ID"
-      - name: Generate checksum
-        run: shasum -a 256 build/ios/ipa/kohera.ipa > kohera-ios-arm64.ipa.sha256
+      - name: Stage IPA and generate checksum
+        run: |
+          cp build/ios/ipa/kohera.ipa kohera-ios-arm64.ipa
+          shasum -a 256 kohera-ios-arm64.ipa > kohera-ios-arm64.ipa.sha256
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ios-release
           path: |
-            build/ios/ipa/kohera.ipa
+            kohera-ios-arm64.ipa
             kohera-ios-arm64.ipa.sha256
       - name: Clean up keychain
         if: always()
@@ -306,7 +310,7 @@ jobs:
             kohera-windows-x64-setup.exe.sha256
             kohera-macos-universal.zip
             kohera-macos-universal.zip.sha256
-            kohera.ipa
+            kohera-ios-arm64.ipa
             kohera-ios-arm64.ipa.sha256
             kohera-android-arm64.apk
             kohera-android-arm64.apk.sha256


### PR DESCRIPTION
## Problem

Automated releases (cut by release-please) publish a GitHub Release with **no assets** on the Releases page.

## Root cause

`release.yml` only triggered on `on: push: tags: ['v*']`. But **release-please creates the tag/release through the GitHub API** (via the app token), and API-created tags **do not emit a `push` event**. So when release-please cut a release, none of the build jobs ever ran → no artifacts → empty Releases page. The `push: tags` trigger only ever fired for a manual `git push origin vX.Y.Z`.

## Secondary bug

Even when builds did run, the iOS `.ipa` was silently dropped from release assets. In `build-ios`, the upload-artifact paths mixed a nested file (`build/ios/ipa/kohera.ipa`) with a workspace-root file (`kohera-ios-arm64.ipa.sha256`). Their least-common-ancestor is the workspace root, so the artifact preserved `build/ios/ipa/kohera.ipa`, but the `publish-release` `files:` glob expected `kohera.ipa` at the root → no match → IPA never attached. (The other platforms stage files in cwd and were unaffected.)

## Fix

`.github/workflows/release.yml`:

1. **Add a `release: types: [published]` trigger** so the build jobs run when release-please publishes a release. Per GitHub's docs, for the `release` event `GITHUB_SHA` is "Last commit in the tagged release" and `GITHUB_REF` is `refs/tags/<tag_name>`, so existing `actions/checkout` (default) and `tag_name: \${{ github.ref_name }}` work unchanged.
2. **Run the `verify-tag` ancestry check for `release` events too** (was gated to `push` only).
3. **Stage the iOS IPA** to the workspace root as `kohera-ios-arm64.ipa` (matching its checksum filename), generate the checksum from the staged file, and update both the upload-artifact path and the publish glob.

`push: tags` is retained for manual tag-push releases. There's no double-run: release-please doesn't emit `push`, and a manually-pushed tag's release is created by `publish-release` using the default `GITHUB_TOKEN`, which doesn't recurse-trigger `release` events.

## Verification

- YAML validated.
- `git diff` reviewed.

## Checklist

- [x] Branch created from `origin/master`
- [x] Single-file change to the release workflow
- [x] No build logic changed (only triggers + asset staging paths)