### PR TITLE
feat(ci): auto-deploy web client and landing page on release

### DIFF
--- a/.github/workflows/web-release.yml
+++ b/.github/workflows/web-release.yml
@@ -65,3 +65,27 @@ jobs:
             GIPHY_API_KEY=${{ secrets.GIPHY_API_KEY }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy.key
+          chmod 600 ~/.ssh/deploy.key
+          cat >> ~/.ssh/config <<END
+          Host matrix-server
+            HostName $DEPLOY_HOST
+            User $DEPLOY_USER
+            IdentityFile ~/.ssh/deploy.key
+            StrictHostKeyChecking accept-new
+          END
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+
+      - name: Deploy
+        run: ssh matrix-server 'sudo /opt/kohera/deploy.sh'


### PR DESCRIPTION
## What

Add a `deploy` job to `web-release.yml` that runs automatically after the image is built and pushed to GHCR.

## How it works

```
[Tag v*] → Build image → Push to GHCR →
  ① Configure SSH (native, no third-party action)
  ② ssh into server → sudo /opt/kohera/deploy.sh
     ├─ curl latest site/index.html from GitHub
     ├─ docker compose pull + up -d
     ├─ cp landing page → /matrix/static-files/public/index.html
     └─ cleanup
```

The deploy script (`/opt/kohera/deploy.sh`) is a root-owned bash script on the server. It:

- Downloads the latest landing page from `master` via `curl`
- Pulls the new Docker image and recreates the container
- Copies the landing page to the matrix-static-files public directory

## Required secrets

| Secret | Description |
|---|---|
| `DEPLOY_HOST` | Server IP |
| `DEPLOY_USER` | `deploy` (restricted service account) |
| `DEPLOY_SSH_KEY` | SSH private key for the deploy user |

## Security

- Deploy user has restricted sudo — only `/opt/kohera/deploy.sh` (no root shell)
- Deploy script is root-owned — deploy user cannot modify it
- SSH is publickey-only via `Match User deploy` in `sshd_config` (bypasses OTP)
- No third-party actions handle the SSH key