### PR TITLE
feat: server highlight words + multi-term matching

### DIFF
--- a/lib/core/utils/text_highlight.dart
+++ b/lib/core/utils/text_highlight.dart
@@ -4,25 +4,64 @@ class HighlightSpan {
   final bool isMatch;
 }
 
-List<HighlightSpan> highlightSpans(String text, String query) {
-  if (query.isEmpty) return [HighlightSpan(text, false)];
+class _Match {
+  final int start;
+  final int end;
+  _Match(this.start, this.end);
+}
+
+List<HighlightSpan> highlightSpans(String text, List<String> terms) {
+  if (terms.isEmpty) return [HighlightSpan(text, false)];
 
   final lower = text.toLowerCase();
-  final queryLower = query.toLowerCase();
-  final spans = <HighlightSpan>[];
-  var start = 0;
+  final matches = <_Match>[];
 
-  while (start < text.length) {
-    final index = lower.indexOf(queryLower, start);
-    if (index == -1) {
-      spans.add(HighlightSpan(text.substring(start), false));
-      break;
+  for (final term in terms) {
+    if (term.isEmpty) continue;
+    final termLower = term.toLowerCase();
+    var start = 0;
+    while (start < text.length) {
+      final index = lower.indexOf(termLower, start);
+      if (index == -1) break;
+      matches.add(_Match(index, index + term.length));
+      start = index + 1; // Allow overlapping matches for different terms
     }
-    if (index > start) {
-      spans.add(HighlightSpan(text.substring(start, index), false));
+  }
+
+  if (matches.isEmpty) {
+    if (text.isEmpty) return [];
+    return [HighlightSpan(text, false)];
+  }
+
+  matches.sort((a, b) => a.start.compareTo(b.start));
+
+  final merged = <_Match>[];
+  var current = matches[0];
+
+  for (var i = 1; i < matches.length; i++) {
+    final next = matches[i];
+    if (next.start <= current.end) {
+      current = _Match(current.start, current.end > next.end ? current.end : next.end);
+    } else {
+      merged.add(current);
+      current = next;
     }
-    spans.add(HighlightSpan(text.substring(index, index + query.length), true));
-    start = index + query.length;
+  }
+  merged.add(current);
+
+  final spans = <HighlightSpan>[];
+  var lastEnd = 0;
+
+  for (final match in merged) {
+    if (match.start > lastEnd) {
+      spans.add(HighlightSpan(text.substring(lastEnd, match.start), false));
+    }
+    spans.add(HighlightSpan(text.substring(match.start, match.end), true));
+    lastEnd = match.end;
+  }
+
+  if (lastEnd < text.length) {
+    spans.add(HighlightSpan(text.substring(lastEnd), false));
   }
 
   return spans;

--- a/lib/features/chat/widgets/search_result_tile.dart
+++ b/lib/features/chat/widgets/search_result_tile.dart
@@ -17,12 +17,14 @@ class SearchResultTile extends StatelessWidget {
     required this.avatarResolver,
     required this.query,
     required this.onTap,
+    this.highlights,
     super.key,
   });
 
   final RoomSearchResult result;
   final AvatarResolver avatarResolver;
   final String query;
+  final List<String>? highlights;
   final VoidCallback onTap;
 
   @override
@@ -100,7 +102,10 @@ class SearchResultTile extends StatelessWidget {
   Widget _buildHighlightedBody(TextTheme tt, ColorScheme cs) {
     final message = result.message;
     final body = message.body;
-    final spans = highlightSpans(body, query);
+    final terms = (highlights != null && highlights!.isNotEmpty)
+        ? highlights!
+        : query.trim().split(RegExp(r'\s+')).where((t) => t.isNotEmpty).toList();
+    final spans = highlightSpans(body, terms);
     final icon = iconForMessageType(message.messageType);
 
     if (icon == null) {

--- a/lib/features/chat/widgets/search_results_body.dart
+++ b/lib/features/chat/widgets/search_results_body.dart
@@ -156,6 +156,7 @@ class SearchResultsBody extends StatelessWidget {
           result: result,
           avatarResolver: avatarResolver,
           query: query,
+          highlights: search.highlights,
           onTap: () => onTapResult(result.message.eventId),
         );
       },

--- a/lib/features/rooms/widgets/message_search_tiles.dart
+++ b/lib/features/rooms/widgets/message_search_tiles.dart
@@ -73,7 +73,8 @@ class MessageSearchResultTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
-    final spans = highlightSpans(result.body, query.trim());
+    final terms = query.trim().split(RegExp(r'\s+')).where((t) => t.isNotEmpty).toList();
+    final spans = highlightSpans(result.body, terms);
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 2),

--- a/test/utils/text_highlight_test.dart
+++ b/test/utils/text_highlight_test.dart
@@ -4,21 +4,21 @@ import 'package:kohera/core/utils/text_highlight.dart';
 void main() {
   group('highlightSpans', () {
     test('returns single non-match span when query is empty', () {
-      final spans = highlightSpans('Hello world', '');
+      final spans = highlightSpans('Hello world', []);
       expect(spans, hasLength(1));
       expect(spans[0].text, 'Hello world');
       expect(spans[0].isMatch, isFalse);
     });
 
     test('returns single non-match span when query not found', () {
-      final spans = highlightSpans('Hello world', 'xyz');
+      final spans = highlightSpans('Hello world', ['xyz']);
       expect(spans, hasLength(1));
       expect(spans[0].text, 'Hello world');
       expect(spans[0].isMatch, isFalse);
     });
 
     test('highlights single match at start', () {
-      final spans = highlightSpans('Hello world', 'Hello');
+      final spans = highlightSpans('Hello world', ['Hello']);
       expect(spans, hasLength(2));
       expect(spans[0].text, 'Hello');
       expect(spans[0].isMatch, isTrue);
@@ -27,7 +27,7 @@ void main() {
     });
 
     test('highlights single match at end', () {
-      final spans = highlightSpans('Hello world', 'world');
+      final spans = highlightSpans('Hello world', ['world']);
       expect(spans, hasLength(2));
       expect(spans[0].text, 'Hello ');
       expect(spans[0].isMatch, isFalse);
@@ -36,7 +36,7 @@ void main() {
     });
 
     test('highlights single match in middle', () {
-      final spans = highlightSpans('Hello big world', 'big');
+      final spans = highlightSpans('Hello big world', ['big']);
       expect(spans, hasLength(3));
       expect(spans[0].text, 'Hello ');
       expect(spans[0].isMatch, isFalse);
@@ -47,26 +47,24 @@ void main() {
     });
 
     test('highlights multiple occurrences', () {
-      final spans = highlightSpans('abcabc', 'abc');
-      expect(spans, hasLength(2));
-      expect(spans[0].text, 'abc');
+      final spans = highlightSpans('abcabc', ['abc']);
+      expect(spans, hasLength(1));
+      expect(spans[0].text, 'abcabc');
       expect(spans[0].isMatch, isTrue);
-      expect(spans[1].text, 'abc');
-      expect(spans[1].isMatch, isTrue);
     });
 
     test('is case-insensitive', () {
-      final spans = highlightSpans('Hello HELLO hello', 'hello');
+      final spans = highlightSpans('Hello HELLO hello', ['hello']);
       expect(spans.where((s) => s.isMatch).length, 3);
     });
 
     test('handles empty text', () {
-      final spans = highlightSpans('', 'query');
+      final spans = highlightSpans('', ['query']);
       expect(spans, isEmpty);
     });
 
     test('handles query that matches entire text', () {
-      final spans = highlightSpans('abc', 'abc');
+      final spans = highlightSpans('abc', ['abc']);
       expect(spans, hasLength(1));
       expect(spans[0].text, 'abc');
       expect(spans[0].isMatch, isTrue);


### PR DESCRIPTION
Support server-provided highlight words (stemming) and multi-term matching in search results.

## Changes
- Updated `highlightSpans` in `lib/core/utils/text_highlight.dart` to accept `List<String>` and merge overlapping/adjacent matches.
- Updated `SearchResultTile` to use server-provided highlights if available, falling back to query terms.
- Updated all call sites of `highlightSpans`.
- Fixed corresponding tests in `test/utils/text_highlight_test.dart`.

Closes #901