### PR TITLE
ci: hide release as draft until artifacts publish + gate tag on build smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
           fail_ci_if_error: false
 
   build-linux:
-    if: github.event_name == 'push'
     needs: [analyze, test]
     runs-on: ubuntu-latest
     steps:
@@ -59,7 +58,6 @@ jobs:
       - run: flutter build linux --release --dart-define=GIPHY_API_KEY=${{ secrets.GIPHY_API_KEY }}
 
   build-macos:
-    if: github.event_name == 'push'
     needs: [analyze, test]
     runs-on: macos-26
     steps:
@@ -77,28 +75,7 @@ jobs:
       - run: flutter build macos --release --dart-define=GIPHY_API_KEY=${{ secrets.GIPHY_API_KEY }}
 
   build-ios:
-    if: github.event_name == 'push'
     needs: [analyze, test]
-    runs-on: macos-26
-    steps:
-      - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: ${{ env.FLUTTER_CHANNEL }}
-          cache: true
-      - run: flutter pub get
-      - name: Pre-build iOS Pods (force repo update)
-        working-directory: ios
-        run: |
-          flutter precache --ios
-          pod install --repo-update
-      - run: flutter build ios --no-codesign --release --dart-define=GIPHY_API_KEY=${{ secrets.GIPHY_API_KEY }}
-
-  # Gate the release tag: compile iOS (no signing) on release-please PRs so a
-  # broken release build is caught before the release PR can merge and cut a
-  # tag. Requires branch protection on master to mark this check required.
-  release-smoke-ios:
-    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please')
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,23 @@ jobs:
           flutter precache --ios
           pod install --repo-update
       - run: flutter build ios --no-codesign --release --dart-define=GIPHY_API_KEY=${{ secrets.GIPHY_API_KEY }}
+
+  # Gate the release tag: compile iOS (no signing) on release-please PRs so a
+  # broken release build is caught before the release PR can merge and cut a
+  # tag. Requires branch protection on master to mark this check required.
+  release-smoke-ios:
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please')
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: ${{ env.FLUTTER_CHANNEL }}
+          cache: true
+      - run: flutter pub get
+      - name: Pre-build iOS Pods (force repo update)
+        working-directory: ios
+        run: |
+          flutter precache --ios
+          pod install --repo-update
+      - run: flutter build ios --no-codesign --release --dart-define=GIPHY_API_KEY=${{ secrets.GIPHY_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  release:
-    types: [published]
   workflow_dispatch:
 
 concurrency:
@@ -20,12 +18,28 @@ jobs:
         with:
           fetch-depth: 0
       - name: Verify tag is on master
-        if: github.event_name == 'push' || github.event_name == 'release'
+        if: github.event_name == 'push'
         run: |
           if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/master; then
             echo "::error::Tag must point to a commit on master"
             exit 1
           fi
+
+  # Hide the release-please-created release as a draft the moment the tag
+  # pushes, so users never see a "released" version that has no artifacts yet.
+  # publish-release un-drafts it only after every platform build + TestFlight
+  # succeed; a failed deploy leaves it hidden as a draft.
+  hide-release:
+    needs: verify-tag
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - run: gh release edit "$GITHUB_REF_NAME" --draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
 
   build-linux:
     needs: verify-tag
@@ -289,10 +303,16 @@ jobs:
 
   publish-release:
     needs: [build-linux, build-windows, build-macos, build-ios, build-android]
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
+      - name: Publish the drafted release
+        run: gh release edit "$GITHUB_REF_NAME" --draft=false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: linux-release
@@ -325,3 +345,4 @@ jobs:
             kohera-android-arm64.apk.sha256
           generate_release_notes: false
           append_body: false
+          draft: false


### PR DESCRIPTION
## Summary

Release-process hardening so the 1.14.0→1.15.0 deployment/notes gap can't recur: a failed deploy no longer leaves a visible "released" version with no artifacts, and a broken release build is caught before a tag is cut.

Follow-up to #926 (the iOS SPM + fastlane signing fix, already merged).

## Changes

### #3 — Hide releases as draft until artifacts publish (`release.yml`)
release-please creates a published release + tag regardless of whether `release.yml` succeeds, so users saw "released" versions with no binaries / no TestFlight build.
- Dropped the `release: published` trigger (it double-ran `release.yml` on every release alongside the tag push). The tag push is the single trigger now.
- Added a `hide-release` job that drafts the release-please-created release the moment the tag pushes.
- `publish-release` now runs only on tag push and un-drafts the release (then attaches artifacts) only after every platform build + TestFlight succeed. A failed deploy leaves the release hidden as a draft.

### #5 — Gate the tag on a build check (`ci.yml`)
- Added `release-smoke-ios` which compiles iOS (`--no-codesign`) on `release-please--*` pull requests, so a broken iOS release build blocks the release PR from merging and cutting a tag.

## Testing

- YAML validated locally.
- Not exercised end-to-end on CI: #3 requires a real tag push and #5 requires a release-please PR. Logically sound; validate on the next real release.

## Notes

- **#5 requires a repo setting:** enable branch protection on `master` and mark `release-smoke-ios`, `analyze`, and `test` as required checks, so the release-please PR can't merge until green. This can't be done in-repo.
- `hide-release` and `publish-release` use the workflow `GITHUB_TOKEN` (`contents: write`) to draft/un-draft. The release is created by the release-please bot app; if the `GITHUB_TOKEN` can't edit an app-created release, switch those steps to the bot app token.

## Checklist

- [x] Commits follow the commitlint format.
- [x] Workflows YAML-validated.