### PR TITLE
feat(#830): two-tier message context menu

### DIFF
--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -493,9 +493,10 @@ class _ChatScreenState extends State<ChatScreen>
     if (event == null || event.redacted) return;
     final isMe = event.senderId == _timelineController.myUserId;
     final cs = Theme.of(context).colorScheme;
-    final List<MessageAction> actions;
+    final List<MessageAction> primaryActions;
+    final List<MessageAction> secondaryActions;
     if (event.status.name == 'error') {
-      actions = [
+      primaryActions = [
         MessageAction(
           label: 'Retry sending',
           icon: Icons.refresh_rounded,
@@ -520,22 +521,21 @@ class _ChatScreenState extends State<ChatScreen>
           color: cs.error,
         ),
       ];
+      secondaryActions = const <MessageAction>[];
     } else {
-      actions = [
+      primaryActions = [
         MessageAction(
           label: 'Reply',
           icon: Icons.reply_rounded,
           onTap: () => _setReplyTo(eventId),
         ),
         MessageAction(
-          label: 'Reply in thread',
-          icon: Icons.forum_outlined,
-          onTap: () => _replyInThread(eventId),
-        ),
-        MessageAction(
-          label: 'Forward',
-          icon: Icons.forward_rounded,
-          onTap: () => _forwardMessage(eventId),
+          label: 'React',
+          icon: Icons.add_reaction_outlined,
+          onTap: () => showEmojiPickerSheet(
+            context,
+            (emoji) => unawaited(_actions.toggleReaction(event, emoji)),
+          ),
         ),
         if (isMe)
           MessageAction(
@@ -546,20 +546,6 @@ class _ChatScreenState extends State<ChatScreen>
               _timelineController.timeline,
               _msgCtrl,
             ),
-          ),
-        MessageAction(
-          label: 'React',
-          icon: Icons.add_reaction_outlined,
-          onTap: () => showEmojiPickerSheet(
-            context,
-            (emoji) => unawaited(_actions.toggleReaction(event, emoji)),
-          ),
-        ),
-        if (canPin)
-          MessageAction(
-            label: isPinned ? 'Unpin' : 'Pin',
-            icon: isPinned ? Icons.push_pin_rounded : Icons.push_pin_outlined,
-            onTap: () => unawaited(_actions.togglePin(event)),
           ),
         MessageAction(
           label: 'Copy',
@@ -575,6 +561,35 @@ class _ChatScreenState extends State<ChatScreen>
             );
           },
         ),
+        if (event.canRedact)
+          MessageAction(
+            label: isMe ? 'Delete' : 'Remove',
+            icon: Icons.delete_outline_rounded,
+            onTap: () => confirmAndDeleteEvent(
+                  context,
+                  isMe: isMe,
+                  onRedact: () => event.room.redactEvent(event.eventId),
+                ),
+            color: cs.error,
+          ),
+      ];
+      secondaryActions = [
+        MessageAction(
+          label: 'Reply in thread',
+          icon: Icons.forum_outlined,
+          onTap: () => _replyInThread(eventId),
+        ),
+        MessageAction(
+          label: 'Forward',
+          icon: Icons.forward_rounded,
+          onTap: () => _forwardMessage(eventId),
+        ),
+        if (canPin)
+          MessageAction(
+            label: isPinned ? 'Unpin' : 'Pin',
+            icon: isPinned ? Icons.push_pin_rounded : Icons.push_pin_outlined,
+            onTap: () => unawaited(_actions.togglePin(event)),
+          ),
         if (!isMe)
           MessageAction(
             label: 'Ignore user',
@@ -589,17 +604,6 @@ class _ChatScreenState extends State<ChatScreen>
             onTap: () => unawaited(_reportMessage(event)),
             color: cs.error,
           ),
-        if (event.canRedact)
-          MessageAction(
-            label: isMe ? 'Delete' : 'Remove',
-            icon: Icons.delete_outline_rounded,
-            onTap: () => confirmAndDeleteEvent(
-                  context,
-                  isMe: isMe,
-                  onRedact: () => event.room.redactEvent(event.eventId),
-                ),
-            color: cs.error,
-          ),
       ];
     }
     final matrix = context.read<MatrixService>();
@@ -612,7 +616,8 @@ class _ChatScreenState extends State<ChatScreen>
       message: message,
       isMe: isMe,
       bubbleRect: bubbleRect,
