### PR TITLE
fix(macos): sign and notarize macOS release with Developer ID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
           channel: ${{ env.FLUTTER_CHANNEL }}
           cache: true
       - run: flutter pub get
+      - name: Disable signing for smoke build
+        working-directory: macos
+        run: |
+          sed -i '' 's/CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;/CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO; CODE_SIGNING_ALLOWED = NO;/' Runner.xcodeproj/project.pbxproj
       - name: Pre-build macOS Pods (force repo update)
         working-directory: macos
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,12 +129,83 @@ jobs:
             ~/Library/Caches/org.swift.swiftpm
           key: pods-macos-${{ hashFiles('macos/Podfile.lock') }}
           restore-keys: pods-macos-
+      - name: Set up SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.MATCH_SSH_PRIVATE_KEY }}
+      - name: Setup fastlane
+        env:
+          APPSTORE_CONNECT_API_KEY: ${{ secrets.APPSTORE_CONNECT_API_KEY }}
+          APPSTORE_CONNECT_KEY_ID: ${{ secrets.APPSTORE_CONNECT_KEY_ID }}
+        run: |
+          gem install fastlane --no-document
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo -n "$APPSTORE_CONNECT_API_KEY" | base64 --decode \
+            -o ~/.appstoreconnect/private_keys/AuthKey_${APPSTORE_CONNECT_KEY_ID}.p8
+      - id: kc_pass
+        run: |
+          pw="$(openssl rand -hex 32)"
+          echo "::add-mask::$pw"
+          echo "password=$pw" >> "$GITHUB_OUTPUT"
+      - name: Sync signing (Developer ID via match)
+        env:
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          APPSTORE_CONNECT_KEY_ID: ${{ secrets.APPSTORE_CONNECT_KEY_ID }}
+          APPSTORE_CONNECT_ISSUER_ID: ${{ secrets.APPSTORE_CONNECT_ISSUER_ID }}
+          APPSTORE_CONNECT_KEY_FILEPATH: ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APPSTORE_CONNECT_KEY_ID }}.p8
+          MATCH_KEYCHAIN_PASSWORD: ${{ steps.kc_pass.outputs.password }}
+        run: fastlane sync_signing_macos
       - run: flutter pub get
-      - run: flutter build macos --release --dart-define=GIPHY_API_KEY=${{ secrets.GIPHY_API_KEY }}
-      - name: Archive build
+      - name: Repair vodozemac framework layout
+        run: |
+          FW="macos/Flutter/ephemeral/Packages/.packages/flutter_vodozemac-0.6.0/flutter_vodozemac.xcframework/macos-arm64_x86_64/flutter_vodozemac.framework"
+          if [ -d "$FW/Versions/A" ]; then
+            echo "Rebuilding canonical versioned framework layout in $FW"
+            rm -rf "$FW/Versions/Current"
+            ln -s A "$FW/Versions/Current"
+            for e in flutter_vodozemac Headers Modules Resources; do
+              rm -rf "$FW/$e"
+              ln -s "Versions/Current/$e" "$FW/$e"
+            done
+            echo "=== $FW ==="
+            ls -la "$FW"
+            echo "=== Versions ==="
+            ls -la "$FW/Versions"
+          else
+            echo "Versions/A not found in $FW, skipping"
+          fi
+      - name: Build macOS
+        run: flutter build macos --release --dart-define=GIPHY_API_KEY=${{ secrets.GIPHY_API_KEY }}
+      - name: Notarize and staple
+        env:
+          APPSTORE_CONNECT_KEY_ID: ${{ secrets.APPSTORE_CONNECT_KEY_ID }}
+          APPSTORE_CONNECT_ISSUER_ID: ${{ secrets.APPSTORE_CONNECT_ISSUER_ID }}
+        run: |
+          APP="build/macos/Build/Products/Release/kohera.app"
+          KEY_FILE="$HOME/.appstoreconnect/private_keys/AuthKey_${APPSTORE_CONNECT_KEY_ID}.p8"
+          ditto -c -k --keepParent "$APP" kohera-macos-universal.zip
+          SUBMIT_OUT=$(xcrun notarytool submit kohera-macos-universal.zip \
+            --key "$KEY_FILE" \
+            --key-id "$APPSTORE_CONNECT_KEY_ID" \
+            --issuer "$APPSTORE_CONNECT_ISSUER_ID" \
+            --wait 2>&1 | tee /dev/stderr)
+          SUBMIT_ID=$(echo "$SUBMIT_OUT" | awk '/^[[:space:]]+id:/{print $2; exit}')
+          STATUS=$(echo "$SUBMIT_OUT" | awk '/^[[:space:]]+status:/{s=$2} END{print s}')
+          if [ "$STATUS" != "Accepted" ]; then
+            echo "::error::Notarization status: $STATUS (id: $SUBMIT_ID). Fetching log:"
+            xcrun notarytool log "$SUBMIT_ID" \
+              --key "$KEY_FILE" \
+              --key-id "$APPSTORE_CONNECT_KEY_ID" \
+              --issuer "$APPSTORE_CONNECT_ISSUER_ID"
+            exit 1
+          fi
+          xcrun stapler staple "$APP"
+          codesign --verify --verbose=4 "$APP"
+      - name: Archive stapled build
         run: |
           cd build/macos/Build/Products/Release
