### PR TITLE
fix: use valid wasm-pack version pin (0.12.1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
   && rustup toolchain install nightly \
   && rustup component add rust-src --toolchain nightly \
   && rustup target add wasm32-unknown-unknown --toolchain nightly \
-  && cargo install wasm-pack --version 0.13.3 \
+  && cargo install wasm-pack --version 0.12.1 \
   && cargo install flutter_rust_bridge_codegen --version 2.11.1
 
 ENV PATH="/root/.cargo/bin:${PATH}"


### PR DESCRIPTION
## Summary

Fixes the Docker build failure caused by pinning `wasm-pack` to `0.13.3`, which does not exist on crates.io.

## Changes

- **Dockerfile**: Change `wasm-pack --version 0.13.3` → `0.12.1` (a valid published version that was current when the vodozemac Wasm bindings were originally generated)

## Testing

- [x] Verified `0.12.1` exists on crates.io
- [ ] `flutter analyze` is clean
- [ ] `flutter test` passes

## Linked issues

Follow-up to #977

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type
- [x] Targets `master`