### PR TITLE
chore: add dependabot config for pub and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+
+updates:
+  # Dart/Flutter dependencies (pubspec.yaml)
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      # Group all minor + patch updates into a single PR
+      # to reduce noise. Major version bumps get individual PRs.
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 10
+
+  # GitHub Actions workflow versions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Sets up Dependabot to automatically monitor and create PRs for outdated dependencies.

## Changes

- Added  configuring two ecosystems:
  - **** — Dart/Flutter dependencies in 
  - **** — pinned action versions in workflow files
- Created a `dependencies` label on the repo for filtering Dependabot PRs

## Configuration Details

| Setting | Value |
|---|---|
| Schedule | Weekly (Monday) |
| Minor/patch updates | Grouped into a single PR |
| Major version bumps | Individual PRs for focused review |
| Commit prefix | `chore(deps)` (conventional commits) |
| PR limit (pub) | 10 |
| PR limit (github-actions) | 5 |
| Labels | `dependencies` (+ `ci` for actions) |

## Testing

- [x] Config validates against Dependabot v2 schema
- [ ] Dependabot runs on next scheduled check (Monday) or can be triggered manually via GitHub UI → Insights → Dependency graph → Dependabot

## Linked issues

N/A