### PR TITLE
feat(#863): scaffold iOS Share Extension + active-account-id persistence

### DIFF
--- a/ios/KoheraShare/Info.plist
+++ b/ios/KoheraShare/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
+				<integer>10</integer>
+				<key>NSExtensionActivationSupportsMovieWithMaxCount</key>
+				<integer>5</integer>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
+				<integer>10</integer>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ios/KoheraShare/KoheraShare.entitlements
+++ b/ios/KoheraShare/KoheraShare.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.io.github.quantumheart.kohera</string>
+	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)io.github.quantumheart.kohera.shared</string>
+	</array>
+</dict>
+</plist>

--- a/ios/KoheraShare/README.md
+++ b/ios/KoheraShare/README.md
@@ -1,0 +1,100 @@
+# KoheraShare — iOS Share Extension target setup
+
+This folder holds the source files for the inbound Share Extension target
+(issue #863). The target itself must be added via Xcode (hand-editing
+`project.pbxproj` is avoided to protect the existing Runner build). Follow
+the steps below once, then commit the resulting `project.pbxproj` changes.
+
+## Files provided
+
+- `ShareViewController.swift` — principal class; in-sheet room picker reading
+  the App-Group `roomSnapshot` store, stages attachments via
+  `NSFileCoordinator`, appends `pendingShares` entries.
+- `Info.plist` — `NSExtension` block (`com.apple.share-services`,
+  activation rule: images ≤10, movies ≤5, text, web URL ≤1, files ≤10).
+- `KoheraShare.entitlements` — App Group `group.io.github.quantumheart.kohera`
+  + keychain sharing `$(AppIdentifierPrefix)io.github.quantumheart.kohera.shared`
+  (mirrors `Runner.entitlements` and `KoheraNotificationService.entitlements`).
+
+## Add the target in Xcode
+
+1. Open `ios/Runner.xcworkspace` in Xcode.
+2. Select the `Runner` project in the navigator → **File → New → Target…**
+3. iOS tab → **Share Extension** → Next.
+   - Product name: `KoheraShare`
+   - Organization identifier: same as Runner (`io.github.quantumheart` so the
+     bundle id becomes `io.github.quantumheart.kohera.KoheraShare` — adjust to
+     match your signing; the issue targets `com.kohera.app.Share` but the
+     existing app bundle id is `io.github.quantumheart.kohera`, so use that
+     prefix to keep App-Group/keychain sharing valid).
+   - Language: Swift.
+   - Uncheck "Include UI test target".
+4. Finish. Xcode creates `KoheraShare/` with a default
+   `ShareViewController.swift` and `Info.plist`. **Delete the generated**
+   `ShareViewController.swift` and **move the three files in this folder into**
+   the `KoheraShare/` group (drag into the Xcode navigator, "Copy items if
+   needed" off since they already live here). Replace the generated
+   `Info.plist` with the one here.
+5. Select the `KoheraShare` target → **Signing & Capabilities**:
+   - Enable **App Groups** → add `group.io.github.quantumheart.kohera`.
+   - Enable **Keychain Sharing** → add
+     `$(AppIdentifierPrefix)io.github.quantumheart.kohera.shared`.
+   - (Or set the code-sign entitlements file to `KoheraShare.entitlements`
+     under Build Settings → Code Signing Entitlements.)
+6. Target **Build Settings**:
+   - Info.plist File → `KoheraShare/Info.plist`.
+   - Code Signing Entitlements → `KoheraShare/KoheraShare.entitlements`.
+   - Product Bundle Identifier → `io.github.quantumheart.kohera.KoheraShare`.
+   - iOS Deployment Target → match Runner (see `Podfile` platform).
+7. Select the `Runner` target → **General → Frameworks, Libraries, and
+   Embedded Content** (or **Build Phases → Embed Foundation Extensions**):
+   confirm `KoheraShare.appex` is listed with "Embed Without Code Signing"
+   (or the embed option Xcode picks for app extensions). The existing
+   `KoheraNotificationService.appex` is the template — mirror its embed row.
+8. Provisioning: both `Runner` and `KoheraShare` targets need a profile that
+   includes the App Group capability. Use the same team as Runner.
+
+## Build & verify
+
+1. `flutter pub get` (so the workspace is up to date), then build from Xcode:
+   `flutter build ios --debug` (or run from Xcode on a device/sim).
+2. From Photos / Files / Safari / Notes, open the share sheet → Kohera should
+   appear.
+3. Select Kohera → the room picker should list rooms from the `roomSnapshot`
+   store (populate by launching the main app first and letting sync run —
+   slice #862 writes the store).
+4. Pick a room → Post → inspect
+   `UserDefaults(suiteName:"group.io.github.quantumheart.kohera")?.string(forKey:"pendingShares")`
+   to confirm the entry was enqueued.
+
+## Schema contract (must match slice #862)
+
+`pendingShares` entries:
+
+```json
+{
+  "id": "<uuid>",
+  "targetRoomId": "!room:server",
+  "accountId": "<MatrixService.clientName>",
+  "kind": "text" | "file",
+  "text": "..." | null,
+  "filePath": "/abs/path/in/app-group" | null,
+  "mimeType": "image/png" | null,
+  "originalFileName": "photo.png" | null,
+  "createdAt": 1700000000000
+}
+```
+
+`roomSnapshot` (read-only here, written by main app):
+
+```json
+[{ "roomId": "!room:server", "displayname": "Project", "avatarMxc": "mxc://..." }]
+```
+
+`activeAccountId` (read-only here): the active account's clientName string.
+
+## Out of scope for this slice
+
+- Draining `pendingShares` and performing the Matrix send — slice #864.
+- Outbound sharing — `share_plus` issue.
+- Android / desktop inbound.

--- a/ios/KoheraShare/ShareViewController.swift
+++ b/ios/KoheraShare/ShareViewController.swift
@@ -1,0 +1,331 @@
+import UIKit
+import MobileCoreServices
+import UniformTypeIdentifiers
+
+/// Share Extension principal class.
+///
+/// Shows an in-sheet room picker populated from the App-Group `roomSnapshot`
+/// store the main app writes on sync. On Post, copies each attachment into the
+/// App-Group container via NSFileCoordinator and appends a `pendingShares`
+/// entry (matching the Dart `PendingShare` schema) so the main app can drain
+/// it and perform the real Matrix send. The Matrix SDK never runs here.
+final class ShareViewController: UIViewController {
+  private let appGroup = "group.io.github.quantumheart.kohera"
+  private let snapshotKey = "roomSnapshot"
+  private let pendingKey = "pendingShares"
+  private let activeAccountKey = "activeAccountId"
+
+  private var rooms: [RoomPick] = []
+  private var accountId: String?
+  private var selectedRoom: RoomPick?
+
+  private let tableView = UITableView(frame: .zero, style: .plain)
+  private let emptyLabel = UILabel()
+  private let postButton = UIBarButtonItem(
+    title: "Post",
+    style: .done,
+    target: nil,
+    action: nil
+  )
+
+  struct RoomPick {
+    let roomId: String
+    let displayname: String
+    let avatarMxc: String?
+  }
+
+  // ── Lifecycle ───────────────────────────────────────────────
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    title = "Share to Kohera"
+    navigationItem.leftBarButtonItem = UIBarButtonItem(
+      barButtonSystemItem: .cancel,
+      target: self,
+      action: #selector(cancel)
+    )
+    postButton.isEnabled = false
+    postButton.target = self
+    postButton.action = #selector(post)
+    navigationItem.rightBarButtonItem = postButton
+
+    view.backgroundColor = .systemBackground
+    configureEmptyLabel()
+    configureTableView()
+    loadFromAppGroup()
+  }
+
+  private func configureEmptyLabel() {
+    emptyLabel.translatesAutoresizingMaskIntoConstraints = false
+    emptyLabel.text = "Open Kohera and log in to populate the room list."
+    emptyLabel.textAlignment = .center
+    emptyLabel.textColor = .secondaryLabel
+    emptyLabel.numberOfLines = 0
+    emptyLabel.font = .preferredFont(forTextStyle: .body)
+    view.addSubview(emptyLabel)
+    NSLayoutConstraint.activate([
+      emptyLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+      emptyLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+      emptyLabel.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 24),
+      emptyLabel.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -24),
+    ])
+  }
+
+  private func configureTableView() {
+    tableView.translatesAutoresizingMaskIntoConstraints = false
+    tableView.dataSource = self
+    tableView.delegate = self
+    tableView.register(UITableViewCell.self, forCellReuseIdentifier: "room")
+    view.addSubview(tableView)
+    NSLayoutConstraint.activate([
+      tableView.topAnchor.constraint(equalTo: view.topAnchor),
+      tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+      tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+    ])
+  }
+
+  // ── App-Group read ──────────────────────────────────────────
+
+  private func loadFromAppGroup() {
+    guard let suite = UserDefaults(suiteName: appGroup) else {
+      showEmpty()
+      return
+    }
+    accountId = suite.string(forKey: activeAccountKey)
+
+    guard let raw = suite.string(forKey: snapshotKey),
+          let data = raw.data(using: .utf8),
+          let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+      showEmpty()
+      return
+    }
+
+    rooms = arr.compactMap { dict in
+      guard let roomId = dict["roomId"] as? String,
+            let displayname = dict["displayname"] as? String else { return nil }
+      return RoomPick(
+        roomId: roomId,
+        displayname: displayname,
+        avatarMxc: dict["avatarMxc"] as? String
+      )
+    }
+    showEmpty()
+  }
+
+  private func showEmpty() {
+    let empty = rooms.isEmpty
+    tableView.isHidden = empty
+    emptyLabel.isHidden = !empty
+    tableView.reloadData()
+  }
+
+  // ── Actions ─────────────────────────────────────────────────
+
+  @objc private func cancel() {
+    extensionContext?.cancelRequest(withError: NSError(domain: "KoheraShare", code: 0))
+  }
+
+  @objc private func post() {
+    guard let room = selectedRoom else { return }
+    postButton.isEnabled = false
+
+    stageAndEnqueue(targetRoom: room) { [weak self] in
+      DispatchQueue.main.async {
+        self?.extensionContext?.completeRequest(returningItems: nil)
+      }
+    }
+  }
+
+  // ── Staging ─────────────────────────────────────────────────
+
+  private func stageAndEnqueue(targetRoom: RoomPick, completion: @escaping () -> Void) {
+    guard let items = extensionContext?.inputItems as? [NSExtensionItem], !items.isEmpty else {
+      enqueueTextShare(targetRoom: targetRoom, text: nil, completion: completion)
+      return
+    }
+
+    let group = DispatchGroup()
+    var staged: [[String: Any]] = []
+
+    for item in items {
+      guard let attachments = item.attachments else { continue }
+      for provider in attachments {
+        group.enter()
+        stageAttachment(provider: provider) { entry in
+          if let entry = entry { staged.append(entry) }
+          group.leave()
+        }
+      }
+    }
+
+    group.notify(queue: .main) { [weak self] in
+      guard let self else { completion(); return }
+      if staged.isEmpty {
+        // Fallback: treat the share as plain text if we could not stage a file.
+        self.enqueueTextShare(targetRoom: targetRoom, text: nil, completion: completion)
+      } else {
+        self.enqueue(staged: staged, targetRoom: targetRoom, completion: completion)
+      }
+    }
+  }
+
+  private func stageAttachment(
+    provider: NSItemProvider,
+    done: @escaping ([String: Any]?) -> Void
+  ) {
+    // Text payload → no file staging; carry the string directly.
+    if provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) {
+      provider.loadItem(forTypeIdentifier: UTType.plainText.identifier, options: nil) { item, _ in
+        let text = (item as? String) ?? (item as? URL)?.absoluteString
+        done(text.map { ["kind": "text", "text": $0] })
+      }
+      return
+    }
+
+    // URL payload → carry the URL string as a text share.
+    if provider.hasItemConformingToTypeIdentifier(UTType.url.identifier) {
+      provider.loadItem(forTypeIdentifier: UTType.url.identifier, options: nil) { item, _ in
+        let text = (item as? URL)?.absoluteString ?? (item as? String)
+        done(text.map { ["kind": "text", "text": $0] })
+      }
+      return
+    }
+
+    // File-backed payload → copy into the App Group container via
+    // NSFileCoordinator (required for Photos / iCloud provider items).
+    let typeIdentifier = provider.registeredTypeIdentifiers.first ?? UTType.data.identifier
+    provider.loadFileRepresentation(forTypeIdentifier: typeIdentifier) { [weak self] tempURL, error in
+      guard let self, let tempURL = tempURL, error == nil else { done(nil); return }
+      self.copyIntoAppGroup(tempURL: tempURL, provider: provider) { entry in
+        done(entry)
+      }
+    }
+  }
+
+  private func copyIntoAppGroup(
+    tempURL: URL,
+    provider: NSItemProvider,
+    done: @escaping ([String: Any]?) -> Void
+  ) {
+    guard let container = FileManager.default.containerURL(
+      forSecurityApplicationGroupIdentifier: appGroup
+    ) else { done(nil); return }
+
+    let dir = container.appendingPathComponent("share_in", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+    let originalName = provider.suggestedName ?? tempURL.lastPathComponent
+    let stagedName = "\(UUID().uuidString)_\(originalName)"
+    let dest = dir.appendingPathComponent(stagedName)
+
+    let coordinator = NSFileCoordinator()
+    coordinator.coordinate(readingItemAt: tempURL, options: [.withoutChanges], error: nil) { src in
+      do {
+        try FileManager.default.copyItem(at: src, to: dest)
+        let mime = self.mime(for: tempURL, provider: provider)
+        done([
+          "kind": "file",
+          "filePath": dest.path,
+          "mimeType": mime,
+          "originalFileName": originalName,
+        ])
+      } catch {
+        NSLog("[Kohera] Share staging copy failed: \(error)")
+        done(nil)
+      }
+    }
+  }
+
+  private func mime(for url: URL, provider: NSItemProvider) -> String {
+    if let type = UTType(filenameExtension: url.pathExtension),
+       let mime = type.preferredMIMEType {
+      return mime
+    }
+    if let id = provider.registeredTypeIdentifiers.first,
+       let type = UTType(id), let mime = type.preferredMIMEType {
+      return mime
+    }
+    return "application/octet-stream"
+  }
+
+  // ── Enqueue ─────────────────────────────────────────────────
+
+  private func enqueueTextShare(
+    targetRoom: RoomPick,
+    text: String?,
+    completion: @escaping () -> Void
+  ) {
+    guard let text = text, !text.isEmpty else { completion(); return }
+    let entry: [String: Any] = [
+      "id": UUID().uuidString,
+      "targetRoomId": targetRoom.roomId,
+      "accountId": accountId ?? "",
+      "kind": "text",
+      "text": text,
+      "createdAt": Int(Date().timeIntervalSince1970 * 1000),
+    ]
+    appendPending(entry: entry, completion: completion)
+  }
+
+  private func enqueue(
+    staged: [[String: Any]],
+    targetRoom: RoomPick,
+    completion: @escaping () -> Void
+  ) {
+    let createdAt = Int(Date().timeIntervalSince1970 * 1000)
+    let group = DispatchGroup()
+    for entry in staged {
+      group.enter()
+      var full: [String: Any] = [
+        "id": UUID().uuidString,
+        "targetRoomId": targetRoom.roomId,
+        "accountId": accountId ?? "",
+        "createdAt": createdAt,
+      ]
+      for (k, v) in entry { full[k] = v }
+      appendPending(entry: full) { group.leave() }
+    }
+    group.notify(queue: .main) { completion() }
+  }
+
+  private func appendPending(entry: [String: Any], completion: @escaping () -> Void) {
+    guard let suite = UserDefaults(suiteName: appGroup) else { completion(); return }
+    var arr: [[String: Any]] = []
+    if let raw = suite.string(forKey: pendingKey),
+       let data = raw.data(using: .utf8),
+       let existing = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
+      arr = existing
+    }
+    arr.append(entry)
+    if let back = try? JSONSerialization.data(withJSONObject: arr),
+       let s = String(data: back, encoding: .utf8) {
+      suite.set(s, forKey: pendingKey)
+      NSLog("[Kohera] Share enqueued for room \(entry["targetRoomId"] ?? "?")")
+    }
+    completion()
+  }
+}
+
+// ── Table view ─────────────────────────────────────────────────
+
+extension ShareViewController: UITableViewDataSource, UITableViewDelegate {
+  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    rooms.count
+  }
+
+  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    let cell = tableView.dequeueReusableCell(withIdentifier: "room", for: indexPath)
+    var content = cell.defaultContentConfiguration()
+    content.text = rooms[indexPath.row].displayname
+    cell.contentConfiguration = content
+    cell.accessoryType = rooms[indexPath.row].roomId == selectedRoom?.roomId ? .checkmark : .none
+    return cell
+  }
+
+  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    selectedRoom = rooms[indexPath.row]
+    postButton.isEnabled = true
+    tableView.reloadRows(at: [indexPath], with: .none)
+  }
+}

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -274,6 +274,13 @@ import UserNotifications
       case "clearAllPendingShares":
         suite?.removeObject(forKey: "pendingShares")
         result(nil)
