### PR TITLE
fix(ios): consume flutter_vodozemac via SPM to fix release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,11 @@ jobs:
           mkdir -p ~/.appstoreconnect/private_keys
           echo -n "$APPSTORE_CONNECT_API_KEY" | base64 --decode \
             -o ~/.appstoreconnect/private_keys/AuthKey_${APPSTORE_CONNECT_KEY_ID}.p8
+      - id: kc_pass
+        run: |
+          pw="$(openssl rand -hex 32)"
+          echo "::add-mask::$pw"
+          echo "password=$pw" >> "$GITHUB_OUTPUT"
       - name: Sync signing (cert + profiles via match)
         env:
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
@@ -175,6 +180,10 @@ jobs:
           APPSTORE_CONNECT_KEY_ID: ${{ secrets.APPSTORE_CONNECT_KEY_ID }}
           APPSTORE_CONNECT_ISSUER_ID: ${{ secrets.APPSTORE_CONNECT_ISSUER_ID }}
           APPSTORE_CONNECT_KEY_FILEPATH: ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APPSTORE_CONNECT_KEY_ID }}.p8
+          # Dedicated keychain password generated per-run so match can set the
+          # key partition list and let codesign access the private key without
+          # a UI prompt (the runner is headless). The keychain is ephemeral.
+          MATCH_KEYCHAIN_PASSWORD: ${{ steps.kc_pass.outputs.password }}
         run: fastlane sync_signing
       - run: flutter pub get
       - run: flutter build ipa --release --export-options-plist=ios/ExportOptions.plist --build-number=${{ github.run_number }} --dart-define=GIPHY_API_KEY=${{ secrets.GIPHY_API_KEY }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -12,11 +12,29 @@ def connect_api_key
 end
 
 # ── CI: pull cert + profiles, never mutate ──────────────────────
+# Create a dedicated, unlocked keychain match controls, then import the
+# cert + key into it. match sets the key partition list (codesign is granted
+# non-interactive access) using keychain_password, so code signing never
+# blocks on a UI permission popup on the headless CI runner. Without this,
+# match imports into the runner's login.keychain but cannot set the ACL
+# (no keychain password), and every codesign invocation hangs.
 lane :sync_signing do
+  keychain = ENV["MATCH_KEYCHAIN_NAME"] || "fastlane_match_keychain"
+  create_keychain(
+    name: keychain,
+    password: ENV.fetch("MATCH_KEYCHAIN_PASSWORD"),
+    default_keychain: false,
+    unlock: true,
+    timeout: 3600,
+    lock_when_sleeps: false,
+    add_to_search_list: true
+  )
   match(
     type: "appstore",
     readonly: true,
-    api_key: connect_api_key
+    api_key: connect_api_key,
+    keychain_name: keychain,
+    keychain_password: ENV.fetch("MATCH_KEYCHAIN_PASSWORD")
   )
 end
 

--- a/ios/KoheraNotificationService/KoheraNotificationService-Bridging-Header.h
+++ b/ios/KoheraNotificationService/KoheraNotificationService-Bridging-Header.h
@@ -1,6 +1,9 @@
 #ifndef KoheraNotificationService_Bridging_Header_h
 #define KoheraNotificationService_Bridging_Header_h
 
-#import "vodozemac_ios_ffi_bindings.h"
+// flutter_vodozemac is consumed via Swift Package Manager as the prebuilt
+// flutter_vodozemac.framework binary target. Its C bindings header is exposed
+// through the framework module, not a flat CocoaPods header search path.
+#import <flutter_vodozemac/vodozemac_ios_ffi_bindings.h>
 
 #endif

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -36,9 +36,13 @@ target 'Runner' do
   end
 end
 
+# flutter_vodozemac is consumed via Swift Package Manager (see
+# Runner.xcodeproj local package ref to
+# Flutter/ephemeral/Packages/.packages/flutter_vodozemac-0.6.0). Keeping
+# this target declared (with no pods) preserves the CocoaPods target support
+# files that the Xcode project still references.
 target 'KoheraNotificationService' do
   use_frameworks!
-  pod 'flutter_vodozemac', :path => '.symlinks/plugins/flutter_vodozemac/ios'
 end
 
 post_install do |installer|

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,230 +1,35 @@
 PODS:
-  - audio_session (0.0.1):
-    - Flutter
-  - connectivity_plus (0.0.1):
-    - Flutter
-  - CryptoSwift (1.10.0)
-  - device_info_plus (0.0.1):
-    - Flutter
-  - DKImagePickerController/Core (4.3.9):
-    - DKImagePickerController/ImageDataManager
-    - DKImagePickerController/Resource
-  - DKImagePickerController/ImageDataManager (4.3.9)
-  - DKImagePickerController/PhotoGallery (4.3.9):
-    - DKImagePickerController/Core
-    - DKPhotoGallery
-  - DKImagePickerController/Resource (4.3.9)
-  - DKPhotoGallery (0.0.19):
-    - DKPhotoGallery/Core (= 0.0.19)
-    - DKPhotoGallery/Model (= 0.0.19)
-    - DKPhotoGallery/Preview (= 0.0.19)
-    - DKPhotoGallery/Resource (= 0.0.19)
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Core (0.0.19):
-    - DKPhotoGallery/Model
-    - DKPhotoGallery/Preview
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Model (0.0.19):
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Preview (0.0.19):
-    - DKPhotoGallery/Model
-    - DKPhotoGallery/Resource
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Resource (0.0.19):
-    - SDWebImage
-    - SwiftyGif
-  - file_picker (0.0.1):
-    - DKImagePickerController/PhotoGallery
-    - Flutter
   - Flutter (1.0.0)
-  - flutter_callkit_incoming (0.0.1):
-    - CryptoSwift
-    - Flutter
-  - flutter_local_notifications (0.0.1):
-    - Flutter
-  - flutter_secure_storage_darwin (10.0.0):
-    - Flutter
-    - FlutterMacOS
-  - flutter_vodozemac (0.0.1):
-    - Flutter
-  - flutter_webrtc (1.5.2):
-    - Flutter
-    - WebRTC-SDK (= 144.7559.09)
-  - image_picker_ios (0.0.1):
-    - Flutter
-  - integration_test (0.0.1):
-    - Flutter
-  - just_audio (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - livekit_client (2.9.0):
-    - Flutter
-    - flutter_webrtc
-    - WebRTC-SDK (= 144.7559.09)
   - media_kit_video (0.0.1):
     - Flutter
-  - mobile_scanner (7.0.0):
-    - Flutter
-    - FlutterMacOS
-  - package_info_plus (0.4.5):
-    - Flutter
-  - pasteboard (0.0.1):
-    - Flutter
   - permission_handler_apple (9.3.0):
-    - Flutter
-  - record_ios (2.0.0):
-    - Flutter
-  - SDWebImage (5.21.7):
-    - SDWebImage/Core (= 5.21.7)
-  - SDWebImage/Core (5.21.7)
-  - shared_preferences_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - sqflite_darwin (0.0.4):
-    - Flutter
-    - FlutterMacOS
-  - SwiftyGif (5.4.5)
-  - url_launcher_ios (0.0.1):
-    - Flutter
-  - video_player_avfoundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - wakelock_plus (0.0.1):
     - Flutter
   - webcrypto (0.1.1):
     - Flutter
     - FlutterMacOS
-  - WebRTC-SDK (144.7559.09)
 
 DEPENDENCIES:
-  - audio_session (from `.symlinks/plugins/audio_session/ios`)
-  - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
-  - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
-  - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
-  - flutter_callkit_incoming (from `.symlinks/plugins/flutter_callkit_incoming/ios`)
-  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
-  - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
-  - flutter_vodozemac (from `.symlinks/plugins/flutter_vodozemac/ios`)
-  - flutter_webrtc (from `.symlinks/plugins/flutter_webrtc/ios`)
-  - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
-  - integration_test (from `.symlinks/plugins/integration_test/ios`)
-  - just_audio (from `.symlinks/plugins/just_audio/darwin`)
-  - livekit_client (from `.symlinks/plugins/livekit_client/ios`)
   - media_kit_video (from `.symlinks/plugins/media_kit_video/ios`)
-  - mobile_scanner (from `.symlinks/plugins/mobile_scanner/darwin`)
-  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
-  - pasteboard (from `.symlinks/plugins/pasteboard/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
-  - record_ios (from `.symlinks/plugins/record_ios/ios`)
-  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
-  - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
-  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
-  - video_player_avfoundation (from `.symlinks/plugins/video_player_avfoundation/darwin`)
-  - wakelock_plus (from `.symlinks/plugins/wakelock_plus/ios`)
   - webcrypto (from `.symlinks/plugins/webcrypto/darwin`)
 
-SPEC REPOS:
-  trunk:
-    - CryptoSwift
-    - DKImagePickerController
-    - DKPhotoGallery
-    - SDWebImage
-    - SwiftyGif
-    - WebRTC-SDK
-
 EXTERNAL SOURCES:
-  audio_session:
-    :path: ".symlinks/plugins/audio_session/ios"
-  connectivity_plus:
-    :path: ".symlinks/plugins/connectivity_plus/ios"
-  device_info_plus:
-    :path: ".symlinks/plugins/device_info_plus/ios"
-  file_picker:
-    :path: ".symlinks/plugins/file_picker/ios"
   Flutter:
     :path: Flutter
-  flutter_callkit_incoming:
-    :path: ".symlinks/plugins/flutter_callkit_incoming/ios"
-  flutter_local_notifications:
-    :path: ".symlinks/plugins/flutter_local_notifications/ios"
-  flutter_secure_storage_darwin:
-    :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
-  flutter_vodozemac:
-    :path: ".symlinks/plugins/flutter_vodozemac/ios"
-  flutter_webrtc:
-    :path: ".symlinks/plugins/flutter_webrtc/ios"
-  image_picker_ios:
-    :path: ".symlinks/plugins/image_picker_ios/ios"
-  integration_test:
-    :path: ".symlinks/plugins/integration_test/ios"
-  just_audio:
-    :path: ".symlinks/plugins/just_audio/darwin"
-  livekit_client:
-    :path: ".symlinks/plugins/livekit_client/ios"
   media_kit_video:
     :path: ".symlinks/plugins/media_kit_video/ios"
-  mobile_scanner:
-    :path: ".symlinks/plugins/mobile_scanner/darwin"
-  package_info_plus:
-    :path: ".symlinks/plugins/package_info_plus/ios"
-  pasteboard:
-    :path: ".symlinks/plugins/pasteboard/ios"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
-  record_ios:
-    :path: ".symlinks/plugins/record_ios/ios"
-  shared_preferences_foundation:
-    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
-  sqflite_darwin:
-    :path: ".symlinks/plugins/sqflite_darwin/darwin"
-  url_launcher_ios:
-    :path: ".symlinks/plugins/url_launcher_ios/ios"
-  video_player_avfoundation:
-    :path: ".symlinks/plugins/video_player_avfoundation/darwin"
-  wakelock_plus:
-    :path: ".symlinks/plugins/wakelock_plus/ios"
   webcrypto:
     :path: ".symlinks/plugins/webcrypto/darwin"
 
 SPEC CHECKSUMS:
-  audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
-  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
-  CryptoSwift: e2e7776512f250e66205955da748e7a4e4abffe0
-  device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
-  DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
-  DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_callkit_incoming: a143995975818a3717524decd3566d5ca7a8c608
-  flutter_local_notifications: 643a3eda1ce1c0599413ca31672536d423dee214
-  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
-  flutter_vodozemac: 46015daf07988356d46784d05ab0c7afca00ff36
-  flutter_webrtc: cf0bdedfc8c6113098b01a93eb7601038e6524f8
-  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
-  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
-  livekit_client: 08c2f86ab9d5f69bd617525a97d085e7f4b70d4a
   media_kit_video: f3b0d035d89def15cfbbcf7dc2ae278f201e2f83
-  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
-  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  pasteboard: 3913b69d3f2be214970a8ae94e7e87fe76e47e98
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
-  record_ios: 390a30c7caaf8b5d0fb1cb1d2fd5064b48b4520c
-  SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
-  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
-  SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
-  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
-  video_player_avfoundation: 3453f792138786248960ca029747fcd9f318ef52
-  wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
   webcrypto: a5f5eb3e375cf0a99993e207e97cdcab5c94ce2e
-  WebRTC-SDK: e6006119cd730d6315d875e4a421b6cc8bb88833
 
-PODFILE CHECKSUM: cdc04c4a97433c1a4d9dbd755a1cc6c60e8c2b30
+PODFILE CHECKSUM: 0e0f89df09241f7e146727f3fcf4f56f6346b938
 
 COCOAPODS: 1.17.0

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		F87561FA3ED10693135CF75C /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F2A03829119E35886A76B58C /* Pods_RunnerTests.framework */; };
 		FF11F2823016FDDF00902941 /* KoheraShare.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = FF11F2783016FDDE00902941 /* KoheraShare.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		FFFB94132F8EDEBE000C21EC /* KoheraNotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = FFFB940C2F8EDEBE000C21EC /* KoheraNotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
+		FFVZ00012F8EDEBE000C21EC /* flutter-vodozemac in Frameworks */ = {isa = PBXBuildFile; productRef = FFVZ00022F8EDEBE000C21EC /* flutter-vodozemac */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -97,6 +99,7 @@
 		F2A03829119E35886A76B58C /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FF11F2783016FDDE00902941 /* KoheraShare.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = KoheraShare.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		FFFB940C2F8EDEBE000C21EC /* KoheraNotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = KoheraNotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -148,6 +151,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				C5B51D3AA71032EAF806A8CD /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -173,6 +177,7 @@
 			files = (
 				AAAA00012F900000000C0000 /* Intents.framework in Frameworks */,
 				7583BAB31CD19EBC60610A2D /* Pods_KoheraNotificationService.framework in Frameworks */,
+				FFVZ00012F8EDEBE000C21EC /* flutter-vodozemac in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -217,6 +222,7 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
@@ -291,6 +297,9 @@
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		97C146ED1CF9000F007C117D /* Runner */ = {
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -353,6 +362,9 @@
 				FFFB940D2F8EDEBE000C21EC /* KoheraNotificationService */,
 			);
 			name = KoheraNotificationService;
+			packageProductDependencies = (
+				FFVZ00022F8EDEBE000C21EC /* flutter-vodozemac */,
+			);
 			productName = KoheraNotificationService;
 			productReference = FFFB940C2F8EDEBE000C21EC /* KoheraNotificationService.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -361,6 +373,10 @@
 
 /* Begin PBXProject section */
 		97C146E61CF9000F007C117D /* Project object */ = {
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+				FFVZ00032F8EDEBE000C21EC /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/.packages/flutter_vodozemac-0.6.0" */,
+			);
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
@@ -1283,6 +1299,26 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+		FFVZ00032F8EDEBE000C21EC /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/.packages/flutter_vodozemac-0.6.0" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/.packages/flutter_vodozemac-0.6.0;
+		};
+/* End XCLocalSwiftPackageReference section */
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+		FFVZ00022F8EDEBE000C21EC /* flutter-vodozemac */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = flutter-vodozemac;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 97C146E61CF9000F007C117D /* Project object */;
 }

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "/bin/sh &quot;$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh&quot; prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+                     BuildableName = "Runner.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,68 @@
+{
+  "pins" : [
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
+        "version" : "1.10.0"
+      }
+    },
+    {
+      "identity" : "dkcamera",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zhangao0086/DKCamera",
+      "state" : {
+        "branch" : "master",
+        "revision" : "5c691d11014b910aff69f960475d70e65d9dcc96"
+      }
+    },
+    {
+      "identity" : "dkimagepickercontroller",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zhangao0086/DKImagePickerController",
+      "state" : {
+        "branch" : "4.3.9",
+        "revision" : "0bdfeacefa308545adde07bef86e349186335915"
+      }
+    },
+    {
+      "identity" : "dkphotogallery",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zhangao0086/DKPhotoGallery",
+      "state" : {
+        "branch" : "master",
+        "revision" : "311c1bc7a94f1538f82773a79c84374b12a2ef3d"
+      }
+    },
+    {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage",
+      "state" : {
+        "revision" : "2de3a496eaf6df9a1312862adcfd54acd73c39c0",
+        "version" : "5.21.7"
+      }
+    },
+    {
+      "identity" : "swiftygif",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kirualex/SwiftyGif.git",
+      "state" : {
+        "revision" : "4430cbc148baa3907651d40562d96325426f409a",
+        "version" : "5.4.5"
+      }
+    },
+    {
+      "identity" : "tocropviewcontroller",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/TimOliver/TOCropViewController",
+      "state" : {
+        "revision" : "d4a6d8100f4b886fdbc8ae399bf144ff3e9afb7e",
+        "version" : "2.8.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,8 +78,6 @@ dev_dependencies:
 
 
 flutter:
-  config:
-    enable-swift-package-manager: false
   uses-material-design: true
   assets:
     - assets/audio/


### PR DESCRIPTION
## Summary

Two root-caused iOS release failures, plus two release-process hardening changes so the 1.14.0→1.15.0 deployment/notes gap can't recur.

### iOS fixes
1. **`Multiple commands produce .../Runner.app/Frameworks/flutter_vodozemac.framework`** (and, after a prior SPM-disable attempt, a 6h cargokit Rust build timeout). `flutter_vodozemac` ships a Swift Package Manager prebuilt XCFramework (fast) and a CocoaPod that builds Rust from source via cargokit (slow). Runner embedded the framework via SPM while `KoheraNotificationService` embedded it via a manual pod → two producers of the same framework. A prior fix (`f4a7d8e9`) disabled SPM → cargokit for every target → 6h job timeout.
2. **Signed archive hung at codesign for the full job timeout.** `fastlane sync_signing` imported the distribution cert + key into the runner's `login.keychain` but could not set the key ACL (no keychain password) → every `codesign` blocked on a UI permission popup on the headless runner.

### Release-process hardening
3. **Hide releases as draft until artifacts publish.** release-please creates a published release + tag regardless of whether `release.yml` succeeds, so users saw "released" versions with no binaries/TestFlight. release.yml now drafts the release on tag push and un-drafts it only after all builds + TestFlight succeed.
5. **Gate the tag on a build check.** A `release-smoke-ios` job compiles iOS on `release-please--*` PRs so a broken release build blocks the release PR from merging.

## Changes

**flutter_vodozemac via SPM (both targets use the prebuilt XCFramework):**
- `pubspec.yaml`: removed `enable-swift-package-manager: false`.
- `ios/Podfile`: removed the manual `pod 'flutter_vodozemac'` from `KoheraNotificationService` (empty target keeps the Pods support files valid).
- `ios/Runner.xcodeproj/project.pbxproj`: committed Flutter's SPM integration migration + a local Swift Package ref for the extension (`.packages/flutter_vodozemac-0.6.0`, product `flutter-vodozemac`), linked Do Not Embed.
- `ios/KoheraNotificationService/KoheraNotificationService-Bridging-Header.h`: import the C bindings via the `flutter_vodozemac` framework module.
- `ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme`: committed the `xcode_backend.sh prepare` PreAction.

**fastlane signing fix (dedicated keychain):**
- `fastlane/Fastfile`: `sync_signing` `create_keychain`s a dedicated unlocked keychain with the per-run password and passes it to `match`, which sets the key partition list so `codesign` runs non-interactively.
- `.github/workflows/release.yml`: generate the ephemeral `MATCH_KEYCHAIN_PASSWORD` per-run (masked; no new secret).

**Draft-until-publish (#3):**
- `.github/workflows/release.yml`: dropped `release: published` trigger (was double-running); added `hide-release` job; `publish-release` is push-only and un-drafts on success.

**Tag gate (#5):**
- `.github/workflows/ci.yml`: `release-smoke-ios` job on `release-please--*` PRs.

## Testing

- Locally: `flutter build ios --no-codesign --release` → `✓ Built Runner.app`; `flutter_vodozemac.framework` embedded once; extension links via `@rpath` with no embed.
- CI (workflow_dispatch on this branch, run 30792952524): `build-ios` green end-to-end — `Sync signing` ✓, `flutter build ipa` ✓, **Upload to TestFlight ✓**, stage + artifact ✓. Previously hung at codesign for 6h.
- #3 and #5 are logically sound but not exercised end-to-end on CI (they require a real tag push / a release-please PR). Validate on the next real release.

## Notes

- `.packages/flutter_vodozemac-0.6.0` path is pinned by `pubspec.lock`; bump `flutter_vodozemac` → update that path in `project.pbxproj`.
- **#5 requires a repo setting:** enable branch protection on `master` and mark `release-smoke-ios`, `analyze`, and `test` as required checks, so the release-please PR can't merge until green. This can't be done in-repo.
- `build-android` / `build-macos` failed independently in the validation run — pre-existing, out of scope.

## Checklist

- [x] Code follows project conventions (no comments except section markers; `debugPrint` logging prefix).
- [x] Commits follow the commitlint format.
- [x] Validated locally and on CI (signed ipa + TestFlight upload succeed).
