### PR TITLE
feat(search): result count header + infinite scroll pagination (#903)

### DIFF
--- a/lib/features/chat/widgets/search_results_body.dart
+++ b/lib/features/chat/widgets/search_results_body.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:kohera/features/chat/services/chat_search_controller.dart';
 import 'package:kohera/features/chat/widgets/search_result_tile.dart';
@@ -7,8 +8,9 @@ import 'package:kohera/shared/widgets/kohera_loader.dart';
 /// Displays search results for in-room message search.
 ///
 /// Shows contextual states: minimum query prompt, loading spinner,
-/// error, empty results, or a scrollable results list.
-class SearchResultsBody extends StatelessWidget {
+/// error, empty results, or a scrollable results list with a result count
+/// header and infinite-scroll pagination.
+class SearchResultsBody extends StatefulWidget {
   const SearchResultsBody({
     required this.search,
     required this.avatarResolver,
@@ -21,10 +23,55 @@ class SearchResultsBody extends StatelessWidget {
   final ValueChanged<String> onTapResult;
 
   @override
+  State<SearchResultsBody> createState() => _SearchResultsBodyState();
+}
+
+class _SearchResultsBodyState extends State<SearchResultsBody> {
+  late final ScrollController _scrollController;
+
+  /// Distance from the bottom (in pixels) that triggers a load-more.
+  static const _loadMoreThreshold = 200;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController()..addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!_scrollController.hasClients) return;
+    final position = _scrollController.position;
+    if (position.pixels >= position.maxScrollExtent - _loadMoreThreshold &&
+        widget.search.nextBatch != null &&
+        !widget.search.isLoading) {
+      unawaited(widget.search.performSearch(loadMore: true));
+    }
+  }
+
+  /// Builds the result count header text shown above the list.
+  String _countText(ChatSearchController search) {
+    final count = search.count;
+    if (count != null) {
+      if (count > search.results.length) {
+        return 'Found $count results for "${search.query}"';
+      }
+      return 'Found $count results';
+    }
+    return 'Showing ${search.results.length} results';
+  }
+
+  @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
-    final query = search.query;
+    final query = widget.search.query;
 
     // Not enough characters yet.
     if (query.length < ChatSearchController.minQueryLength) {
@@ -43,7 +90,7 @@ class SearchResultsBody extends StatelessWidget {
     }
 
     // Error state.
-    if (search.error != null) {
+    if (widget.search.error != null) {
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(32),
@@ -54,7 +101,7 @@ class SearchResultsBody extends StatelessWidget {
                   size: 48, color: cs.error.withValues(alpha: 0.6),),
               const SizedBox(height: 12),
               Text(
-                search.error!,
+                widget.search.error!,
                 style: tt.bodyMedium?.copyWith(color: cs.error),
                 textAlign: TextAlign.center,
               ),
@@ -65,14 +112,14 @@ class SearchResultsBody extends StatelessWidget {
     }
 
     // Loading first batch.
-    if (search.isLoading && search.results.isEmpty) {
+    if (widget.search.isLoading && widget.search.results.isEmpty) {
       return const Center(child: KoheraLoader());
     }
 
     // Empty results.
-    if (search.results.isEmpty && !search.isLoading) {
+    if (widget.search.results.isEmpty && !widget.search.isLoading) {
       // Encrypted room on a platform without the local FTS5 index (e.g. web).
-      if (search.isEncryptedRoom && !search.hasLocalIndex) {
+      if (widget.search.isEncryptedRoom && !widget.search.hasLocalIndex) {
         return Center(
           child: Padding(
             padding: const EdgeInsets.all(32),
@@ -111,7 +158,7 @@ class SearchResultsBody extends StatelessWidget {
                 ),
                 textAlign: TextAlign.center,
               ),
-              if (search.isEncryptedRoom) ...[
+              if (widget.search.isEncryptedRoom) ...[
                 const SizedBox(height: 8),
                 Text(
                   'Encrypted rooms are searched on this device only.',
@@ -127,39 +174,57 @@ class SearchResultsBody extends StatelessWidget {
       );
     }
 
-    // Results list.
-    return ListView.builder(
-      padding: const EdgeInsets.symmetric(vertical: 4),
-      itemCount: search.results.length + (search.nextBatch != null ? 1 : 0),
-      itemBuilder: (context, i) {
-        // "Load more" button at the end.
-        if (i == search.results.length) {
-          return Padding(
-            padding: const EdgeInsets.symmetric(vertical: 12),
-            child: Center(
-              child: search.isLoading
-                  ? const SizedBox(
+    // Results list with count header and infinite scroll.
+    final showLoadingMore =
+        widget.search.isLoading && widget.search.nextBatch != null;
+
+    return Column(
+      children: [
+        // Result count header.
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Text(
+            _countText(widget.search),
+            style: tt.bodySmall?.copyWith(
+              color: cs.onSurfaceVariant,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ),
+        // Results list.
+        Expanded(
+          child: ListView.builder(
+            controller: _scrollController,
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            itemCount: widget.search.results.length + (showLoadingMore ? 1 : 0),
+            itemBuilder: (context, i) {
+              // Loading indicator at the bottom while fetching more.
+              if (i == widget.search.results.length) {
+                return const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 12),
+                  child: Center(
+                    child: SizedBox(
                       width: 24,
                       height: 24,
                       child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : TextButton(
-                      onPressed: () => search.performSearch(loadMore: true),
-                      child: const Text('Load more results'),
                     ),
-            ),
-          );
-        }
+                  ),
+                );
+              }
 
-        final result = search.results[i];
-        return SearchResultTile(
-          result: result,
-          avatarResolver: avatarResolver,
-          query: query,
-          highlights: search.highlights,
-          onTap: () => onTapResult(result.message.eventId),
-        );
-      },
+              final result = widget.search.results[i];
+              return SearchResultTile(
+                result: result,
+                avatarResolver: widget.avatarResolver,
+                query: query,
+                highlights: widget.search.highlights,
+                onTap: () => widget.onTapResult(result.message.eventId),
+              );
+            },
+          ),
+        ),
+      ],
     );
   }
+
 }

--- a/test/screens/chat_search_test.dart
+++ b/test/screens/chat_search_test.dart
@@ -55,6 +55,9 @@ void main() {
     when(mockTimeline.events).thenReturn([]);
     when(mockTimeline.canRequestHistory).thenReturn(false);
     when(mockRoom.client).thenReturn(mockClient);
+    final mockUser = User('@alice:example.com', room: mockRoom);
+    when(mockRoom.unsafeGetUserFromMemoryOrFallback(any))
+        .thenReturn(mockUser);
     when(mockRoom.encrypted).thenReturn(false);
     when(mockRoom.getTimeline(eventContextId: anyNamed('eventContextId'), onUpdate: anyNamed('onUpdate')))
         .thenAnswer((_) async => mockTimeline);
@@ -212,6 +215,88 @@ void main() {
         SearchResults(searchCategories: ResultCategories()),
       );
       await tester.pumpAndSettle();
+    });
+
+    testWidgets('shows result count header when results are present',
+        (tester) async {
+      when(mockClient.search(
+        any,
+        nextBatch: anyNamed('nextBatch'),
+      )).thenAnswer((_) async => SearchResults(
+            searchCategories: ResultCategories(
+              roomEvents: ResultRoomEvents(
+                results: [
+                  Result(
+                    result: MatrixEvent(
+                      type: 'm.room.message',
+                      content: {'body': 'hello world', 'msgtype': 'm.text'},
+                      eventId: r'$1:example.com',
+                      senderId: '@alice:example.com',
+                      originServerTs: DateTime(2024, 1, 1, 12),
+                      roomId: '!room:example.com',
+                    ),
+                    rank: 0.1,
+                    context: SearchResultsEventContext(),
+                  ),
+                ],
+                count: 1,
+              ),
+            ),
+          ));
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.search_rounded));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).last, 'hello');
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Found 1 results'), findsOneWidget);
+    });
+
+    testWidgets('does not show Load more results button (infinite scroll)',
+        (tester) async {
+      when(mockClient.search(
+        any,
+        nextBatch: anyNamed('nextBatch'),
+      )).thenAnswer((_) async => SearchResults(
+            searchCategories: ResultCategories(
+              roomEvents: ResultRoomEvents(
+                results: [
+                  Result(
+                    result: MatrixEvent(
+                      type: 'm.room.message',
+                      content: {'body': 'hello world', 'msgtype': 'm.text'},
+                      eventId: r'$1:example.com',
+                      senderId: '@alice:example.com',
+                      originServerTs: DateTime(2024, 1, 1, 12),
+                      roomId: '!room:example.com',
+                    ),
+                    rank: 0.1,
+                    context: SearchResultsEventContext(),
+                  ),
+                ],
+                count: 1,
+                nextBatch: 'next_batch_token',
+              ),
+            ),
+          ));
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.search_rounded));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).last, 'hello');
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pumpAndSettle();
+
+      // The manual "Load more results" button should NOT exist.
+      expect(find.text('Load more results'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Summary

Replace the manual "Load more results" button with auto-triggering infinite scroll pagination. Show a result count header above the list.

## Changes

- **`SearchResultsBody`**: Convert from `StatelessWidget` to `StatefulWidget` with a `ScrollController` that triggers `performSearch(loadMore: true)` when the user scrolls within 200px of the bottom
- **Result count header**: 
  - `Found {count} results for "{query}"` when `count > results.length` (more pages available)
  - `Found {count} results` when `count == results.length` (all loaded)
  - `Showing {results.length} results` when `count` is `null` (local search)
- **Remove** the manual "Load more results" `TextButton`
- **Loading indicator**: small `CircularProgressIndicator` (24×24) at the bottom of the list while fetching more results
- **No bottom widget** when `nextBatch` is `null` (no more results)
- **Tests**: 
  - Verify result count header appears with actual results
  - Verify "Load more results" button no longer exists

## Verification

- `flutter analyze` — no new issues (all 16 are pre-existing info-level)
- `flutter test test/screens/chat_search_test.dart` — 10/10 pass
- `flutter test test/widgets/search_result_tile_test.dart` — 16/16 pass
- `flutter test test/utils/text_highlight_test.dart` — all pass

Closes #903
Refs #895