-          zip -r ../../../../../kohera-macos-universal.zip kohera.app
+          ditto -c -k --keepParent kohera.app ../../../../../kohera-macos-universal.zip
       - name: Generate checksum
         run: shasum -a 256 kohera-macos-universal.zip > kohera-macos-universal.zip.sha256
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,3 +45,38 @@ lane :provision do
     api_key: connect_api_key
   )
 end
+
+# ── macOS: Developer ID Application cert for notarized release ──
+# CI pulls read-only via sync_signing_macos; local rotation regenerates
+# via provision_macos. Developer ID certs need no provisioning profile,
+# so match only stores the certificate itself.
+lane :sync_signing_macos do
+  keychain = ENV["MATCH_KEYCHAIN_NAME"] || "fastlane_match_keychain"
+  create_keychain(
+    name: keychain,
+    password: ENV.fetch("MATCH_KEYCHAIN_PASSWORD"),
+    default_keychain: false,
+    unlock: true,
+    timeout: 3600,
+    lock_when_sleeps: false,
+    add_to_search_list: true
+  )
+  match(
+    type: "developer_id",
+    platform: "macos",
+    readonly: true,
+    api_key: connect_api_key,
+    keychain_name: keychain,
+    keychain_password: ENV.fetch("MATCH_KEYCHAIN_PASSWORD"),
+    app_identifier: ["io.github.quantumheart.kohera"]
+  )
+end
+
+lane :provision_macos do
+  match(
+    type: "developer_id",
+    platform: "macos",
+    api_key: connect_api_key,
+    app_identifier: ["io.github.quantumheart.kohera"]
+  )
+end

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -731,7 +731,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 54H5SS9R29;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -741,6 +743,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				OTHER_CODE_SIGN_FLAGS = "--options runtime --timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.quantumheart.kohera;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
## Summary

Fix the macOS release job: it failed at codesign with no signing identity and a malformed `flutter_vodozemac` framework. Wire up Developer ID signing + notarization so the macOS artifact is notarized and Gatekeeper-clear.

## Changes

- `fastlane/Fastfile`: `sync_signing_macos` (CI, read-only) + `provision_macos` (local) lanes, `match type: developer_id`, platform macos.
- `macos/Runner.xcodeproj/project.pbxproj` Release config: Manual signing, Developer ID Application identity, `--options runtime --timestamp`, `CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO` (drops `get-task-allow`).
- `.github/workflows/release.yml` build-macos: import Developer ID cert via match, repair the malformed `flutter_vodozemac` framework layout, build, `notarytool submit --wait` (log printed on failure), staple, ditto-zip, checksum, upload.

## Testing

- [x] `flutter analyze` clean
- [x] `build-macos` green end to end on CI (run 30862468696): cert pulled, framework repaired, build signed with hardened runtime + timestamp, notarization `Accepted`, staple succeeded, artifact uploaded.

Prerequisite: create the Developer ID cert once locally with `fastlane provision_macos` as the Account Holder before CI can pull it.

## Linked issues

Closes #

## Checklist

- [x] Conventional Commits subjects; issue refs only in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use `debugPrint('[Kohera] ...')`
- [x] No stray comments (only `// ── Section ──` markers)
- [ ] Tests added/updated
- [x] Targets `master`