### PR TITLE
feat: add deep linking for matrix.to integration

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,6 +44,27 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- Deep link: custom URI scheme -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="io.github.quantumheart.kohera"/>
+            </intent-filter>
+            <!-- Deep link: standard matrix: URI scheme -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="matrix"/>
+            </intent-filter>
+            <!-- Deep link: intercept matrix.to HTTPS links -->
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https" android:host="matrix.to"/>
+            </intent-filter>
         </activity>
         <service
             android:name="de.julianassmann.flutter_background.IsolateHolderService"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -6,6 +6,18 @@
 	<array>
 		<string>INSendMessageIntent</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>io.github.quantumheart.kohera</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>matrix</string>
+				<string>io.github.quantumheart.kohera</string>
+			</array>
+		</dict>
+	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/models/server_auth_capabilities.dart';
 import 'package:kohera/core/routing/account_switch_redirector.dart';
-import 'package:kohera/core/routing/active_matrix_listenable.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/routing/widgets/add_account_shell.dart';
 import 'package:kohera/core/services/app_config.dart';
@@ -40,8 +39,10 @@ import 'package:provider/provider.dart';
 /// The router resolves the active [MatrixService] dynamically from
 /// [manager] so that account switches don't require recreating the router
 /// (which would reset the navigation stack and cause a visible flash).