+      case "readActiveAccountId":
+        result(suite?.string(forKey: "activeAccountId"))
+      case "writeActiveAccountId":
+        if let id = call.arguments as? String {
+          suite?.set(id, forKey: "activeAccountId")
+        }
+        result(nil)
       default:
         result(FlutterMethodNotImplemented)
       }

--- a/lib/features/share_in/services/share_in_store.dart
+++ b/lib/features/share_in/services/share_in_store.dart
@@ -11,6 +11,11 @@ const String kRoomSnapshotKey = 'roomSnapshot';
 /// App-Group shared-defaults key holding the JSON array of [PendingShare].
 const String kPendingSharesKey = 'pendingShares';
 
+/// App-Group shared-defaults key holding the active account's clientName
+/// (the `MatrixService.clientName` the Share Extension should attribute
+/// staged shares to).
+const String kActiveAccountIdKey = 'activeAccountId';
+
 /// Write-only target for [RoomSnapshotService] so it can be tested without a
 /// real platform channel.
 abstract class RoomSnapshotSink {
@@ -55,6 +60,21 @@ class ShareInStore implements RoomSnapshotSink {
 
   Future<void> clearAllPendingShares() async {
     await _invokeVoid('clearAllPendingShares', null);
+  }
+
+  Future<String?> readActiveAccountId() async {
+    try {
+      return await _channel.invokeMethod<String>('readActiveAccountId');
+    } on PlatformException catch (e) {
+      debugPrint('[Kohera] ShareInStore readActiveAccountId unavailable: $e');
+      return null;
+    } on MissingPluginException {
+      return null;
+    }
+  }
+
+  Future<void> writeActiveAccountId(String accountId) async {
+    await _invokeVoid('writeActiveAccountId', accountId);
   }
 
   Future<T?> _invokeJson<T>(String method) async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -107,6 +107,9 @@ class _KoheraAppState extends State<KoheraApp> {
         client: clientManager.activeService.client,
         sink: ShareInStore(),
       )..start();
+      unawaited(ShareInStore().writeActiveAccountId(
+        clientManager.activeService.clientName,
+      ));
     } catch (e) {
       debugPrint('[Kohera] Initialization failed: $e');
       if (!mounted) return;
@@ -147,6 +150,7 @@ class _KoheraAppState extends State<KoheraApp> {
         client: current.client,
         sink: ShareInStore(),
       )..start();
+      unawaited(ShareInStore().writeActiveAccountId(current.clientName));
       setState(() => _displayedService = current);
     });
   }

