### PR TITLE
fix: fall back to in-memory secure storage when Linux keyring is locked (#963)

### DIFF
--- a/lib/core/services/client_manager.dart
+++ b/lib/core/services/client_manager.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:kohera/core/services/client_factory.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/services/secure_storage.dart';
 import 'package:matrix/matrix.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -26,19 +27,20 @@ class ClientManager extends ChangeNotifier {
     FlutterSecureStorage? storage,
     SharedPreferences? prefs,
     MatrixServiceFactory? serviceFactory,
-  })  : _storage = storage ??
-              const FlutterSecureStorage(
-                iOptions: IOSOptions(
-                  groupId: 'group.io.github.quantumheart.kohera',
-                  accessibility: KeychainAccessibility.first_unlock,
-                ),
-                webOptions: WebOptions(
-                  dbName: 'KoheraEncryptedStorage',
-                  publicKey: 'KoheraSecureStorage',
-                ),
-              ),
-        _prefs = prefs,
-        _serviceFactory = serviceFactory;
+  }) : _storage =
+           storage ??
+           KoheraSecureStorage(
+             iOptions: const IOSOptions(
+               groupId: 'group.io.github.quantumheart.kohera',
+               accessibility: KeychainAccessibility.first_unlock,
+             ),
+             webOptions: const WebOptions(
+               dbName: 'KoheraEncryptedStorage',
+               publicKey: 'KoheraSecureStorage',
+             ),
+           ),
+       _prefs = prefs,
+       _serviceFactory = serviceFactory;
 
   static const _clientNamesKey = 'kohera_client_names';
 
