### PR TITLE
fix(#170): apply account-deactivation review follow-up

### DIFF
--- a/lib/features/settings/widgets/deactivate_account_dialog.dart
+++ b/lib/features/settings/widgets/deactivate_account_dialog.dart
@@ -14,14 +14,13 @@ import 'package:provider/provider.dart';
 class DeactivateAccountDialog extends StatefulWidget {
   const DeactivateAccountDialog({super.key});
 
-  /// Opens the dialog. Returns `true` if deactivation succeeded.
-  static Future<bool> show(BuildContext context) async {
-    final result = await showDialog<bool>(
+  /// Opens the dialog.
+  static Future<void> show(BuildContext context) async {
+    await showDialog<void>(
       context: context,
       barrierDismissible: false,
       builder: (_) => const DeactivateAccountDialog(),
     );
-    return result ?? false;
   }
 
   @override
@@ -35,6 +34,7 @@ class _DeactivateAccountDialogState extends State<DeactivateAccountDialog> {
   final _idServerController = TextEditingController();
   bool _busy = false;
   String? _error;
+  String? _idServerError;
 
   late final MatrixService _matrix;
   late final ClientManager _manager;
@@ -65,9 +65,14 @@ class _DeactivateAccountDialogState extends State<DeactivateAccountDialog> {
 
   Future<void> _confirm() async {
     final idServer = _idServerController.text.trim();
+    if (_showIdServer && idServer.isNotEmpty && !_isValidIdServer(idServer)) {
+      setState(() => _idServerError = 'Enter a valid identity server URL.');
+      return;
+    }
     setState(() {
       _busy = true;
       _error = null;
+      _idServerError = null;
     });
     try {
       await _service.deactivate(
@@ -75,13 +80,33 @@ class _DeactivateAccountDialogState extends State<DeactivateAccountDialog> {
         idServer: _showIdServer && idServer.isNotEmpty ? idServer : null,
       );
       if (!mounted) return;
-      Navigator.of(context).pop(true);
+      Navigator.of(context).pop();
       await _manager.removeService(_matrix);
     } on MatrixException catch (e) {
+      _matrix.uia.clearCachedPassword();
       _setError(e.errorMessage);
+    } on Exception catch (e) {
+      if (_isCancelError(e)) {
+        if (!mounted) return;
+        setState(() => _busy = false);
+        return;
+      }
+      _setError('Deactivation failed: $e');
     } catch (e) {
       _setError('Deactivation failed: $e');
     }
+  }
+
+  bool _isCancelError(Object e) {
+    final message = e.toString().toLowerCase();
+    return message.contains('canceled') || message.contains('cancelled');
+  }
+
+  bool _isValidIdServer(String value) {
+    final uri = Uri.tryParse(value);
+    return uri != null &&
+        (uri.scheme == 'http' || uri.scheme == 'https') &&
+        uri.host.isNotEmpty;
   }
 
   void _setError(String message) {
@@ -143,7 +168,10 @@ class _DeactivateAccountDialogState extends State<DeactivateAccountDialog> {
                 value: _showIdServer,
                 onChanged: _busy
                     ? null
-                    : (v) => setState(() => _showIdServer = v ?? false),
+                    : (v) => setState(() {
+                        _showIdServer = v ?? false;
+                        _idServerError = null;
+                      }),
                 title: const Text('Unbind third-party identifiers'),
                 subtitle: const Text(
                   'Provide an identity server to unbind your 3PIDs from. '
@@ -159,11 +187,17 @@ class _DeactivateAccountDialogState extends State<DeactivateAccountDialog> {
                 TextField(
                   controller: _idServerController,
                   enabled: !_busy,
-                  decoration: const InputDecoration(
+                  decoration: InputDecoration(
                     labelText: 'Identity server',
                     hintText: 'https://vector.im',
-                    border: OutlineInputBorder(),
+                    border: const OutlineInputBorder(),
+                    errorText: _idServerError,
                   ),
+                  onChanged: (_) {
+                    if (_idServerError != null) {
+                      setState(() => _idServerError = null);
+                    }
+                  },
                 ),
               ],
               if (_error != null) ...[
@@ -179,7 +213,7 @@ class _DeactivateAccountDialogState extends State<DeactivateAccountDialog> {
       ),
       actions: [
         TextButton(
-          onPressed: _busy ? null : () => Navigator.of(context).pop(false),
+          onPressed: _busy ? null : () => Navigator.of(context).pop(),
           child: const Text('Cancel'),
         ),
         FilledButton(

--- a/test/e2e/settings_screen_test.dart
+++ b/test/e2e/settings_screen_test.dart
@@ -118,7 +118,16 @@ void main() {
   }
 
   Future<void> scrollToBottom(WidgetTester tester) async {
-    await tester.drag(find.byType(ListView), const Offset(0, -5000));
+    await tester.scrollUntilVisible(
+      find.text('Sign Out'),
+      200,
+      scrollable: find
+          .descendant(
+            of: find.byType(ListView),
+            matching: find.byType(Scrollable),
+          )
+          .first,
+    );
     await tester.pumpAndSettle();
   }
 

--- a/test/widgets/deactivate_account_dialog_test.dart
+++ b/test/widgets/deactivate_account_dialog_test.dart
@@ -17,6 +17,7 @@ import 'package:provider/provider.dart';
   MockSpec<MatrixService>(),
   MockSpec<ChatBackupService>(),
   MockSpec<ClientManager>(),
+  MockSpec<UiaService>(),
 ])
 import 'deactivate_account_dialog_test.mocks.dart';
 
@@ -25,17 +26,17 @@ void main() {
   late MockMatrixService mockMatrix;
   late MockChatBackupService mockChatBackup;
   late MockClientManager mockManager;
-  late UiaService uiaService;
+  late MockUiaService mockUia;
 
   setUp(() {
     mockClient = MockClient();
     mockMatrix = MockMatrixService();
     mockChatBackup = MockChatBackupService();
     mockManager = MockClientManager();
-    uiaService = UiaService(client: mockClient);
+    mockUia = MockUiaService();
 
     when(mockMatrix.client).thenReturn(mockClient);
-    when(mockMatrix.uia).thenReturn(uiaService);
+    when(mockMatrix.uia).thenReturn(mockUia);
     when(mockMatrix.chatBackup).thenReturn(mockChatBackup);
     when(mockClient.userID).thenReturn('@alice:example.com');
     when(mockChatBackup.chatBackupNeeded).thenReturn(false);
@@ -178,6 +179,70 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.textContaining('Wrong password'), findsOneWidget);
+      verifyNever(mockManager.removeService(mockMatrix));
+    });
+
+    testWidgets('password-prompt cancel is benign (no error shown)',
+        (tester) async {
+      when(mockClient.uiaRequestBackground<IdServerUnbindResult>(any))
+          .thenThrow(Exception('Request has been canceled'));
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Deactivate'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('canceled'), findsNothing);
+      expect(find.textContaining('Deactivation failed'), findsNothing);
+      expect(find.text('Deactivate'), findsOneWidget);
+      verifyNever(mockManager.removeService(mockMatrix));
+    });
+
+    testWidgets('clears cached password after a wrong-password failure',
+        (tester) async {
+      when(mockClient.deactivateAccount(
+        auth: anyNamed('auth'),
+        erase: anyNamed('erase'),
+        idServer: anyNamed('idServer'),
+      )).thenThrow(MatrixException.fromJson({
+        'errcode': 'M_FORBIDDEN',
+        'error': 'Wrong password',
+      }));
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Deactivate'));
+      await tester.pumpAndSettle();
+
+      verify(mockUia.clearCachedPassword()).called(1);
+    });
+
+    testWidgets('rejects an invalid identity server without deactivating',
+        (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Unbind third-party identifiers'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Identity server').first,
+        'not a url',
+      );
+
+      await tester.tap(find.text('Deactivate'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('valid identity server'), findsOneWidget);
+      verifyNever(mockClient.deactivateAccount(
+        auth: anyNamed('auth'),
+        erase: anyNamed('erase'),
+        idServer: anyNamed('idServer'),
+      ));
       verifyNever(mockManager.removeService(mockMatrix));
     });
   });

--- a/test/widgets/deactivate_account_dialog_test.mocks.dart
+++ b/test/widgets/deactivate_account_dialog_test.mocks.dart
@@ -7419,3 +7419,64 @@ class MockClientManager extends _i1.Mock implements _i28.ClientManager {
     returnValueForMissingStub: null,
   );
 }
+
+/// A class which mocks [UiaService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockUiaService extends _i1.Mock implements _i10.UiaService {
+  @override
+  _i5.Stream<_i2.UiaRequest<dynamic>> get onUiaRequest =>
+      (super.noSuchMethod(
+            Invocation.getter(#onUiaRequest),
+            returnValue: _i5.Stream<_i2.UiaRequest<dynamic>>.empty(),
+            returnValueForMissingStub:
+                _i5.Stream<_i2.UiaRequest<dynamic>>.empty(),
+          )
+          as _i5.Stream<_i2.UiaRequest<dynamic>>);
+
+  @override
+  set passwordPromptBuilder(_i10.PasswordPromptBuilder? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#passwordPromptBuilder, value),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void listenForUia() => super.noSuchMethod(
+    Invocation.method(#listenForUia, []),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  void completeUiaWithPassword(
+    _i2.UiaRequest<dynamic>? request,
+    String? password,
+  ) => super.noSuchMethod(
+    Invocation.method(#completeUiaWithPassword, [request, password]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  void setCachedPassword(String? password) => super.noSuchMethod(
+    Invocation.method(#setCachedPassword, [password]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  void clearCachedPassword() => super.noSuchMethod(
+    Invocation.method(#clearCachedPassword, []),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  void cancelUiaSub() => super.noSuchMethod(
+    Invocation.method(#cancelUiaSub, []),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  void dispose() => super.noSuchMethod(
+    Invocation.method(#dispose, []),
+    returnValueForMissingStub: null,
+  );
+}


### PR DESCRIPTION
## Summary

Applies the review follow-up that was missing from the squash-merge of #170. The original PR was merged from the pre-push branch HEAD, so the fix commit never landed on `master`. This restores it.

## Changes

- \`DeactivateAccountDialog._confirm\` treats a cancelled password prompt as benign (no more \`Deactivation failed: Exception: Request has been canceled\`).
- On \`MatrixException\` (wrong password) the dialog calls \`UiaService.clearCachedPassword()\` so the retry prompt is not silently suppressed for 30s by the cached wrong password.
- Optional identity-server field is validated (http/https + non-empty host) before submitting; field shows \`errorText\`, cleared on edit or unbind toggle.
- \`DeactivateAccountDialog.show\` returns \`Future<void>\` (drops unused bool); \`pop(true)\`/\`pop(false)\` → \`pop()\`.
- \`settings_screen_test.dart\` replaces the magic \`-5000\` drag with \`scrollUntilVisible(find.text('Sign Out'), …)\`.
- Dialog tests add a \`MockUiaService\` and cover: benign password-prompt cancel, cached-password cleared on wrong-password, invalid identity server rejected without deactivating.

## Testing

- \`flutter analyze\` clean on changed files.
- \`flutter test test/widgets test/features test/e2e\` — all pass.
- Full suite: 2485 pass; the only 2 failures are the pre-existing \`message_bubble_golden_test\` PICO-8 cases that also fail on \`master\` (font rendering, unrelated).

## Linked issues

Refs #170