--- a/test/features/share_in/share_in_store_test.dart
+++ b/test/features/share_in/share_in_store_test.dart
@@ -142,6 +142,31 @@ void main() {
     });
   });
 
+  group('ShareInStore.activeAccountId', () {
+    test('reads the id returned by native', () async {
+      setHandler((call) async {
+        if (call.method == 'readActiveAccountId') return 'default';
+        return null;
+      });
+      expect(await store.readActiveAccountId(), 'default');
+    });
+
+    test('returns null when native returns null', () async {
+      setHandler((call) async => null);
+      expect(await store.readActiveAccountId(), isNull);
+    });
+
+    test('write invokes with id argument', () async {
+      setHandler((call) async {
+        calls.add(MapEntry(call.method, call.arguments));
+        return null;
+      });
+      await store.writeActiveAccountId('work');
+      expect(calls.single.key, 'writeActiveAccountId');
+      expect(calls.single.value, 'work');
+    });
+  });
+
   group('ShareInStore platform-missing degradation', () {
     test('read returns empty when no native handler registered', () async {
       // No mock handler set → MissingPluginException path.


### PR DESCRIPTION
## Summary

Native slice for the iOS inbound Share Extension (#863). Scaffolds the Share Extension source files (custom `ShareViewController` with an in-sheet room picker, `Info.plist`, entitlements) and closes the account-id gap so the extension can populate `PendingShare.accountId`. The Xcode target itself is added via the Xcode UI (one-time, documented in `ios/KoheraShare/README.md`) to avoid hand-editing `project.pbxproj`.

## Changes

- `ios/KoheraShare/ShareViewController.swift` — custom `UIViewController` with a `UITableView` room picker reading the App-Group `roomSnapshot` store; on Post, stages each `NSItemProvider` attachment into the App-Group container via `NSFileCoordinator` (text/URL carried inline, file-backed items copied), appends a `pendingShares` entry matching the Dart `PendingShare` schema, then `completeRequest`. Empty-snapshot and no-account states render without crashing.
- `ios/KoheraShare/Info.plist` — `NSExtension` block: `com.apple.share-services`, principal class `$(PRODUCT_MODULE_NAME).ShareViewController`, activation rule (images ≤10, movies ≤5, text, web URL ≤1, files ≤10).
- `ios/KoheraShare/KoheraShare.entitlements` — App Group `group.io.github.quantumheart.kohera` + keychain sharing `$(AppIdentifierPrefix)io.github.quantumheart.kohera.shared` (mirrors Runner + KoheraNotificationService).
- `ios/KoheraShare/README.md` — precise Xcode target-add checklist (File → New → Target, bundle id, entitlements, embed appex, provisioning) + schema contract.
- `lib/features/share_in/services/share_in_store.dart` — `readActiveAccountId`/`writeActiveAccountId` over the `kohera/share` channel + `kActiveAccountIdKey`.
- `ios/Runner/AppDelegate.swift` — native `readActiveAccountId`/`writeActiveAccountId` handlers on the App-Group `UserDefaults` suite.
- `lib/main.dart` — main app writes the active `MatrixService.clientName` to the store on init and on account switch.
- `test/features/share_in/share_in_store_test.dart` — tests for the new active-account-id store methods.

No `receive_sharing_intent` dependency — it requires Swift Package Manager and the project is Pods-only (see #865).

## Testing

- [x] `flutter analyze` is clean (whole project)
- [x] `flutter test test/features/share_in/` passes (26 tests) — covers the new `activeAccountId` store methods (read native value, null, write invocation) plus the existing model/store/snapshot-service suites.
- [ ] Xcode build of the Share Extension target — **not yet verified**; the target must be added in Xcode per `ios/KoheraShare/README.md`. Build + share-sheet verification belongs to the target-add commit.
- [ ] Acceptance criteria (share sheet from Photos/Files/Safari/Notes, room picker populated, Post enqueues `pendingShares`) — pending the Xcode target-add + device test.

## Screenshots / recordings

Not applicable yet — the extension UI is not buildable until the Xcode target is added.

## Linked issues

Refs #863
Refs #861

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix (Dart) / `NSLog("[Kohera] ...")` (Swift)
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master`