### PR TITLE
fix(android): suppress R8 missing Play Core classes + add Android to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,30 @@ jobs:
           pod install --repo-update
       - run: flutter build macos --release --dart-define=GIPHY_API_KEY=${{ secrets.GIPHY_API_KEY }}
 
+  build-android:
+    needs: [analyze, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: '17'
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: ${{ env.FLUTTER_CHANNEL }}
+          cache: true
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('android/**/*.gradle*', 'android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-${{ runner.os }}-
+      - run: flutter pub get
+      - run: flutter build apk --release --target-platform android-arm64 --dart-define=GIPHY_API_KEY=${{ secrets.GIPHY_API_KEY }}
+
   build-ios:
     needs: [analyze, test]
     runs-on: macos-26

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -4,6 +4,17 @@
 -keep class io.flutter.app.** { *; }
 -keep class io.flutter.embedding.** { *; }
 
+# ── Play Core deferred components (not used) ─────────────────
+# Flutter's embedding engine references Google Play Core split-install
+# classes (FlutterPlayStoreSplitApplication, PlayStoreDeferredComponentManager)
+# for deferred component / dynamic feature module support. This app does not
+# ship deferred components, so the Play Core dependency is absent. R8 full mode
+# (default since AGP 8.0) treats missing classes as errors, so suppress them.
+-dontwarn com.google.android.play.core.splitcompat.**
+-dontwarn com.google.android.play.core.splitinstall.**
+-dontwarn com.google.android.play.core.tasks.**
+-dontwarn com.google.android.play.core.**
+
 # ── Dart-JNI bridge (reflection-heavy) ──────────────────────
 -keep class com.github.dart_lang.jni.** { *; }
 -keep class com.github.dart_lang.jni_flutter.** { *; }


### PR DESCRIPTION
## Problem

The Android release build (CD) was failing during R8 minification (`minifyReleaseWithR8`):

```
Execution failed for task ':app:minifyReleaseWithR8'.
> Compilation failed to complete

ERROR: R8: Missing class com.google.android.play.core.splitcompat.SplitCompatApplication
Missing class com.google.android.play.core.splitinstall.SplitInstallException
... (11 Play Core classes total)
```

Flutter's embedding engine references `com.google.android.play.core.*` classes for Play Store deferred component / dynamic feature module support. The app doesn't use deferred components, so the Play Core dependency isn't included. R8 full mode (default since AGP 8.0) treats missing classes as **errors**, causing the build to fail during minification.

This was introduced by commit `385c7ade` ("enable R8 minification and resource shrinking"), which turned on `isMinifyEnabled = true`.

Additionally, CI had **no** `build-android` job (only `build-linux`, `build-macos`, `build-ios`), so Android release build breakage was only caught at release-tag time, never on PRs.

## Fix

1. **`android/app/proguard-rules.pro`** — Added `-dontwarn com.google.android.play.core.**` rules to suppress R8's missing-class errors for the unused Play Core split-install classes.

2. **`.github/workflows/ci.yml`** — Added a `build-android` smoke job (gated on `analyze` + `test`) matching the existing platform build jobs, so Android release builds are validated on pull requests before reaching the release tag.