### PR TITLE
feat(search): timeline-aware display resolution for edits/threads (#902)

### DIFF
--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -272,6 +272,7 @@ class _ChatScreenState extends State<ChatScreen>
       roomId: widget.roomId,
       searchService: RoomSearchService(
         client: matrix.client,
+        getTimeline: () => _timelineController.timeline,
         localSearchService: indexerDb == null
             ? null
             : LocalSearchService(

--- a/lib/features/chat/services/room_search_service.dart
+++ b/lib/features/chat/services/room_search_service.dart
@@ -19,13 +19,24 @@ import 'package:matrix/matrix.dart';
 /// empty [RoomSearchResponse] flagged `isEncryptedRoom: true` is returned so
 /// the UI can show the platform-specific "not available" message.
 class RoomSearchService {
-  RoomSearchService({required this.client, this.localSearchService});
+  RoomSearchService({
+    required this.client,
+    this.localSearchService,
+    this.getTimeline,
+  });
 
   final Client client;
 
   /// Optional local (FTS5) search backend for encrypted rooms. `null` when the
   /// platform does not support the local search index.
   final LocalSearchService? localSearchService;
+
+  /// Optional accessor for the room's live [Timeline], used to aggregate
+  /// edits and thread relations when resolving matched messages and their
+  /// context. `null` when no timeline is available (e.g. before the room has
+  /// loaded); resolution then falls back to the raw event without edit/thread
+  /// aggregation.
+  final Timeline? Function()? getTimeline;
 
   /// Number of context events to request before and after each match.
   static const contextBeforeLimit = 3;
@@ -89,6 +100,11 @@ class RoomSearchService {
         return const RoomSearchResponse();
       }
 
+      // Reuse the room's live timeline (if loaded) so that edited and
+      // threaded messages display correctly via `MessageDisplayResolver`.
+      // The timeline is not owned by this service and must not be disposed
+      // here.
+      final timeline = getTimeline?.call();
       const resolver = MessageDisplayResolver();
       final results = <RoomSearchResult>[];
       for (final result in roomEvents.results ?? <Result>[]) {
@@ -96,18 +112,20 @@ class RoomSearchService {
         if (matrixEvent == null) continue;
 
         final event = Event.fromMatrixEvent(matrixEvent, room);
-        final message = resolver(event);
+        final message = resolver(event, timeline: timeline);
 
         final context = result.context;
         final before = _resolveContext(
           context?.eventsBefore,
           room,
           resolver,
+          timeline,
         );
         final after = _resolveContext(
           context?.eventsAfter,
           room,
           resolver,
+          timeline,
         );
 
         results.add(RoomSearchResult(
@@ -134,10 +152,11 @@ class RoomSearchService {
     List<MatrixEvent>? events,
     Room room,
     MessageDisplayResolver resolver,
+    Timeline? timeline,
   ) {
     if (events == null || events.isEmpty) return const [];
     return events
-        .map((me) => resolver(Event.fromMatrixEvent(me, room)))
+        .map((me) => resolver(Event.fromMatrixEvent(me, room), timeline: timeline))
         .toList(growable: false);
   }
 }

--- a/lib/features/chat/widgets/search_result_tile.dart
+++ b/lib/features/chat/widgets/search_result_tile.dart
@@ -64,7 +64,7 @@ class SearchResultTile extends StatelessWidget {
                     children: [
                       Row(
                         children: [
-                          Expanded(
+                          Flexible(
                             child: Text(
                               message.senderName,
                               maxLines: 1,
@@ -74,6 +74,27 @@ class SearchResultTile extends StatelessWidget {
                               ),
                             ),
                           ),
+                          if (message.threadRootId != null) ...[
+                            const SizedBox(width: 4),
+                            Icon(
+                              Icons.forum_rounded,
+                              size: 12,
+                              color: cs.onSurfaceVariant
+                                  .withValues(alpha: 0.5),
+                            ),
+                          ],
+                          if (message.isEdited) ...[
+                            const SizedBox(width: 4),
+                            Text(
+                              '(edited)',
+                              style: tt.bodySmall?.copyWith(
+                                color: cs.onSurfaceVariant
+                                    .withValues(alpha: 0.5),
+                                fontStyle: FontStyle.italic,
+                              ),
+                            ),
+                          ],
+                          const SizedBox(width: 8),
                           Text(
                             formatRelativeTimestamp(message.timestamp),
                             style: tt.bodySmall?.copyWith(

--- a/test/widgets/search_result_tile_test.dart
+++ b/test/widgets/search_result_tile_test.dart
@@ -374,5 +374,79 @@ void main() {
       expect(ctxRichText.maxLines, 1);
       expect(ctxRichText.overflow, TextOverflow.ellipsis);
     });
+
+    testWidgets('shows (edited) indicator for edited messages', (tester) async {
+      final result = RoomSearchResult(
+        message: makeMessage(body: 'edited body').copyWith(isEdited: true),
+      );
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          child: SearchResultTile(
+            result: result,
+            avatarResolver: avatarResolver,
+            query: 'edited',
+            onTap: () {},
+          ),
+        ),
+      );
+
+      expect(find.text('(edited)'), findsOneWidget);
+    });
+
+    testWidgets('does not show (edited) for non-edited messages',
+        (tester) async {
+      final result = RoomSearchResult(message: makeMessage());
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          child: SearchResultTile(
+            result: result,
+            avatarResolver: avatarResolver,
+            query: 'hello',
+            onTap: () {},
+          ),
+        ),
+      );
+
+      expect(find.text('(edited)'), findsNothing);
+    });
+
+    testWidgets('shows thread icon for thread root messages', (tester) async {
+      final result = RoomSearchResult(
+        message: makeMessage().copyWith(threadRootId: r'$threadRoot'),
+      );
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          child: SearchResultTile(
+            result: result,
+            avatarResolver: avatarResolver,
+            query: 'hello',
+            onTap: () {},
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.forum_rounded), findsOneWidget);
+    });
+
+    testWidgets('does not show thread icon for non-thread messages',
+        (tester) async {
+      final result = RoomSearchResult(message: makeMessage());
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          child: SearchResultTile(
+            result: result,
+            avatarResolver: avatarResolver,
+            query: 'hello',
+            onTap: () {},
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.forum_rounded), findsNothing);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Pass the room's live `Timeline` to `MessageDisplayResolver` in the server-side search path (`RoomSearchService`) so that edited and threaded messages display correctly in search results.

Previously, search results were built from raw `Event`s with no `Timeline`, so `isEdited` was always `false` and `threadRootId` was always `null`.

## Changes

- **`RoomSearchService`**: Add optional `getTimeline` callback (mirrors `LocalSearchService`'s existing pattern). In the unencrypted search path, call `getTimeline?.call()` and pass the resulting `Timeline` to `MessageDisplayResolver` for both the matched event and context events. The timeline is reused (not created/disposed) — it's the room's live timeline from `MessageTimelineController`.
- **`chat_screen.dart`**: Wire `getTimeline: () => _timelineController.timeline` into `RoomSearchService`.
- **`SearchResultTile`**: Show "(edited)" indicator (italic, dimmed) next to the sender name when `message.isEdited` is true. Show thread icon (`Icons.forum_rounded`) when `message.threadRootId` is non-null.
- **Tests**: Add 4 widget tests:
  - Shows "(edited)" indicator for edited messages
  - Does not show "(edited)" for non-edited messages
  - Shows thread icon for thread root messages
  - Does not show thread icon for non-thread messages

## Verification

- `flutter analyze` — no new issues (all 16 are pre-existing info-level)
- `flutter test test/widgets/search_result_tile_test.dart` — 16/16 pass
- `flutter test test/screens/chat_search_test.dart` — all pass
- `flutter test test/services/message_search_database_test.dart` — all pass
- `flutter test test/services/message_indexer_service_test.dart` — all pass

Closes #902
Refs #895