-GoRouter buildRouter(ClientManager manager) {
-  final refreshListenable = ActiveMatrixListenable(manager);
+GoRouter buildRouter(
+  ClientManager manager, {
+  required Listenable refreshListenable,
+}) {
   final switchRedirector = AccountSwitchRedirector(manager.activeService);
   return GoRouter(
     refreshListenable: refreshListenable,

--- a/lib/core/services/deep_link_service.dart
+++ b/lib/core/services/deep_link_service.dart
@@ -3,6 +3,10 @@ import 'dart:async';
 import 'package:app_links/app_links.dart';
 import 'package:flutter/foundation.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kohera/core/routing/route_names.dart';
+import 'package:kohera/core/services/client_manager.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:matrix/matrix.dart';
 
 /// Receives native deep links (`matrix:`, `io.github.quantumheart.kohera://`,
 /// and `https://matrix.to/…`) and navigates to the matching room or user.
@@ -12,130 +16,329 @@ import 'package:go_router/go_router.dart';
 /// `CFBundleURLTypes` (macOS). On mobile the custom scheme
 /// `io.github.quantumheart.kohera://` and `matrix:` are registered in the
 /// platform manifests. Android additionally intercepts `matrix.to` HTTPS links.
+///
+/// Links received before the user is ready (logged out or in E2EE setup) are
+/// queued and replayed once auth/backup completes — otherwise the router
+/// redirect would silently drop the target.
 class DeepLinkService {
-  DeepLinkService(this._router);
+  DeepLinkService({
+    required GoRouter router,
+    required ClientManager clientManager,
+    required Listenable refreshListenable,
+  })  : _router = router,
+        _clientManager = clientManager,
+        _refresh = refreshListenable;
 
   final GoRouter _router;
-  AppLinks? _appLinks;
+  final ClientManager _clientManager;
+  final Listenable _refresh;
+
+  /// Lazily constructed so the platform plugin isn't touched until first use;
+  /// the "must call [init] first" contract is then compile-time-enforced.
+  late final AppLinks _appLinks = AppLinks();
   StreamSubscription<Uri>? _sub;
+
+  /// Target queued while the user isn't ready to navigate (logged out / E2EE
+  /// setup); replayed from [_refresh].
+  DeepLinkIntent? _pendingIntent;
+
+  /// Duplicate-delivery guard: `app_links` has historically double-delivered
+  /// the initial link and a stream event on some Android versions.
+  Uri? _lastUri;
+  DateTime? _lastHandledAt;
+  static const _dedupeWindow = Duration(seconds: 2);
+
+  MatrixService get _matrix => _clientManager.activeService;
+  Client get _client => _matrix.client;
+
+  /// `true` when a `/rooms/…` navigation won't be bounced to `/login` or
+  /// `/e2ee-setup` by the router redirect.
+  bool get _isReady =>
+      _matrix.isLoggedIn &&
+      (_matrix.chatBackup.chatBackupNeeded != true || _matrix.hasSkippedSetup);
 
   /// Start listening for incoming deep links.
   void init() {
-    _appLinks = AppLinks();
-    _sub = _appLinks!.uriLinkStream.listen(
+    _sub = _appLinks.uriLinkStream.listen(
       _handleUri,
       onError: (Object e) => debugPrint('[DeepLink] Stream error: $e'),
     );
+    _refresh.addListener(_onRefresh);
   }
 
   /// Process the initial link that launched the app (if any).
   Future<void> processInitialLink() async {
     try {
-      final initial = await _appLinks?.getInitialLink();
-      if (initial != null) _handleUri(initial);
+      final initial = await _appLinks.getInitialLink();
+      if (initial != null) await _handleUri(initial);
     } catch (e) {
       debugPrint('[DeepLink] Initial link error: $e');
     }
   }
 
-  void _handleUri(Uri uri) {
-    debugPrint('[DeepLink] Received: $uri');
-    final target = _parseUri(uri);
-    if (target == null) return;
-    _router.go(target);
+  // ── Handling ───────────────────────────────────────────────
+
+  Future<void> _handleUri(Uri uri) async {
+    if (_isDuplicate(uri)) return;
+    _lastUri = uri;
+    _lastHandledAt = DateTime.now();
+    if (kDebugMode) debugPrint('[DeepLink] Received: $uri');
+
+    final intent = parseDeepLinkUri(uri);
+    if (intent == null) return;
+    await _applyIntent(intent);
   }
 
-  /// Convert a deep-link [Uri] into a go_router path, or `null` if unrecognised.
+  bool _isDuplicate(Uri uri) {
+    final last = _lastUri;
+    final at = _lastHandledAt;
+    return last != null &&
+        last.toString() == uri.toString() &&
+        at != null &&
+        DateTime.now().difference(at) < _dedupeWindow;
+  }
+
+  /// Resolve and navigate to [intent], or queue it if the user isn't ready.
+  Future<void> _applyIntent(DeepLinkIntent intent) async {
+    if (!_isReady) {
+      // Queue; the router redirect would otherwise drop the target. Only the
+      // latest intent is kept.
+      _pendingIntent = intent;
+      return;
+    }
+    final target = await _resolveIntent(intent);
+    if (target != null) _router.go(target.path, extra: target.eventId);
+  }
+
+  /// Replayed when auth/backup state changes (login, E2EE setup done).
+  void _onRefresh() {
+    final pending = _pendingIntent;
+    if (pending == null || !_isReady) return;
+    _pendingIntent = null;
+    unawaited(
+      _resolveIntent(pending).then((target) {
+        if (target != null) _router.go(target.path, extra: target.eventId);
+      }),
+    );
+  }
+
+  // ── Resolution (may hit the network) ───────────────────────
+
+  /// Resolve an intent to a go_router target, resolving room aliases to
+  /// canonical room IDs and joining when requested. Returns `null` when the
+  /// link isn't actionable (e.g. an unjoined room without an explicit join
+  /// intent) so a broken `ChatScreen` is never navigated to.
+  Future<_DeepLinkTarget?> _resolveIntent(DeepLinkIntent intent) async {
+    final id = intent.identifier;
+    if (id.isEmpty) return null;
+    switch (id[0]) {
+      case '@':
+        // Users go to home — the app can show a DM creation dialog. A future
+        // improvement can deep-link directly to an existing DM room.
+        return const _DeepLinkTarget(path: RoutePaths.home);
+      case '#':
+      case '!':
+        final roomId = await _resolveRoomId(
+          id,
+          action: intent.action,
+          via: intent.via,
+        );
+        if (roomId == null) return null;
+        return _DeepLinkTarget(
+          path: '$RoutePaths.roomPrefix${Uri.encodeComponent(roomId)}',
+          eventId: intent.eventId,
+        );
+      default:
+        return null;
+    }
+  }
+
+  /// Resolve a room identifier (alias or `!id`) to a canonical room ID.
   ///
-  /// Supported formats:
-  /// - `matrix:u/<user>?action=chat` → user
-  /// - `matrix:r/<alias>?action=join` → room alias
-  /// - `matrix:roomid/<id>?action=join` → room ID
-  /// - `matrix:r/<alias>/e/<event>` → event in room
-  /// - `matrix:roomid/<id>/e/<event>` → event in room by ID
-  /// - `io.github.quantumheart.kohera://chat/<identifier>` → room or user
-  /// - `https://matrix.to/#/<identifier>` → room or user
-  String? _parseUri(Uri uri) {
-    final scheme = uri.scheme;
-
-    if (scheme == 'matrix') {
-      return _parseMatrixScheme(uri);
+  /// Joined rooms resolve locally (no network). Unjoined rooms are only
+  /// joined when [action] is `'join'` (with `?via=…` servers); otherwise the
+  /// link isn't actionable.
+  Future<String?> _resolveRoomId(
+    String identifier, {
+    String? action,
+    List<String> via = const [],
+  }) async {
+    final client = _client;
+    if (identifier.startsWith('!')) {
+      if (client.getRoomById(identifier) != null) return identifier;
+    } else {
+      final room = client.getRoomByAlias(identifier);
+      if (room != null) return room.id;
     }
-
-    if (scheme == 'io.github.quantumheart.kohera') {
-      // io.github.quantumheart.kohera://chat/<identifier>
-      if (uri.host != 'chat') return null;
-      final segments = uri.pathSegments;
-      if (segments.isEmpty) return null;
-      final identifier = Uri.decodeComponent(segments.first);
-      return _routeForIdentifier(identifier);
+    if (action == 'join') {
+      return _join(identifier, via);
     }
-
-    if (scheme == 'https' && uri.host == 'matrix.to') {
-      // https://matrix.to/#/<identifier>
-      final fragment = uri.fragment;
-      if (fragment.isEmpty) return null;
-      // Strip leading "/" from the fragment
-      var id = fragment;
-      if (id.startsWith('/')) id = id.substring(1);
-      // Strip event-id path if present
-      final slash = id.indexOf('/');
-      if (slash >= 0) id = id.substring(0, slash);
-      id = Uri.decodeComponent(id);
-      return _routeForIdentifier(id);
-    }
-
     return null;
   }
 
-  /// Parse a `matrix:` URI into a go_router path.
-  String? _parseMatrixScheme(Uri uri) {
-    // matrix: URIs use the format: matrix:<type>/<identifier>?action=...
-    // The path is everything after "matrix:"
-    final path = uri.toString().substring('matrix:'.length);
-    final parts = path.split('/');
-    if (parts.length < 2) return null;
-
-    final type = parts[0];
-    final encodedId = parts[1];
-    final identifier = Uri.decodeComponent(encodedId);
-
-    switch (type) {
-      case 'u':
-        // User: matrix:u/<user>?action=chat
-        return _routeForIdentifier('@$identifier');
-      case 'r':
-        // Room alias: matrix:r/<alias>
-        return _routeForIdentifier('#$identifier');
-      case 'roomid':
-        // Room ID: matrix:roomid/<id>
-        return _routeForIdentifier('!$identifier');
-      default:
-        return null;
-    }
-  }
-
-  /// Map a Matrix identifier (with sigil) to a go_router path.
-  String? _routeForIdentifier(String identifier) {
-    if (identifier.isEmpty) return null;
-    final sigil = identifier[0];
-    switch (sigil) {
-      case '@':
-        // Users go to home — the app can show a DM creation dialog.
-        // For now, navigate home; a future improvement can deep-link
-        // directly to a DM room if one already exists.
-        return '/';
-      case '#':
-      case '!':
-        // Rooms navigate to /rooms/<encoded identifier>.
-        return '/rooms/${Uri.encodeComponent(identifier)}';
-      default:
-        return null;
+  /// Join a room by alias or ID, waiting for it to appear in sync.
+  Future<String?> _join(String address, List<String> via) async {
+    try {
+      final roomId = await _client.joinRoom(
+        address,
+        via: via.isEmpty ? null : via,
+      );
+      await _client
+          .waitForRoomInSync(roomId, join: true)
+          .timeout(const Duration(seconds: 30));
+      return roomId;
+    } catch (e) {
+      debugPrint('[DeepLink] join "$address" failed: $e');
+      return null;
     }
   }
 
   void dispose() {
     unawaited(_sub?.cancel());
     _sub = null;
+    _refresh.removeListener(_onRefresh);
   }
+}
+
+/// A parsed deep link before any resolution/network work.
+class DeepLinkIntent {
+  const DeepLinkIntent({
+    required this.identifier,
+    this.action,
+    this.via = const [],
+    this.eventId,
+  });
+
+  /// Matrix identifier with its sigil (`@user`, `#alias`, `!id`).
+  final String identifier;
+
+  /// `?action=` value (e.g. `chat`, `join`), if present.
+  final String? action;
+
+  /// `?via=server1&via=server2` servers, for joining rooms via alias.
+  final List<String> via;
+
+  /// Event ID for event links (`…/e/<event>` or matrix.to `…/<event>`).
+  final String? eventId;
+
+  @override
+  String toString() =>
+      'DeepLinkIntent(identifier: $identifier, action: $action, '
+      'via: $via, eventId: $eventId)';
+}
+
+/// A resolved go_router destination.
+class _DeepLinkTarget {
+  const _DeepLinkTarget({required this.path, this.eventId});
+
+  final String path;
+
+  /// Passed as `state.extra` so `ChatScreen` reads it as `initialEventId`.
+  final String? eventId;
+}
+
+/// Convert a deep-link [Uri] into a [DeepLinkIntent], or `null` if unrecognised.
+///
+/// Pure (no network, no platform) so it is unit-testable.
+///
+/// Supported formats:
+/// - `matrix:u/<user>?action=chat` → user
+/// - `matrix:r/<alias>?action=join&via=server` → room alias
+/// - `matrix:roomid/<id>?action=join` → room ID
+/// - `matrix:r/<alias>/e/<event>` / `matrix:roomid/<id>/e/<event>` → event
+/// - `io.github.quantumheart.kohera://chat/<identifier>` → room or user
+/// - `https://matrix.to/#/<identifier>[/<event>][?via=server]` → room or user
+DeepLinkIntent? parseDeepLinkUri(Uri uri) {
+  final scheme = uri.scheme;
+
+  if (scheme == 'matrix') {
+    return _parseMatrixScheme(uri);
+  }
+
+  if (scheme == 'io.github.quantumheart.kohera') {
+    // io.github.quantumheart.kohera://chat/<identifier>
+    if (uri.host != 'chat') return null;
+    // pathSegments are already percent-decoded — don't decode twice.
+    final segments = uri.pathSegments;
+    if (segments.isEmpty) return null;
+    return DeepLinkIntent(
+      identifier: segments.first,
+      action: uri.queryParameters['action'],
+      via: uri.queryParametersAll['via'] ?? const [],
+    );
+  }
+
+  if (scheme == 'https' && uri.host == 'matrix.to') {
+    // https://matrix.to/#/<identifier>[/<event>][?via=server]
+    // The query (?via=…) is inside the fragment, so split it off manually —
+    // uri.queryParameters is empty here.
+    var fragment = uri.fragment;
+    if (fragment.isEmpty) return null;
+    var fragmentQuery = '';
+    final q = fragment.indexOf('?');
+    if (q >= 0) {
+      fragmentQuery = fragment.substring(q + 1);
+      fragment = fragment.substring(0, q);
+    }
+    if (fragment.startsWith('/')) fragment = fragment.substring(1);
+    final segments = fragment.split('/');
+    if (segments.isEmpty || segments.first.isEmpty) return null;
+    final identifier = Uri.decodeComponent(segments.first);
+    final eventId = segments.length >= 2 && segments[1].isNotEmpty
+        ? Uri.decodeComponent(segments[1])
+        : null;
+    final via = fragmentQuery.isEmpty
+        ? const <String>[]
+        : Uri.parse('?$fragmentQuery').queryParametersAll['via'] ?? const [];
+    return DeepLinkIntent(
+      identifier: identifier,
+      eventId: eventId,
+      via: via,
+    );
+  }
+
+  return null;
+}
+
+/// Parse a `matrix:` URI into an intent.
+///
+/// Uses [Uri.path] (not `toString()`) so the query string (`?action=…`,
+/// `?via=…`) isn't glued onto the identifier, and percent-encoding is
+/// preserved for the single decode below.
+DeepLinkIntent? _parseMatrixScheme(Uri uri) {
+  final path = uri.path;
+  final parts = path.split('/');
+  if (parts.length < 2) return null;
+
+  final type = parts[0];
+  final identifier = Uri.decodeComponent(parts[1]);
+
+  // Event segment: matrix:<type>/<id>/e/<event>
+  String? eventId;
+  if (parts.length >= 4 && parts[2] == 'e') {
+    eventId = Uri.decodeComponent(parts[3]);
+  }
+
+  final action = uri.queryParameters['action'];
+  final via = uri.queryParametersAll['via'] ?? const [];
+
+  String? sigil;
+  switch (type) {
+    case 'u':
+      sigil = '@';
+    case 'r':
+      sigil = '#';
+    case 'roomid':
+      sigil = '!';
+  }
+  if (sigil == null) return null;
+  // The sigil is implied by the type segment, but accept it if the source
+  // already includes it (the fork emits room-id URIs with a leading `!`).
+  final full = identifier.startsWith(sigil) ? identifier : '$sigil$identifier';
+  return DeepLinkIntent(
+    identifier: full,
+    action: action,
+    via: via,
+    eventId: eventId,
+  );
 }

--- a/lib/core/services/deep_link_service.dart
+++ b/lib/core/services/deep_link_service.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+
+import 'package:app_links/app_links.dart';
+import 'package:flutter/foundation.dart';
+import 'package:go_router/go_router.dart';
+
+/// Receives native deep links (`matrix:`, `io.github.quantumheart.kohera://`,
+/// and `https://matrix.to/…`) and navigates to the matching room or user.
+///
+/// On desktop platforms the `matrix:` URI scheme is registered via the
+/// `.desktop` file (Linux), Inno Setup registry entries (Windows), and
+/// `CFBundleURLTypes` (macOS). On mobile the custom scheme
+/// `io.github.quantumheart.kohera://` and `matrix:` are registered in the
+/// platform manifests. Android additionally intercepts `matrix.to` HTTPS links.
+class DeepLinkService {
+  DeepLinkService(this._router);
+
+  final GoRouter _router;
+  AppLinks? _appLinks;
+  StreamSubscription<Uri>? _sub;
+
+  /// Start listening for incoming deep links.
+  void init() {
+    _appLinks = AppLinks();
+    _sub = _appLinks!.uriLinkStream.listen(
+      _handleUri,
+      onError: (Object e) => debugPrint('[DeepLink] Stream error: $e'),
+    );
+  }
+
+  /// Process the initial link that launched the app (if any).
+  Future<void> processInitialLink() async {
+    try {
+      final initial = await _appLinks?.getInitialLink();
+      if (initial != null) _handleUri(initial);
+    } catch (e) {
+      debugPrint('[DeepLink] Initial link error: $e');
+    }
+  }
+
+  void _handleUri(Uri uri) {
+    debugPrint('[DeepLink] Received: $uri');
+    final target = _parseUri(uri);
+    if (target == null) return;
+    _router.go(target);
+  }
+
+  /// Convert a deep-link [Uri] into a go_router path, or `null` if unrecognised.
+  ///
+  /// Supported formats:
+  /// - `matrix:u/<user>?action=chat` → user
+  /// - `matrix:r/<alias>?action=join` → room alias
+  /// - `matrix:roomid/<id>?action=join` → room ID
+  /// - `matrix:r/<alias>/e/<event>` → event in room
+  /// - `matrix:roomid/<id>/e/<event>` → event in room by ID
+  /// - `io.github.quantumheart.kohera://chat/<identifier>` → room or user
+  /// - `https://matrix.to/#/<identifier>` → room or user
+  String? _parseUri(Uri uri) {
+    final scheme = uri.scheme;
+
+    if (scheme == 'matrix') {
+      return _parseMatrixScheme(uri);
+    }
+
+    if (scheme == 'io.github.quantumheart.kohera') {
+      // io.github.quantumheart.kohera://chat/<identifier>
+      if (uri.host != 'chat') return null;
+      final segments = uri.pathSegments;
+      if (segments.isEmpty) return null;
+      final identifier = Uri.decodeComponent(segments.first);
+      return _routeForIdentifier(identifier);
+    }
+
+    if (scheme == 'https' && uri.host == 'matrix.to') {
+      // https://matrix.to/#/<identifier>
+      final fragment = uri.fragment;
+      if (fragment.isEmpty) return null;
+      // Strip leading "/" from the fragment
+      var id = fragment;
+      if (id.startsWith('/')) id = id.substring(1);
+      // Strip event-id path if present
+      final slash = id.indexOf('/');
+      if (slash >= 0) id = id.substring(0, slash);
+      id = Uri.decodeComponent(id);
+      return _routeForIdentifier(id);
+    }
+
+    return null;
+  }
+
+  /// Parse a `matrix:` URI into a go_router path.
+  String? _parseMatrixScheme(Uri uri) {
+    // matrix: URIs use the format: matrix:<type>/<identifier>?action=...
+    // The path is everything after "matrix:"
+    final path = uri.toString().substring('matrix:'.length);
+    final parts = path.split('/');
+    if (parts.length < 2) return null;
+
+    final type = parts[0];
+    final encodedId = parts[1];
+    final identifier = Uri.decodeComponent(encodedId);
+
+    switch (type) {
+      case 'u':
+        // User: matrix:u/<user>?action=chat
+        return _routeForIdentifier('@$identifier');
+      case 'r':
+        // Room alias: matrix:r/<alias>
+        return _routeForIdentifier('#$identifier');
+      case 'roomid':
+        // Room ID: matrix:roomid/<id>
+        return _routeForIdentifier('!$identifier');
+      default:
+        return null;
+    }
+  }
+
+  /// Map a Matrix identifier (with sigil) to a go_router path.
+  String? _routeForIdentifier(String identifier) {
+    if (identifier.isEmpty) return null;
+    final sigil = identifier[0];
+    switch (sigil) {
+      case '@':
+        // Users go to home — the app can show a DM creation dialog.
+        // For now, navigate home; a future improvement can deep-link
+        // directly to a DM room if one already exists.
+        return '/';
+      case '#':
+      case '!':
+        // Rooms navigate to /rooms/<encoded identifier>.
+        return '/rooms/${Uri.encodeComponent(identifier)}';
+      default:
+        return null;
+    }
+  }
+
+  void dispose() {
+    unawaited(_sub?.cancel());
+    _sub = null;
+  }
+}

--- a/lib/core/services/deep_link_service.dart
+++ b/lib/core/services/deep_link_service.dart
@@ -285,7 +285,7 @@ DeepLinkIntent? parseDeepLinkUri(Uri uri) {
     if (segments.isEmpty || segments.first.isEmpty) return null;
     final identifier = Uri.decodeComponent(segments.first);
     final eventId = segments.length >= 2 && segments[1].isNotEmpty
-        ? Uri.decodeComponent(segments[1])
+        ? _ensureEventSigil(Uri.decodeComponent(segments[1]))
         : null;
     final via = fragmentQuery.isEmpty
         ? const <String>[]
@@ -299,6 +299,12 @@ DeepLinkIntent? parseDeepLinkUri(Uri uri) {
 
   return null;
 }
+
+/// Re-adds the leading `$` on an event id if the source omitted it. The Kohera
+/// matrix.to fork strips the `$` from event ids when emitting `matrix:` URIs
+/// (parallel to stripping room/user sigils); matrix.to HTTPS links keep it.
+String _ensureEventSigil(String id) =>
+    id.startsWith(r'$') ? id : r'$' + id;
 
 /// Parse a `matrix:` URI into an intent.
 ///
@@ -316,7 +322,7 @@ DeepLinkIntent? _parseMatrixScheme(Uri uri) {
   // Event segment: matrix:<type>/<id>/e/<event>
   String? eventId;
   if (parts.length >= 4 && parts[2] == 'e') {
-    eventId = Uri.decodeComponent(parts[3]);
+    eventId = _ensureEventSigil(Uri.decodeComponent(parts[3]));
   }
 
   final action = uri.queryParameters['action'];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:kohera/core/brand/brand_constants.dart';
 import 'package:kohera/core/routing/app_router.dart';
 import 'package:kohera/core/services/app_config.dart';
 import 'package:kohera/core/services/client_manager.dart';
+import 'package:kohera/core/services/deep_link_service.dart';
 import 'package:kohera/core/services/github_releases_service.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/preferences_service.dart';
@@ -65,7 +66,8 @@ class _KoheraAppState extends State<KoheraApp> {
   final _ringtoneService = RingtoneService();
   RoomSnapshotService? _roomSnapshotService;
   AvatarCacheService? _avatarCacheService;
-  ShareIntakeController? _shareIntake;
+ShareIntakeController? _shareIntake;
+  DeepLinkService? _deepLinkService;
 
   @override
   void initState() {
@@ -137,6 +139,9 @@ class _KoheraAppState extends State<KoheraApp> {
         clientManager: clientManager,
         router: _router!,
       )..start();
+      // Start deep-link listener now that the router exists.
+      _deepLinkService = DeepLinkService(_router!)..init();
+      unawaited(_deepLinkService!.processInitialLink());
     } catch (e) {
       debugPrint('[Kohera] Initialization failed: $e');
       if (!mounted) return;
@@ -181,6 +186,7 @@ class _KoheraAppState extends State<KoheraApp> {
   void dispose() {
     _clientManager?.removeListener(_onActiveServiceChanged);
     _router?.dispose();
+    _deepLinkService?.dispose();
     _roomSnapshotService?.dispose();
     unawaited(_avatarCacheService?.dispose());
     unawaited(_ringtoneService.dispose());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/brand/brand_constants.dart';
+import 'package:kohera/core/routing/active_matrix_listenable.dart';
 import 'package:kohera/core/routing/app_router.dart';
 import 'package:kohera/core/services/app_config.dart';
 import 'package:kohera/core/services/client_manager.dart';
@@ -128,19 +129,29 @@ ShareIntakeController? _shareIntake;
       await minSplash;
       if (!mounted) return;
       clientManager.addListener(_onActiveServiceChanged);
+      final refreshListenable = ActiveMatrixListenable(clientManager);
       setState(() {
         _clientManager = clientManager;
         _preferencesService = prefs;
         _displayedService = clientManager.activeService;
-        _router = buildRouter(clientManager);
+        _router = buildRouter(
+          clientManager,
+          refreshListenable: refreshListenable,
+        );
       });
       _bindShareIn(clientManager.activeService);
       _shareIntake = ShareIntakeController(
         clientManager: clientManager,
         router: _router!,
       )..start();
-      // Start deep-link listener now that the router exists.
-      _deepLinkService = DeepLinkService(_router!)..init();
+      // Start deep-link listener now that the router exists. The shared
+      // refreshListenable lets queued links replay once login / E2EE setup
+      // completes instead of being dropped by the router redirect.
+      _deepLinkService = DeepLinkService(
+        router: _router!,
+        clientManager: clientManager,
+        refreshListenable: refreshListenable,
+      )..init();
       unawaited(_deepLinkService!.processInitialLink());
     } catch (e) {
       debugPrint('[Kohera] Initialization failed: $e');

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,7 @@
 #include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <flutter_webrtc/flutter_web_r_t_c_plugin.h>
+#include <gtk/gtk_plugin.h>
 #include <livekit_client/live_kit_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
 #include <media_kit_video/media_kit_video_plugin.h>
@@ -37,6 +38,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_webrtc_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterWebRTCPlugin");
   flutter_web_r_t_c_plugin_register_with_registrar(flutter_webrtc_registrar);
+  g_autoptr(FlPluginRegistrar) gtk_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
+  gtk_plugin_register_with_registrar(gtk_registrar);
   g_autoptr(FlPluginRegistrar) livekit_client_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "LiveKitPlugin");
   live_kit_plugin_register_with_registrar(livekit_client_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -8,6 +8,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
   flutter_secure_storage_linux
   flutter_webrtc
+  gtk
   livekit_client
   media_kit_libs_linux
   media_kit_video

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import app_links
 import audio_session
 import connectivity_plus
 import desktop_drop
@@ -33,6 +34,7 @@ import webcrypto
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -36,5 +36,16 @@
 	<string>NSApplication</string>
 	<key>NSScreenCaptureUsageDescription</key>
 	<string>Kohera needs screen capture access for screen sharing in calls.</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>io.github.quantumheart.kohera</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>matrix</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,6 +25,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "5f88447519add627fe1cbcab4fd1da3d4fed15b9baf29f28b22535c95ecee3e8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "7546f09a6e93f4a2df2fe2bd40a5c6c64310ac461b036d82b43033be7a59f809"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.4"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   archive:
     dependency: transitive
     description:
@@ -696,6 +728,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: "4ff85b2a16724029dd9e5bbb5a94b6918f9973f74ba571c949d2002801879cf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   highlight:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ">=3.11.0 <4.0.0"
 
 dependencies:
+  app_links: ^6.3.3
   animations: ^2.0.11
   cached_network_image: ^3.3.1
   cached_network_image_platform_interface: ^4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=3.11.0 <4.0.0"
 
 dependencies:
-  app_links: ^6.3.3
   animations: ^2.0.11
+  app_links: ^6.3.3
   cached_network_image: ^3.3.1
   cached_network_image_platform_interface: ^4.0.0
   canonical_json: ^1.1.2

--- a/test/core/services/deep_link_service_test.dart
+++ b/test/core/services/deep_link_service_test.dart
@@ -132,6 +132,30 @@ void main() {
         [],
         null,
       ),
+      // ── exact shapes the Kohera matrix.to fork emits ───────────────
+      // Desktop matrix: URIs strip the sigil (and the `$` from event ids);
+      // the parser must re-add them.
+      (
+        'matrix:roomid/room123%3Amatrix.org?action=join&via=matrix.org',
+        '!room123:matrix.org',
+        'join',
+        ['matrix.org'],
+        null,
+      ),
+      (
+        'matrix:roomid/room123%3Amatrix.org/e/event456%3Amatrix.org?action=join',
+        '!room123:matrix.org',
+        'join',
+        [],
+        r'$event456:matrix.org',
+      ),
+      (
+        'matrix:r/freenet-locutus%3Amatrix.org/e/event456%3Amatrix.org?action=join&via=matrix.org',
+        '#freenet-locutus:matrix.org',
+        'join',
+        ['matrix.org'],
+        r'$event456:matrix.org',
+      ),
     ];
 
     for (final (uri, identifier, action, via, eventId) in cases) {

--- a/test/core/services/deep_link_service_test.dart
+++ b/test/core/services/deep_link_service_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/services/deep_link_service.dart';
+
+void main() {
+  group('parseDeepLinkUri', () {
+    // (uri, expectedIdentifier, expectedAction, expectedVia, expectedEventId)
+    const cases = <(String, String, String?, List<String>, String?)>[
+      // ── matrix: scheme ───────────────────────────────────────────
+      // query string must NOT be glued onto the identifier (#1).
+      (
+        'matrix:u/alice%3Aexample.org?action=chat',
+        '@alice:example.org',
+        'chat',
+        [],
+        null,
+      ),
+      // room id with action + via servers (the fork's join links).
+      (
+        'matrix:roomid/!id%3Aexample.org?action=join&via=server.one&via=server.two',
+        '!id:example.org',
+        'join',
+        ['server.one', 'server.two'],
+        null,
+      ),
+      // room id WITHOUT a leading `!` (spec form) — sigil is implied.
+      (
+        'matrix:roomid/id%3Aexample.org?action=join',
+        '!id:example.org',
+        'join',
+        [],
+        null,
+      ),
+      // room alias.
+      (
+        'matrix:r/room%3Aexample.org?action=join',
+        '#room:example.org',
+        'join',
+        [],
+        null,
+      ),
+      // event link by alias (matrix:r/<alias>/e/<event>) (#3).
+      (
+        r'matrix:r/room%3Aexample.org/e/$event%3Aexample.org',
+        '#room:example.org',
+        null,
+        [],
+        r'$event:example.org',
+      ),
+      // event link by room id (matrix:roomid/<id>/e/<event>) (#3).
+      (
+        r'matrix:roomid/!id%3Aexample.org/e/$event%3Aexample.org',
+        '!id:example.org',
+        null,
+        [],
+        r'$event:example.org',
+      ),
+      // ── custom scheme ─────────────────────────────────────────────
+      // pathSegments are already decoded — must not double-decode (#2b),
+      // and an encoded '#' sigil (fork-side fix) survives.
+      (
+        'io.github.quantumheart.kohera://chat/%23room%3Aexample.org',
+        '#room:example.org',
+        null,
+        [],
+        null,
+      ),
+      (
+        'io.github.quantumheart.kohera://chat/%21id%3Aexample.org',
+        '!id:example.org',
+        null,
+        [],
+        null,
+      ),
+      (
+        'io.github.quantumheart.kohera://chat/%40alice%3Aexample.org',
+        '@alice:example.org',
+        null,
+        [],
+        null,
+      ),
+      // custom scheme with the wrong host is ignored.
+      ('io.github.quantumheart.kohera://other/something', '', null, [], null),
+      // ── https://matrix.to ──────────────────────────────────────────
+      (
+        'https://matrix.to/#/%21id%3Aexample.org',
+        '!id:example.org',
+        null,
+        [],
+        null,
+      ),
+      // alias via matrix.to (the '#' starts the fragment, the sigil '#' is
+      // the first char of the identifier).
+      (
+        'https://matrix.to/#/%23room%3Aexample.org',
+        '#room:example.org',
+        null,
+        [],
+        null,
+      ),
+      // matrix.to with an event id segment (#3).
+      (
+        r'https://matrix.to/#/%21id%3Aexample.org/$event%3Aexample.org',
+        '!id:example.org',
+        null,
+        [],
+        r'$event:example.org',
+      ),
+      // matrix.to with ?via= servers (the query lives inside the fragment).
+      (
+        'https://matrix.to/#/%23room%3Aexample.org?via=server.one',
+        '#room:example.org',
+        null,
+        ['server.one'],
+        null,
+      ),
+      // empty matrix.to fragment is ignored.
+      ('https://matrix.to/#/', '', null, [], null),
+    ];
+
+    for (final (uri, identifier, action, via, eventId) in cases) {
+      test('parses "$uri"', () {
+        final parsed = parseDeepLinkUri(Uri.parse(uri));
+        if (identifier.isEmpty) {
+          expect(parsed, isNull, reason: '$uri should not produce an intent');
+          return;
+        }
+        expect(parsed, isNotNull, reason: '$uri should parse');
+        expect(parsed!.identifier, identifier);
+        expect(parsed.action, action);
+        expect(parsed.via, via);
+        expect(parsed.eventId, eventId);
+      });
+    }
+
+    test('returns null for an unrecognised scheme', () {
+      expect(parseDeepLinkUri(Uri.parse('https://example.com/rooms/foo')),
+          isNull);
+    });
+
+    test('returns null for a matrix: uri missing the identifier', () {
+      expect(parseDeepLinkUri(Uri.parse('matrix:u')), isNull);
+    });
+  });
+}

--- a/test/core/services/deep_link_service_test.dart
+++ b/test/core/services/deep_link_service_test.dart
@@ -115,6 +115,23 @@ void main() {
       ),
       // empty matrix.to fragment is ignored.
       ('https://matrix.to/#/', '', null, [], null),
+      // ── real-world shapes (raw `#` sigil, unencoded colon) ─────────
+      // The exact link from the issue: matrix.to with a raw `#` alias.
+      (
+        'https://matrix.to/#/#freenet-locutus:matrix.org',
+        '#freenet-locutus:matrix.org',
+        null,
+        [],
+        null,
+      ),
+      // matrix: alias join link for the same room.
+      (
+        'matrix:r/freenet-locutus:matrix.org?action=join',
+        '#freenet-locutus:matrix.org',
+        'join',
+        [],
+        null,
+      ),
     ];
 
     for (final (uri, identifier, action, via, eventId) in cases) {

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <app_links/app_links_plugin_c_api.h>
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
@@ -24,6 +25,8 @@
 #include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  AppLinksPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   DesktopDropPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  app_links
   connectivity_plus
   desktop_drop
   dynamic_color

--- a/windows/packaging/inno_setup.iss
+++ b/windows/packaging/inno_setup.iss
@@ -29,5 +29,17 @@ Source: "..\..\build\windows\x64\runner\Release\*"; DestDir: "{app}"; Flags: ign
 Name: "{group}\Kohera"; Filename: "{app}\kohera.exe"; AppUserModelID: "io.github.quantumheart.kohera"
 Name: "{autodesktop}\Kohera"; Filename: "{app}\kohera.exe"; Tasks: desktopicon; AppUserModelID: "io.github.quantumheart.kohera"
 
+[Registry]
+; Register matrix: URI scheme handler
+Root: HKCU; Subkey: "Software\Classes\matrix"; ValueType: string; ValueName: ""; ValueData: "URL:Matrix Protocol"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\matrix"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\matrix\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\kohera.exe,0"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\matrix\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\kohera.exe"" ""%1"""; Flags: uninsdeletekey
+; Register io.github.quantumheart.kohera: URI scheme handler
+Root: HKCU; Subkey: "Software\Classes\io.github.quantumheart.kohera"; ValueType: string; ValueName: ""; ValueData: "URL:Kohera Protocol"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\io.github.quantumheart.kohera"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\io.github.quantumheart.kohera\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\kohera.exe,0"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Classes\io.github.quantumheart.kohera\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\kohera.exe"" ""%1"""; Flags: uninsdeletekey
+
 [Run]
 Filename: "{app}\kohera.exe"; Description: "{cm:LaunchProgram,Kohera}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
## Summary

Adds deep linking support so that `matrix:` URIs, `io.github.quantumheart.kohera://` custom scheme URIs, and `matrix.to` HTTPS links open directly in Kohera.

## Changes

### Platform URI scheme registration
- **iOS**: `CFBundleURLTypes` for `matrix:` and `io.github.quantumheart.kohera:` schemes in `Info.plist`
- **macOS**: `CFBundleURLTypes` for `matrix:` scheme in `Info.plist`
- **Android**: Intent filters for `matrix:`, custom scheme, and `matrix.to` HTTPS links in `AndroidManifest.xml`
- **Windows**: Protocol handler registry entries in Inno Setup installer for both schemes
- **Linux**: `.desktop` file already had `MimeType=x-scheme-handler/matrix`

### Deep link receiver
- Added `app_links` package for cross-platform URI reception
- New `DeepLinkService` parses incoming URIs (`matrix:u/<user>`, `matrix:r/<alias>`, `matrix:roomid/<id>`, `io.github.quantumheart.kohera://chat/<identifier>`, `https://matrix.to/#/<identifier>`) and navigates via `go_router`
- Wired into `main.dart` — starts listening after router initialization, processes initial launch link

### matrix.to fork
Also updated the [matrix.to fork](https://github.com/Quantumheart/matrix.to) `Kohera.js` client definition with matching `getDeepLink()` implementations for all platforms.