-      actions: actions,
+      actions: primaryActions,
+      secondaryActions: secondaryActions,
       avatarResolver: matrix.avatarResolver,
       mentionResolver: _buildMentionResolver(event.room.id),
       mediaResolver: matrix.mediaResolver,

--- a/lib/features/chat/widgets/message_action_sheet.dart
+++ b/lib/features/chat/widgets/message_action_sheet.dart
@@ -40,6 +40,7 @@ void showMessageActionSheet({
   required AvatarResolver avatarResolver,
   required MentionDisplayNameResolver mentionResolver,
   required MediaResolver mediaResolver,
+  List<MessageAction> secondaryActions = const [],
   void Function(String emoji)? onQuickReact,
 }) {
   unawaited(
@@ -49,6 +50,7 @@ void showMessageActionSheet({
         isMe: isMe,
         bubbleRect: bubbleRect,
         actions: actions,
+        secondaryActions: secondaryActions,
         avatarResolver: avatarResolver,
         mentionResolver: mentionResolver,
         mediaResolver: mediaResolver,
@@ -67,6 +69,7 @@ class _MessageActionSheetRoute extends PopupRoute<void> {
     required this.isMe,
     required this.bubbleRect,
     required this.actions,
+    required this.secondaryActions,
     required this.avatarResolver,
     required this.mentionResolver,
     required this.mediaResolver,
@@ -78,6 +81,7 @@ class _MessageActionSheetRoute extends PopupRoute<void> {
   final bool isMe;
   final Rect bubbleRect;
   final List<MessageAction> actions;
+  final List<MessageAction> secondaryActions;
   final AvatarResolver avatarResolver;
   final MentionDisplayNameResolver mentionResolver;
   final MediaResolver mediaResolver;
@@ -107,6 +111,7 @@ class _MessageActionSheetRoute extends PopupRoute<void> {
       isMe: isMe,
       bubbleRect: bubbleRect,
       actions: actions,
+      secondaryActions: secondaryActions,
       avatarResolver: avatarResolver,
       mentionResolver: mentionResolver,
       mediaResolver: mediaResolver,
@@ -125,6 +130,7 @@ class _MessageActionSheet extends StatefulWidget {
     required this.isMe,
     required this.bubbleRect,
     required this.actions,
+    required this.secondaryActions,
     required this.avatarResolver,
     required this.mentionResolver,
     required this.mediaResolver,
@@ -137,6 +143,7 @@ class _MessageActionSheet extends StatefulWidget {
   final bool isMe;
   final Rect bubbleRect;
   final List<MessageAction> actions;
+  final List<MessageAction> secondaryActions;
   final AvatarResolver avatarResolver;
   final MentionDisplayNameResolver mentionResolver;
   final MediaResolver mediaResolver;
@@ -155,6 +162,19 @@ class _MessageActionSheetState extends State<_MessageActionSheet> {
   static const _gap = 8.0;
 
   late final CurvedAnimation _curved;
+  bool _showSecondary = false;
+
+  MessageAction? get _moreAction => (!_showSecondary &&
+          widget.secondaryActions.isNotEmpty)
+      ? MessageAction(
+          label: 'More…',
+          icon: Icons.more_horiz_rounded,
+          onTap: () => setState(() => _showSecondary = true),
+        )
+      : null;
+
+  List<MessageAction> get _visibleActions =>
+      _showSecondary ? widget.secondaryActions : widget.actions;
 
   @override
   void initState() {
@@ -180,7 +200,10 @@ class _MessageActionSheetState extends State<_MessageActionSheet> {
     final safeBottom = mq.padding.bottom + 8;
 
     final hasQuickReact = widget.onQuickReact != null;
-    final actionListHeight = widget.actions.length * _actionRowHeight;
+    final visibleActions = _visibleActions;
+    final moreAction = _moreAction;
+    final rowCount = visibleActions.length + (moreAction != null ? 1 : 0);
+    final actionListHeight = rowCount * _actionRowHeight;
     final quickReactSpace = hasQuickReact ? _quickReactHeight + _gap : 0.0;
 
     final totalHeight =
@@ -270,7 +293,10 @@ class _MessageActionSheetState extends State<_MessageActionSheet> {
                 begin: const Offset(0, 0.08),
                 end: Offset.zero,
               ).animate(_curved),
-              child: _ActionList(actions: widget.actions),
+              child: _ActionList(
+              actions: visibleActions,
+              moreAction: moreAction,
+            ),
             ),
           ),
         ),
@@ -282,13 +308,22 @@ class _MessageActionSheetState extends State<_MessageActionSheet> {
 // ── Action list widget ──────────────────────────────────
 
 class _ActionList extends StatelessWidget {
-  const _ActionList({required this.actions});
+  const _ActionList({required this.actions, this.moreAction});
 
   final List<MessageAction> actions;
+
+  /// Optional trailing "More…" row that swaps to the secondary tier instead
+  /// of dismissing the sheet.
+  final MessageAction? moreAction;
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final divider = Divider(
+      height: 1,
+      thickness: 0.5,
+      color: cs.outlineVariant.withValues(alpha: 0.4),
+    );
 
     return Material(
       elevation: 4,
@@ -299,13 +334,12 @@ class _ActionList extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           for (int i = 0; i < actions.length; i++) ...[
-            if (i > 0)
-              Divider(
-                height: 1,
-                thickness: 0.5,
-                color: cs.outlineVariant.withValues(alpha: 0.4),
-              ),
+            if (i > 0) divider,
             _ActionRow(action: actions[i]),
+          ],
+          if (moreAction != null) ...[
+            if (actions.isNotEmpty) divider,
+            _ActionRow(action: moreAction!, popOnTap: false),
           ],
         ],
       ),
@@ -373,9 +407,13 @@ class _QuickReactBar extends StatelessWidget {
 }
 
 class _ActionRow extends StatelessWidget {
-  const _ActionRow({required this.action});
+  const _ActionRow({required this.action, this.popOnTap = true});
 
   final MessageAction action;
+
+  /// When false the row invokes [action.onTap] without dismissing the sheet
+  /// (used by the "More…" row to swap tiers).
+  final bool popOnTap;
 
   @override
   Widget build(BuildContext context) {
@@ -384,7 +422,7 @@ class _ActionRow extends StatelessWidget {
 
     return InkWell(
       onTap: () {
-        Navigator.of(context).pop();
+        if (popOnTap) Navigator.of(context).pop();
         action.onTap();
       },
       child: SizedBox(

--- a/lib/features/chat/widgets/message_bubble_context_menu.dart
+++ b/lib/features/chat/widgets/message_bubble_context_menu.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:kohera/shared/widgets/popup_menu_item_row.dart';
 
+/// Vertical offset of the secondary "More…" menu from the primary anchor,
+/// so the second tier does not reopen over the same tap point.
+const double _secondaryMenuOffset = 48;
+
 Future<void> showMessageContextMenu(
   BuildContext context, {
   required bool isMe,
@@ -23,8 +27,10 @@ Future<void> showMessageContextMenu(
   VoidCallback? onReport,
 }) async {
   final cs = Theme.of(context).colorScheme;
-  final items = <PopupMenuItem<String>>[
-    if (isFailed) ...[
+
+  // ── Failed branch: Retry / Discard only ──────────────────────
+  if (isFailed) {
+    final failedItems = <PopupMenuItem<String>>[
       if (onRetrySend != null)
         menuItemRow(Icons.refresh_rounded, 'Retry sending', 'outbox_retry'),
       if (onDiscardSend != null)
@@ -34,14 +40,67 @@ Future<void> showMessageContextMenu(
           'outbox_discard',
           color: cs.error,
         ),
-    ] else ...[
-      if (onReply != null) menuItemRow(Icons.reply_rounded, 'Reply', 'reply'),
+    ];
+    if (failedItems.isEmpty) return;
+    final value = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        position.dx,
+        position.dy,
+        position.dx,
+        position.dy,
+      ),
+      color: cs.surfaceContainer,
+      items: failedItems,
+    );
+    if (!context.mounted) return;
+    if (value == 'outbox_retry') onRetrySend?.call();
+    if (value == 'outbox_discard') onDiscardSend?.call();
+    return;
+  }
+
+  // ── Primary tier ─────────────────────────────────────────────
+  final hasSecondary = [
+    onReplyInThread,
+    onForward,
+    onPin,
+    onIgnoreSender,
+    onReport,
+  ].any((c) => c != null);
+
+  final primaryItems = <PopupMenuItem<String>>[
+    if (onReply != null) menuItemRow(Icons.reply_rounded, 'Reply', 'reply'),
+    if (onReact != null)
+      menuItemRow(Icons.add_reaction_outlined, 'React', 'react'),
+    if (onEdit != null) menuItemRow(Icons.edit_rounded, 'Edit', 'edit'),
+    if (!isRedacted) menuItemRow(Icons.copy_rounded, 'Copy', 'copy'),
+    if (onDelete != null)
+      menuItemRow(
+        Icons.delete_outline_rounded,
+        isMe ? 'Delete' : 'Remove',
+        'delete',
+        color: cs.error,
+      ),
+    if (hasSecondary) menuItemRow(Icons.more_horiz_rounded, 'More…', 'more'),
+  ];
+  if (primaryItems.isEmpty) return;
+
+  final primary = await showMenu<String>(
+    context: context,
+    position: RelativeRect.fromLTRB(
+      position.dx,
+      position.dy,
+      position.dx,
+      position.dy,
+    ),
+    color: cs.surfaceContainer,
+    items: primaryItems,
+  );
+  if (!context.mounted) return;
+  if (primary == 'more') {
+    final secondaryItems = <PopupMenuItem<String>>[
       if (onReplyInThread != null)
         menuItemRow(Icons.forum_outlined, 'Reply in thread', 'reply_in_thread'),
-      if (onEdit != null) menuItemRow(Icons.edit_rounded, 'Edit', 'edit'),
-      if (onReact != null)
-        menuItemRow(Icons.add_reaction_outlined, 'React', 'react'),
-      if (!isRedacted) menuItemRow(Icons.copy_rounded, 'Copy', 'copy'),
       if (onForward != null)
         menuItemRow(Icons.forward_rounded, 'Forward', 'forward'),
       if (onPin != null)
@@ -64,42 +123,85 @@ Future<void> showMessageContextMenu(
           'report',
           color: cs.error,
         ),
-      if (onDelete != null)
-        menuItemRow(
-          Icons.delete_outline_rounded,
-          isMe ? 'Delete' : 'Remove',
-          'delete',
-          color: cs.error,
-        ),
-    ],
-  ];
-  if (items.isEmpty) return;
-  final value = await showMenu<String>(
-    context: context,
-    position: RelativeRect.fromLTRB(
-        position.dx, position.dy, position.dx, position.dy,),
-    color: cs.surfaceContainer,
-    items: items,
+    ];
+    final secondary = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        position.dx,
+        position.dy + _secondaryMenuOffset,
+        position.dx,
+        position.dy + _secondaryMenuOffset,
+      ),
+      color: cs.surfaceContainer,
+      items: secondaryItems,
+    );
+    if (!context.mounted) return;
+    await _dispatchMenuValue(
+      secondary,
+      onReply: onReply,
+      onEdit: onEdit,
+      onReact: onReact,
+      onPin: onPin,
+      onDelete: onDelete,
+      onReplyInThread: onReplyInThread,
+      onForward: onForward,
+      onIgnoreSender: onIgnoreSender,
+      onReport: onReport,
+      copyableBody: copyableBody,
+    );
+    return;
+  }
+
+  await _dispatchMenuValue(
+    primary,
+    onReply: onReply,
+    onEdit: onEdit,
+    onReact: onReact,
+    onPin: onPin,
+    onDelete: onDelete,
+    onReplyInThread: onReplyInThread,
+    onForward: onForward,
+    onIgnoreSender: onIgnoreSender,
+    onReport: onReport,
+    copyableBody: copyableBody,
   );
-  if (!context.mounted) return;
-  if (value == 'outbox_retry') {
-    onRetrySend?.call();
-    return;
+}
+
+Future<void> _dispatchMenuValue(
+  String? value, {
+  required String copyableBody,
+  VoidCallback? onReply,
+  VoidCallback? onEdit,
+  VoidCallback? onReact,
+  VoidCallback? onPin,
+  VoidCallback? onDelete,
+  VoidCallback? onReplyInThread,
+  VoidCallback? onForward,
+  VoidCallback? onIgnoreSender,
+  VoidCallback? onReport,
+}) async {
+  switch (value) {
+    case 'reply':
+      onReply?.call();
+    case 'forward':
+      onForward?.call();
+    case 'reply_in_thread':
+      onReplyInThread?.call();
+    case 'react':
+      onReact?.call();
+    case 'edit':
+      onEdit?.call();
+    case 'pin':
+      onPin?.call();
+    case 'ignore_sender':
+      onIgnoreSender?.call();
+    case 'report':
+      onReport?.call();
+    case 'copy':
+      await Clipboard.setData(ClipboardData(text: copyableBody));
+    case 'delete':
+      onDelete?.call();
+    default:
+      break;
   }
-  if (value == 'outbox_discard') {
-    onDiscardSend?.call();
-    return;
-  }
-  if (value == 'reply') onReply?.call();
-  if (value == 'forward') onForward?.call();
-  if (value == 'reply_in_thread') onReplyInThread?.call();
-  if (value == 'react') onReact?.call();
-  if (value == 'edit') onEdit?.call();
-  if (value == 'pin') onPin?.call();
-  if (value == 'ignore_sender') onIgnoreSender?.call();
-  if (value == 'report') onReport?.call();
-  if (value == 'copy') {
-    await Clipboard.setData(ClipboardData(text: copyableBody));
-  }
-  if (value == 'delete') onDelete?.call();
 }

--- a/test/widgets/chat/message_action_sheet_test.dart
+++ b/test/widgets/chat/message_action_sheet_test.dart
@@ -56,6 +56,7 @@ Finder _emojiImage(String emoji) => find.byWidgetPredicate(
 void main() {
   Widget buildTestWidget({
     required List<MessageAction> actions,
+    List<MessageAction> secondaryActions = const [],
     void Function(String emoji)? onQuickReact,
     KoheraMessageDisplay? message,
   }) {
@@ -75,6 +76,7 @@ void main() {
                   isMe: true,
                   bubbleRect: const Rect.fromLTWH(50, 50, 300, 60),
                   actions: actions,
+                  secondaryActions: secondaryActions,
                   avatarResolver: const _FakeAvatarResolver(),
                   mentionResolver: (_) => null,
                   mediaResolver: const _FakeMediaResolver(),
@@ -219,6 +221,72 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Reply'), findsNothing);
+    });
+  });
+
+  group('Two-tier More…', () {
+    testWidgets('More… row appears only when secondary actions are set',
+        (tester) async {
+      suppressLayoutErrors(tester);
+      final primary = [
+        MessageAction(label: 'Reply', icon: Icons.reply, onTap: () {}),
+      ];
+
+      await tester.pumpWidget(buildTestWidget(actions: primary));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('More…'), findsNothing);
+      await tester.tapAt(Offset.zero);
+      await tester.pumpAndSettle();
+
+      await tester.pumpWidget(buildTestWidget(
+        actions: primary,
+        secondaryActions: [
+          MessageAction(label: 'Forward', icon: Icons.forward, onTap: () {}),
+        ],
+      ));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('More…'), findsOneWidget);
+      expect(find.text('Forward'), findsNothing);
+    });
+
+    testWidgets('tapping More… swaps to the secondary tier and fires its handler',
+        (tester) async {
+      suppressLayoutErrors(tester);
+      var forwarded = false;
+      await tester.pumpWidget(buildTestWidget(
+        actions: [
+          MessageAction(label: 'Reply', icon: Icons.reply, onTap: () {}),
+        ],
+        secondaryActions: [
+          MessageAction(
+            label: 'Forward',
+            icon: Icons.forward,
+            onTap: () => forwarded = true,
+          ),
+        ],
+      ));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Reply'), findsOneWidget);
+      expect(find.text('Forward'), findsNothing);
+
+      await tester.tap(find.text('More…'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Forward'), findsOneWidget);
+      expect(find.text('Reply'), findsNothing);
+      expect(find.text('More…'), findsNothing);
+
+      await tester.tap(find.text('Forward'));
+      await tester.pumpAndSettle();
+
+      expect(forwarded, isTrue);
+      expect(find.text('Forward'), findsNothing);
     });
   });
 }

--- a/test/widgets/chat/message_actions_test.dart
+++ b/test/widgets/chat/message_actions_test.dart
@@ -1059,4 +1059,202 @@ void main() {
       expect(find.text('Edited message'), findsNothing);
     });
   });
+
+  // ── Two-tier context menu ───────────────────────────────────
+
+  Widget menuHarness({required VoidCallback onOpen}) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => Center(
+            child: ElevatedButton(
+              onPressed: onOpen,
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('Two-tier context menu', () {
+    testWidgets('primary tier shows 5 actions + More… when all callbacks set',
+        (tester) async {
+      final fired = <String>[];
+      await tester.pumpWidget(
+        menuHarness(
+          onOpen: () => showMessageContextMenu(
+            tester.element(find.text('open')),
+            isMe: false,
+            isPinned: false,
+            isFailed: false,
+            isRedacted: false,
+            copyableBody: 'hi',
+            position: const Offset(100, 100),
+            onReply: () => fired.add('reply'),
+            onEdit: () => fired.add('edit'),
+            onReact: () => fired.add('react'),
+            onDelete: () => fired.add('delete'),
+            onReplyInThread: () => fired.add('reply_in_thread'),
+            onForward: () => fired.add('forward'),
+            onPin: () => fired.add('pin'),
+            onIgnoreSender: () => fired.add('ignore_sender'),
+            onReport: () => fired.add('report'),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byWidgetPredicate((w) => w is PopupMenuItem<String>),
+        findsNWidgets(6),
+      );
+      expect(find.text('Reply'), findsOneWidget);
+      expect(find.text('React'), findsOneWidget);
+      expect(find.text('Edit'), findsOneWidget);
+      expect(find.text('Copy'), findsOneWidget);
+      expect(find.text('Remove'), findsOneWidget);
+      expect(find.text('More…'), findsOneWidget);
+      // Secondary actions are not yet visible.
+      expect(find.text('Reply in thread'), findsNothing);
+      expect(find.text('Forward'), findsNothing);
+      expect(find.text('Ignore user'), findsNothing);
+      expect(fired, isEmpty);
+    });
+
+    testWidgets('More… is omitted when no secondary callbacks are set',
+        (tester) async {
+      await tester.pumpWidget(
+        menuHarness(
+          onOpen: () => showMessageContextMenu(
+            tester.element(find.text('open')),
+            isMe: true,
+            isPinned: false,
+            isFailed: false,
+            isRedacted: false,
+            copyableBody: 'hi',
+            position: const Offset(100, 100),
+            onReply: () {},
+            onEdit: () {},
+            onDelete: () {},
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Reply'), findsOneWidget);
+      expect(find.text('Edit'), findsOneWidget);
+      expect(find.text('Delete'), findsOneWidget);
+      expect(find.text('More…'), findsNothing);
+    });
+
+    testWidgets('tapping More… opens the secondary tier and fires its handler',
+        (tester) async {
+      final fired = <String>[];
+      await tester.pumpWidget(
+        menuHarness(
+          onOpen: () => showMessageContextMenu(
+            tester.element(find.text('open')),
+            isMe: false,
+            isPinned: false,
+            isFailed: false,
+            isRedacted: false,
+            copyableBody: 'hi',
+            position: const Offset(100, 100),
+            onReply: () => fired.add('reply'),
+            onEdit: () => fired.add('edit'),
+            onReact: () => fired.add('react'),
+            onDelete: () => fired.add('delete'),
+            onReplyInThread: () => fired.add('reply_in_thread'),
+            onForward: () => fired.add('forward'),
+            onPin: () => fired.add('pin'),
+            onIgnoreSender: () => fired.add('ignore_sender'),
+            onReport: () => fired.add('report'),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('More…'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Reply in thread'), findsOneWidget);
+      expect(find.text('Forward'), findsOneWidget);
+      expect(find.text('Pin'), findsOneWidget);
+      expect(find.text('Ignore user'), findsOneWidget);
+      expect(find.text('Report'), findsOneWidget);
+      // Primary tier closed.
+      expect(find.text('Reply'), findsNothing);
+      expect(find.text('More…'), findsNothing);
+
+      await tester.tap(find.text('Forward'));
+      await tester.pumpAndSettle();
+
+      expect(fired, ['forward']);
+    });
+
+    testWidgets('secondary tier reflects pinned state as Unpin', (tester) async {
+      await tester.pumpWidget(
+        menuHarness(
+          onOpen: () => showMessageContextMenu(
+            tester.element(find.text('open')),
+            isMe: true,
+            isPinned: true,
+            isFailed: false,
+            isRedacted: false,
+            copyableBody: 'hi',
+            position: const Offset(100, 100),
+            onReply: () {},
+            onPin: () {},
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('More…'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Unpin'), findsOneWidget);
+      expect(find.text('Pin'), findsNothing);
+    });
+
+    testWidgets('failed branch shows only Retry / Discard', (tester) async {
+      final fired = <String>[];
+      await tester.pumpWidget(
+        menuHarness(
+          onOpen: () => showMessageContextMenu(
+            tester.element(find.text('open')),
+            isMe: true,
+            isPinned: false,
+            isFailed: true,
+            isRedacted: false,
+            copyableBody: 'hi',
+            position: const Offset(100, 100),
+            onRetrySend: () => fired.add('retry'),
+            onDiscardSend: () => fired.add('discard'),
+            onReply: () => fired.add('reply'),
+            onReport: () => fired.add('report'),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Retry sending'), findsOneWidget);
+      expect(find.text('Discard message'), findsOneWidget);
+      expect(
+        find.byWidgetPredicate((w) => w is PopupMenuItem<String>),
+        findsNWidgets(2),
+      );
+      expect(find.text('More…'), findsNothing);
+      expect(find.text('Reply'), findsNothing);
+
+      await tester.tap(find.text('Retry sending'));
+      await tester.pumpAndSettle();
+      expect(fired, ['retry']);
+    });
+  });
 }

--- a/test/widgets/chat/pinned_messages_test.dart
+++ b/test/widgets/chat/pinned_messages_test.dart
@@ -405,6 +405,8 @@ void main() {
         buttons: kSecondaryButton,
       );
       await tester.pumpAndSettle();
+      await tester.tap(find.text('More…'));
+      await tester.pumpAndSettle();
 
       expect(find.text('Pin'), findsOneWidget);
     });
@@ -487,6 +489,8 @@ void main() {
         buttons: kSecondaryButton,
       );
       await tester.pumpAndSettle();
+      await tester.tap(find.text('More…'));
+      await tester.pumpAndSettle();
       await tester.tap(find.text('Pin'));
       await tester.pumpAndSettle();
 
@@ -529,6 +533,8 @@ void main() {
         tester.getTopLeft(find.text('Unpin me')) + const Offset(8, 8),
         buttons: kSecondaryButton,
       );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('More…'));
       await tester.pumpAndSettle();
       await tester.tap(find.text('Unpin'));
       await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary

Reduces the message bubble context menu's perceived size by splitting it into a primary tier of most-used actions plus a `More…` entry that reopens a secondary menu for less frequent actions.

## Changes

- `lib/features/chat/widgets/message_bubble_context_menu.dart` — `showMessageContextMenu` refactored into a two-tier flow.
  - Primary tier (non-failed): Reply, React, Edit, Copy, Delete/Remove, `More…` (last only when at least one secondary callback is non-null).
  - Secondary tier (after `More…`): Reply in thread, Forward, Pin/Unpin, Ignore user, Report — each gated on its callback.
  - Failed branch unchanged: Retry sending / Discard message only.
  - Secondary `showMenu` opens 48px below the primary anchor so it does not reopen over the same tap point.
  - `showMessageContextMenu` signature unchanged; `chat_screen.dart` callers untouched.
- `test/widgets/chat/message_actions_test.dart` — new `Two-tier context menu` group: 5+More… primary layout, `More…` omission, secondary dispatch + handler firing, pinned-state label, failed branch.
- `test/widgets/chat/pinned_messages_test.dart` — existing pin tests now open `More…` before tapping Pin/Unpin.

## Testing

- [x] `flutter analyze` clean on changed files
- [x] `flutter test test/widgets/chat` — 340 pass
- [x] Full suite: 2490 pass; only the 2 pre-existing `message_bubble_golden_test` PICO-8 cases fail (font rendering, also fail on `master`, unrelated)
- [x] No `@GenerateNiceMocks` changes — `build_runner` not required

## Acceptance criteria

- [x] Primary menu shows at most 6 items (5 primary + `More…`) in the non-failed branch
- [x] Failed branch shows only Retry / Discard
- [x] Tapping `More…` opens a second `showMenu` with the secondary actions whose callbacks are non-null
- [x] No secondary callback is lost; each still fires its original handler
- [x] `flutter analyze` passes
- [x] Existing context-menu/pin tests updated and pass

## Linked issues

Closes #830