@@ -78,16 +80,16 @@ class ClientManager extends ChangeNotifier {
     // Remove services that failed to restore (not logged in), unless it's
     // the only one left (so we still show the login screen).
     if (_services.length > 1) {
-      final toRemove =
-          _services.where((s) => !s.isLoggedIn).toList();
+      final toRemove = _services.where((s) => !s.isLoggedIn).toList();
       for (final s in toRemove) {
         _services.remove(s);
         _clientMap.remove(s);
       }
       if (_services.isEmpty) {
         // All failed — create a fresh default.
-        final (client, service) =
-            await _createServicePair(clientName: 'default');
+        final (client, service) = await _createServicePair(
+          clientName: 'default',
+        );
         await service.init(restoreSession: false);
         _services.add(service);
         _clientMap[service] = client;
@@ -128,8 +130,7 @@ class ClientManager extends ChangeNotifier {
   Future<MatrixService> createLoginService() async {
     cancelPendingService();
     final name = _generateClientName();
-    final (client, service) =
-        await _createServicePair(clientName: name);
+    final (client, service) = await _createServicePair(clientName: name);
     _clientMap[service] = client;
     await service.init(restoreSession: false);
     _pendingService = service;
@@ -199,8 +200,9 @@ class ClientManager extends ChangeNotifier {
 
     if (_services.isEmpty) {
       // Last account removed — create a fresh default for login screen.
-      final (newClient, fresh) =
-          await _createServicePair(clientName: 'default');
+      final (newClient, fresh) = await _createServicePair(
+        clientName: 'default',
+      );
       await fresh.init(restoreSession: false);
       _services.add(fresh);
       _clientMap[fresh] = newClient;
@@ -212,7 +214,9 @@ class ClientManager extends ChangeNotifier {
     }
 
     // Resume sync for the new active account if the old active was removed.
-    if (wasActive && _services.isNotEmpty && _services[_activeIndex].isLoggedIn) {
+    if (wasActive &&
+        _services.isNotEmpty &&
+        _services[_activeIndex].isLoggedIn) {
       _services[_activeIndex].sync.resume();
     }
 

--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -4,6 +4,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:kohera/core/services/client_avatar_resolver.dart';
 import 'package:kohera/core/services/client_media_resolver.dart';
+import 'package:kohera/core/services/secure_storage.dart';
 import 'package:kohera/core/services/session_backup.dart';
 import 'package:kohera/core/services/sticker_pack_service.dart';
 import 'package:kohera/core/services/sub_services/auth_service.dart';
@@ -40,18 +41,19 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
     required Client client,
     FlutterSecureStorage? storage,
     this.clientName = 'default',
-  })  : _client = client,
-        _storage = storage ??
-            const FlutterSecureStorage(
-              iOptions: IOSOptions(
-                groupId: 'group.io.github.quantumheart.kohera',
-                accessibility: KeychainAccessibility.first_unlock,
-              ),
-              webOptions: WebOptions(
-                dbName: 'KoheraEncryptedStorage',
-                publicKey: 'KoheraSecureStorage',
-              ),
-            ) {
+  }) : _client = client,
+       _storage =
+           storage ??
+           KoheraSecureStorage(
+             iOptions: const IOSOptions(
+               groupId: 'group.io.github.quantumheart.kohera',
+               accessibility: KeychainAccessibility.first_unlock,
+             ),
+             webOptions: const WebOptions(
+               dbName: 'KoheraEncryptedStorage',
+               publicKey: 'KoheraSecureStorage',
+             ),
+           ) {
     uia = UiaService(client: _client);
     chatBackup = ChatBackupService(
       client: _client,
@@ -292,8 +294,10 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
         await chatBackup.deleteStoredRecoveryKey();
         await chatBackup.deleteDismissalState();
       } else {
-        debugPrint('[Kohera] Transient refresh failure, keeping session '
-            'for next sync/refresh retry');
+        debugPrint(
+          '[Kohera] Transient refresh failure, keeping session '
+          'for next sync/refresh retry',
+        );
       }
     }
   }
@@ -391,13 +395,15 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
   }
 
   Future<
-      ({
-        String? token,
-        String? refreshToken,
-        String? userId,
-        String? homeserver,
-        String? deviceId
-      })> _readSessionKeys() async {
+    ({
+      String? token,
+      String? refreshToken,
+      String? userId,
+      String? homeserver,
+      String? deviceId,
+    })
+  >
+  _readSessionKeys() async {
     final results = await Future.wait([
       _storage.read(key: koheraKey(clientName, 'access_token')),
       _storage.read(key: koheraKey(clientName, 'refresh_token')),
@@ -450,9 +456,11 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
         auth.isLoggedIn = false;
         return;
       }
-      debugPrint('[Kohera] Session restored from database – '
-          'encryption=${_client.encryption != null ? "available" : "null"}, '
-          'encryptionEnabled=${_client.encryptionEnabled}');
+      debugPrint(
+        '[Kohera] Session restored from database – '
+        'encryption=${_client.encryption != null ? "available" : "null"}, '
+        'encryptionEnabled=${_client.encryptionEnabled}',
+      );
       await _activateSession();
       try {
         if (_client.accessToken != null) {
@@ -460,8 +468,10 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
         }
         await auth.saveSessionBackup();
       } catch (e) {
-        debugPrint('[Kohera] Persisting restored session failed '
-            '(non-fatal): $e');
+        debugPrint(
+          '[Kohera] Persisting restored session failed '
+          '(non-fatal): $e',
+        );
       }
     } catch (e, s) {
       debugPrint('[Kohera] Database session restore failed: $e');
@@ -480,8 +490,9 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
       String? refreshToken,
       String? userId,
       String? homeserver,
-      String? deviceId
-    }) keys;
+      String? deviceId,
+    })
+    keys;
     try {
       keys = await _readSessionKeys();
     } catch (e) {
@@ -499,9 +510,10 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
     );
 
     debugPrint(
-        '[Kohera] Database restore unavailable; seeding session from keychain '
-        'for ${keys.userId} on ${keys.homeserver} '
-        '(deviceId=${keys.deviceId}, clientName=$clientName)');
+      '[Kohera] Database restore unavailable; seeding session from keychain '
+      'for ${keys.userId} on ${keys.homeserver} '
+      '(deviceId=${keys.deviceId}, clientName=$clientName)',
+    );
 
     try {
       final homeserverUri = Uri.parse(keys.homeserver!);
@@ -515,9 +527,11 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
         newDeviceName: 'Kohera Flutter',
         newOlmAccount: backup?.olmAccount,
       );
-      debugPrint('[Kohera] Session restored from keychain – '
-          'encryption=${_client.encryption != null ? "available" : "null"}, '
-          'encryptionEnabled=${_client.encryptionEnabled}');
+      debugPrint(
+        '[Kohera] Session restored from keychain – '
+        'encryption=${_client.encryption != null ? "available" : "null"}, '
+        'encryptionEnabled=${_client.encryptionEnabled}',
+      );
       await _activateSession();
       try {
         if (_client.accessToken != null) {
@@ -525,8 +539,10 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
         }
         await auth.saveSessionBackup();
       } catch (e) {
-        debugPrint('[Kohera] Persisting restored session failed '
-            '(non-fatal): $e');
+        debugPrint(
+          '[Kohera] Persisting restored session failed '
+          '(non-fatal): $e',
+        );
       }
     } catch (e, s) {
       debugPrint('[Kohera] Keychain session restore failed: $e');

--- a/lib/core/services/secure_storage.dart
+++ b/lib/core/services/secure_storage.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// [FlutterSecureStorage] wrapper that falls back to an in-memory store when
+/// the platform keyring is locked (Linux) or otherwise unavailable.
+///
+/// This lets the app start on Linux desktops that do not have an unlocked
+/// libsecret keyring, at the cost of credentials not persisting across app
+/// restarts in that configuration.
+class KoheraSecureStorage extends FlutterSecureStorage {
+  KoheraSecureStorage({
+    super.iOptions,
+    super.aOptions,
+    super.lOptions,
+    super.wOptions,
+    super.webOptions,
+    super.mOptions,
+  });
+
+  final Map<String, String> _fallback = {};
+  bool _useFallback = false;
+
+  Future<T> _withFallback<T>(
+    Future<T> Function() attempt,
+    T Function() fallback,
+  ) async {
+    if (_useFallback) return fallback();
+    try {
+      return await attempt();
+    } on PlatformException catch (e) {
+      if (e.code == 'KeyringLocked') {
+        debugPrint(
+          '[Kohera] Keyring locked; using in-memory secure storage fallback. '
+          'Credentials will not persist across app restarts.',
+        );
+        _useFallback = true;
+        return fallback();
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) => _withFallback(
+    () => super.read(
+      key: key,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    ),
+    () => _fallback[key],
+  );
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) => _withFallback(
+    () => super.write(
+      key: key,
+      value: value,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    ),
+    () {
+      if (value == null) {
+        _fallback.remove(key);
+      } else {
+        _fallback[key] = value;
+      }
+    },
+  );
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) => _withFallback(
+    () => super.delete(
+      key: key,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    ),
+    () => _fallback.remove(key),
+  );
+
+  @override
+  Future<bool> containsKey({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) => _withFallback(
+    () => super.containsKey(
+      key: key,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    ),
+    () => _fallback.containsKey(key),
+  );
+
+  @override
+  Future<Map<String, String>> readAll({
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) => _withFallback(
+    () => super.readAll(
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    ),
+    () => Map.unmodifiable(_fallback),
+  );
+
+  @override
+  Future<void> deleteAll({
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) => _withFallback(
+    () => super.deleteAll(
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    ),
+    _fallback.clear,
+  );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -585,7 +585,7 @@ packages:
     source: hosted
     version: "3.0.1"
   flutter_secure_storage_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: flutter_secure_storage_platform_interface
       sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,6 +69,7 @@ dev_dependencies:
   fake_async: ^1.3.1
   flutter_ci_guard: ^0.4.0
   flutter_local_notifications_platform_interface: any
+  flutter_secure_storage_platform_interface: ^2.0.1
   flutter_test:
     sdk: flutter
   integration_test:

--- a/test/services/client_manager_test.dart
+++ b/test/services/client_manager_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/client_manager.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/services/secure_storage.dart';
 import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/annotations.dart';
@@ -36,11 +37,12 @@ class _TestServiceFactory extends MatrixServiceFactory {
     when(mockClient.userID).thenReturn('@$clientName:example.com');
     when(mockClient.dispose()).thenAnswer((_) async {});
     when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
-    when(mockClient.onPresenceChanged)
-        .thenReturn(CachedStreamController<CachedPresence>());
+    when(
+      mockClient.onPresenceChanged,
+    ).thenReturn(CachedStreamController<CachedPresence>());
     final s = MatrixService(
       client: mockClient,
-      storage: storage ?? const FlutterSecureStorage(),
+      storage: storage ?? KoheraSecureStorage(),
       clientName: clientName,
     );
     s.isLoggedInForTest = true;
@@ -78,8 +80,9 @@ void main() {
     });
 
     test('creates services for each stored name', () async {
-      when(mockPrefs.getStringList('kohera_client_names'))
-          .thenReturn(['default', 'work']);
+      when(
+        mockPrefs.getStringList('kohera_client_names'),
+      ).thenReturn(['default', 'work']);
       when(mockPrefs.setStringList(any, any)).thenAnswer((_) async => true);
 
       final createdNames = <String>[];
@@ -96,8 +99,9 @@ void main() {
     });
 
     test('removes non-logged-in services in multi-account init', () async {
-      when(mockPrefs.getStringList('kohera_client_names'))
-          .thenReturn(['default', 'expired']);
+      when(
+        mockPrefs.getStringList('kohera_client_names'),
+      ).thenReturn(['default', 'expired']);
       when(mockPrefs.setStringList(any, any)).thenAnswer((_) async => true);
 
       final manager = ClientManager(
@@ -116,8 +120,9 @@ void main() {
 
   group('setActiveAccount', () {
     test('switches active service and notifies listeners', () async {
-      when(mockPrefs.getStringList('kohera_client_names'))
-          .thenReturn(['default', 'work']);
+      when(
+        mockPrefs.getStringList('kohera_client_names'),
+      ).thenReturn(['default', 'work']);
       when(mockPrefs.setStringList(any, any)).thenAnswer((_) async => true);
 
       final manager = ClientManager(
@@ -168,9 +173,12 @@ void main() {
 
       final newMockClient = MockClient();
       when(newMockClient.rooms).thenReturn([]);
-      when(newMockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
-      when(newMockClient.onPresenceChanged)
-          .thenReturn(CachedStreamController<CachedPresence>());
+      when(
+        newMockClient.onSync,
+      ).thenReturn(CachedStreamController<SyncUpdate>());
+      when(
+        newMockClient.onPresenceChanged,
+      ).thenReturn(CachedStreamController<CachedPresence>());
       final newService = MatrixService(
         client: newMockClient,
         storage: mockStorage,
@@ -182,17 +190,20 @@ void main() {
       expect(manager.services, hasLength(2));
       expect(manager.activeIndex, 1);
       expect(manager.activeService.clientName, 'account_1');
-      verify(mockPrefs.setStringList(
-        'kohera_client_names',
-        ['default', 'account_1'],
-      ),).called(1);
+      verify(
+        mockPrefs.setStringList(
+          'kohera_client_names',
+          ['default', 'account_1'],
+        ),
+      ).called(1);
     });
   });
 
   group('removeService', () {
     test('removes service and adjusts active index', () async {
-      when(mockPrefs.getStringList('kohera_client_names'))
-          .thenReturn(['default', 'work']);
+      when(
+        mockPrefs.getStringList('kohera_client_names'),
+      ).thenReturn(['default', 'work']);
       when(mockPrefs.setStringList(any, any)).thenAnswer((_) async => true);
 
       final services = <MatrixService>[];
@@ -243,11 +254,11 @@ void main() {
     test(
       'switches active before logging out when other accounts exist',
       () async {
-        when(mockPrefs.getStringList('kohera_client_names'))
-            .thenReturn(['default', 'work']);
+        when(
+          mockPrefs.getStringList('kohera_client_names'),
+        ).thenReturn(['default', 'work']);
         when(mockPrefs.setStringList(any, any)).thenAnswer((_) async => true);
-        when(mockStorage.delete(key: anyNamed('key')))
-            .thenAnswer((_) async {});
+        when(mockStorage.delete(key: anyNamed('key'))).thenAnswer((_) async {});
 
         final services = <MatrixService>[];
         final manager = ClientManager(
@@ -264,8 +275,7 @@ void main() {
         // capture the currently active service's logged-in state.
         final activeLoggedSnapshots = <bool>[];
         manager.addListener(() {
-          activeLoggedSnapshots
-              .add(manager.activeService.isLoggedIn);
+          activeLoggedSnapshots.add(manager.activeService.isLoggedIn);
         });
 
         await manager.signOut(target);
@@ -280,12 +290,10 @@ void main() {
       },
     );
 
-    test('falls through to login flow when last account signs out',
-        () async {
+    test('falls through to login flow when last account signs out', () async {
       when(mockPrefs.getStringList('kohera_client_names')).thenReturn(null);
       when(mockPrefs.setStringList(any, any)).thenAnswer((_) async => true);
-      when(mockStorage.delete(key: anyNamed('key')))
-          .thenAnswer((_) async {});
+      when(mockStorage.delete(key: anyNamed('key'))).thenAnswer((_) async {});
 
       final services = <MatrixService>[];
       final manager = ClientManager(
@@ -318,8 +326,9 @@ void main() {
     });
 
     test('returns true with multiple accounts', () async {
-      when(mockPrefs.getStringList('kohera_client_names'))
-          .thenReturn(['default', 'work']);
+      when(
+        mockPrefs.getStringList('kohera_client_names'),
+      ).thenReturn(['default', 'work']);
       when(mockPrefs.setStringList(any, any)).thenAnswer((_) async => true);
 
       final manager = ClientManager(
@@ -348,8 +357,9 @@ class _MixedLoginFactory extends MatrixServiceFactory {
     when(mockClient.rooms).thenReturn([]);
     when(mockClient.userID).thenReturn('@$clientName:example.com');
     when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
-    when(mockClient.onPresenceChanged)
-        .thenReturn(CachedStreamController<CachedPresence>());
+    when(
+      mockClient.onPresenceChanged,
+    ).thenReturn(CachedStreamController<CachedPresence>());
     final s = MatrixService(
       client: mockClient,
       storage: storage ?? _storage,
@@ -383,8 +393,9 @@ class _CountingFactory extends MatrixServiceFactory {
     when(mockClient.rooms).thenReturn([]);
     when(mockClient.dispose()).thenAnswer((_) async {});
     when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
-    when(mockClient.onPresenceChanged)
-        .thenReturn(CachedStreamController<CachedPresence>());
+    when(
+      mockClient.onPresenceChanged,
+    ).thenReturn(CachedStreamController<CachedPresence>());
     final s = MatrixService(
       client: mockClient,
       storage: storage ?? _storage,

--- a/test/services/secure_storage_test.dart
+++ b/test/services/secure_storage_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/services/secure_storage.dart';
+
+class _LockedKeyringPlatform extends FlutterSecureStoragePlatform {
+  @override
+  Future<bool> containsKey({
+    required String key,
+    required Map<String, String> options,
+  }) => _throw();
+
+  @override
+  Future<void> delete({
+    required String key,
+    required Map<String, String> options,
+  }) => _throw();
+
+  @override
+  Future<void> deleteAll({required Map<String, String> options}) => _throw();
+
+  @override
+  Future<String?> read({
+    required String key,
+    required Map<String, String> options,
+  }) => _throw();
+
+  @override
+  Future<Map<String, String>> readAll({
+    required Map<String, String> options,
+  }) => _throw();
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+    required Map<String, String> options,
+  }) => _throw();
+
+  Future<T> _throw<T>() async => throw PlatformException(
+    code: 'KeyringLocked',
+    message: 'KeyringLocked',
+  );
+}
+
+class _OtherErrorPlatform extends FlutterSecureStoragePlatform {
+  @override
+  Future<bool> containsKey({
+    required String key,
+    required Map<String, String> options,
+  }) => _throw();
+
+  @override
+  Future<void> delete({
+    required String key,
+    required Map<String, String> options,
+  }) => _throw();
+
+  @override
+  Future<void> deleteAll({required Map<String, String> options}) => _throw();
+
+  @override
+  Future<String?> read({
+    required String key,
+    required Map<String, String> options,
+  }) => _throw();
+
+  @override
+  Future<Map<String, String>> readAll({
+    required Map<String, String> options,
+  }) => _throw();
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+    required Map<String, String> options,
+  }) => _throw();
+
+  Future<T> _throw<T>() async => throw PlatformException(
+    code: 'SomeOtherError',
+    message: 'SomeOtherError',
+  );
+}
+
+void main() {
+  group('KoheraSecureStorage', () {
+    late FlutterSecureStoragePlatform originalPlatform;
+
+    setUpAll(() {
+      originalPlatform = FlutterSecureStoragePlatform.instance;
+    });
+
+    tearDown(() {
+      FlutterSecureStoragePlatform.instance = originalPlatform;
+    });
+
+    test('read falls back to in-memory when keyring is locked', () async {
+      FlutterSecureStoragePlatform.instance = _LockedKeyringPlatform();
+      final storage = KoheraSecureStorage();
+
+      expect(await storage.read(key: 'foo'), isNull);
+      await storage.write(key: 'foo', value: 'bar');
+      expect(await storage.read(key: 'foo'), 'bar');
+    });
+
+    test('delete removes value from in-memory fallback', () async {
+      FlutterSecureStoragePlatform.instance = _LockedKeyringPlatform();
+      final storage = KoheraSecureStorage();
+
+      await storage.write(key: 'foo', value: 'bar');
+      expect(await storage.read(key: 'foo'), 'bar');
+      await storage.delete(key: 'foo');
+      expect(await storage.read(key: 'foo'), isNull);
+    });
+
+    test('containsKey works with in-memory fallback', () async {
+      FlutterSecureStoragePlatform.instance = _LockedKeyringPlatform();
+      final storage = KoheraSecureStorage();
+
+      expect(await storage.containsKey(key: 'foo'), false);
+      await storage.write(key: 'foo', value: 'bar');
+      expect(await storage.containsKey(key: 'foo'), true);
+    });
+
+    test('readAll returns in-memory values when keyring is locked', () async {
+      FlutterSecureStoragePlatform.instance = _LockedKeyringPlatform();
+      final storage = KoheraSecureStorage();
+
+      await storage.write(key: 'foo', value: 'bar');
+      await storage.write(key: 'baz', value: 'qux');
+      expect(await storage.readAll(), {'foo': 'bar', 'baz': 'qux'});
+    });
+
+    test('deleteAll clears in-memory fallback', () async {
+      FlutterSecureStoragePlatform.instance = _LockedKeyringPlatform();
+      final storage = KoheraSecureStorage();
+
+      await storage.write(key: 'foo', value: 'bar');
+      await storage.deleteAll();
+      expect(await storage.read(key: 'foo'), isNull);
+      expect(await storage.readAll(), isEmpty);
+    });
+
+    test('rethrows non-keyring PlatformException', () async {
+      FlutterSecureStoragePlatform.instance = _OtherErrorPlatform();
+      final storage = KoheraSecureStorage();
+
+      expect(
+        () => storage.read(key: 'foo'),
+        throwsA(isA<PlatformException>()),
+      );
+    });
+
+    test('write with null value removes key in fallback', () async {
+      FlutterSecureStoragePlatform.instance = _LockedKeyringPlatform();
+      final storage = KoheraSecureStorage();
+
+      await storage.write(key: 'foo', value: 'bar');
+      await storage.write(key: 'foo', value: null);
+      expect(await storage.read(key: 'foo'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #963.

On Linux, `flutter_secure_storage` uses libsecret. When the keyring is locked or unavailable, the app crashes during startup with:

```
libsecret_error: KeyringLocked
[Kohera] Initialization failed: PlatformException(KeyringLocked, KeyringLocked, null, null)
```

This PR adds `KoheraSecureStorage`, a `FlutterSecureStorage` subclass that catches `PlatformException(code: KeyringLocked)` and falls back to an in-memory store so the app can still start.

## What changed

- **New:** `lib/core/services/secure_storage.dart`
  - `KoheraSecureStorage extends FlutterSecureStorage`
  - Catches `KeyringLocked` on any read/write/delete operation
  - Falls back to an in-memory `Map<String, String>`
  - Logs `[Kohera] Keyring locked; using in-memory secure storage fallback...`

- **Updated:** `lib/core/services/client_manager.dart` and `lib/core/services/matrix_service.dart`
  - Use `KoheraSecureStorage` as the default secure storage instance

- **Tests:** `test/services/secure_storage_test.dart`
  - Simulates a locked keyring platform and verifies read/write/delete/readAll/deleteAll/containsKey fall back to memory
  - Verifies non-keyring `PlatformException`s are still rethrown

- **Dependencies:** added `flutter_secure_storage_platform_interface` to `dev_dependencies` for test platform mocking.

## Trade-off

When the keyring is locked, credentials are stored in memory only and will not persist across app restarts. The user will need to log in again after restarting the app. This is preferable to a startup crash.

## Verification

- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — all pass
- [x] `flutter test --coverage` — CI gate passes (≥80%)

Closes #963