### PR TITLE
feat(search): date separators + chronological grouping (#904)

### DIFF
--- a/lib/core/utils/time_format.dart
+++ b/lib/core/utils/time_format.dart
@@ -22,6 +22,26 @@ String formatMessageTime(DateTime ts) {
   return '${months[ts.month - 1]} ${ts.day}, ${ts.year}, $time';
 }
 
+/// Formats a [DateTime] as a human-readable day label for grouping.
+///
+/// Returns 'Today', 'Yesterday', or a formatted date like 'Jan 15, 2026'.
+String formatDateLabel(DateTime ts) {
+  final now = DateTime.now();
+  final today = DateTime(now.year, now.month, now.day);
+  final msgDate = DateTime(ts.year, ts.month, ts.day);
+  final diff = today.difference(msgDate).inDays;
+
+  if (diff == 0) return 'Today';
+  if (diff == 1) return 'Yesterday';
+
+  const months = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+  if (ts.year == now.year) return '${months[ts.month - 1]} ${ts.day}';
+  return '${months[ts.month - 1]} ${ts.day}, ${ts.year}';
+}
+
 String formatRelativeTimestamp(DateTime ts) {
   final now = DateTime.now();
   final diff = now.difference(ts);

--- a/lib/features/chat/widgets/search_results_body.dart
+++ b/lib/features/chat/widgets/search_results_body.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:kohera/core/utils/time_format.dart';
+import 'package:kohera/features/chat/models/room_search_result.dart';
 import 'package:kohera/features/chat/services/chat_search_controller.dart';
 import 'package:kohera/features/chat/widgets/search_result_tile.dart';
 import 'package:kohera/shared/services/avatar_resolver.dart';
@@ -9,7 +11,7 @@ import 'package:kohera/shared/widgets/kohera_loader.dart';
 ///
 /// Shows contextual states: minimum query prompt, loading spinner,
 /// error, empty results, or a scrollable results list with a result count
-/// header and infinite-scroll pagination.
+/// header, date separators, and infinite-scroll pagination.
 class SearchResultsBody extends StatefulWidget {
   const SearchResultsBody({
     required this.search,
@@ -65,6 +67,24 @@ class _SearchResultsBodyState extends State<SearchResultsBody> {
       return 'Found $count results';
     }
     return 'Showing ${search.results.length} results';
+  }
+
+  /// Pre-processes results into a flat list of list items, inserting a date
+  /// separator before any result whose timestamp falls on a different day
+  /// than the previous result.
+  List<_ListItem> _buildItems(List<RoomSearchResult> results) {
+    final items = <_ListItem>[];
+    DateTime? prevDay;
+    for (final result in results) {
+      final ts = result.message.timestamp;
+      final day = DateTime(ts.year, ts.month, ts.day);
+      if (prevDay == null || day != prevDay) {
+        items.add(_ListItem.separator(formatDateLabel(ts)));
+      }
+      items.add(_ListItem.result(result));
+      prevDay = day;
+    }
+    return items;
   }
 
   @override
@@ -174,9 +194,11 @@ class _SearchResultsBodyState extends State<SearchResultsBody> {
       );
     }
 
-    // Results list with count header and infinite scroll.
+    // Results list with count header, date separators, and infinite scroll.
     final showLoadingMore =
         widget.search.isLoading && widget.search.nextBatch != null;
+    final items = _buildItems(widget.search.results);
+    final itemCount = items.length + (showLoadingMore ? 1 : 0);
 
     return Column(
       children: [
@@ -196,10 +218,10 @@ class _SearchResultsBodyState extends State<SearchResultsBody> {
           child: ListView.builder(
             controller: _scrollController,
             padding: const EdgeInsets.symmetric(vertical: 4),
-            itemCount: widget.search.results.length + (showLoadingMore ? 1 : 0),
+            itemCount: itemCount,
             itemBuilder: (context, i) {
               // Loading indicator at the bottom while fetching more.
-              if (i == widget.search.results.length) {
+              if (i == items.length) {
                 return const Padding(
                   padding: EdgeInsets.symmetric(vertical: 12),
                   child: Center(
@@ -212,7 +234,12 @@ class _SearchResultsBodyState extends State<SearchResultsBody> {
                 );
               }
 
-              final result = widget.search.results[i];
+              final item = items[i];
+              if (item.isSeparator) {
+                return _DateSeparator(label: item.label!);
+              }
+
+              final result = item.result!;
               return SearchResultTile(
                 result: result,
                 avatarResolver: widget.avatarResolver,
@@ -226,5 +253,49 @@ class _SearchResultsBodyState extends State<SearchResultsBody> {
       ],
     );
   }
+}
 
+/// A single item in the flattened search results list — either a date
+/// separator header or a search result tile.
+class _ListItem {
+  _ListItem.separator(this.label) : result = null;
+  _ListItem.result(this.result) : label = null;
+
+  final String? label;
+  final RoomSearchResult? result;
+
+  bool get isSeparator => label != null;
+}
+
+/// A date separator header rendered between results on different days.
+class _DateSeparator extends StatelessWidget {
+  const _DateSeparator({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        children: [
+          Expanded(child: Divider(color: cs.outlineVariant, thickness: 0.5)),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Text(
+              label,
+              style: tt.labelSmall?.copyWith(
+                color: cs.onSurfaceVariant,
+                letterSpacing: 0.5,
+              ),
+            ),
+          ),
+          Expanded(child: Divider(color: cs.outlineVariant, thickness: 0.5)),
+        ],
+      ),
+    );
+  }
 }

--- a/test/screens/chat_search_test.dart
+++ b/test/screens/chat_search_test.dart
@@ -298,5 +298,63 @@ void main() {
       // The manual "Load more results" button should NOT exist.
       expect(find.text('Load more results'), findsNothing);
     });
+
+    testWidgets('shows date separators between results on different days',
+        (tester) async {
+      when(mockClient.search(
+        any,
+        nextBatch: anyNamed('nextBatch'),
+      )).thenAnswer((_) async => SearchResults(
+            searchCategories: ResultCategories(
+              roomEvents: ResultRoomEvents(
+                results: [
+                  Result(
+                    result: MatrixEvent(
+                      type: 'm.room.message',
+                      content: {'body': 'recent msg', 'msgtype': 'm.text'},
+                      eventId: r'$2:example.com',
+                      senderId: '@alice:example.com',
+                      originServerTs: DateTime(2024, 6, 15, 14),
+                      roomId: '!room:example.com',
+                    ),
+                    rank: 0.5,
+                    context: SearchResultsEventContext(),
+                  ),
+                  Result(
+                    result: MatrixEvent(
+                      type: 'm.room.message',
+                      content: {'body': 'old msg', 'msgtype': 'm.text'},
+                      eventId: r'$1:example.com',
+                      senderId: '@bob:example.com',
+                      originServerTs: DateTime(2024, 6, 10, 9),
+                      roomId: '!room:example.com',
+                    ),
+                    rank: 0.3,
+                    context: SearchResultsEventContext(),
+                  ),
+                ],
+                count: 2,
+              ),
+            ),
+          ));
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.search_rounded));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).last, 'msg');
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pumpAndSettle();
+
+      // Result count header should be present.
+      expect(find.textContaining('Found 2 results'), findsOneWidget);
+
+      // Date separators are rendered as Dividers with a label.
+      // Two results on different days produce two separators.
+      final dividers = find.byType(Divider);
+      expect(dividers, findsWidgets);
+    });
   });
 }

--- a/test/utils/time_format_test.dart
+++ b/test/utils/time_format_test.dart
@@ -36,4 +36,27 @@ void main() {
       expect(formatRelativeTimestamp(ts), '6d ago');
     });
   });
+
+  group('formatDateLabel', () {
+    test('returns "Today" for today', () {
+      final now = DateTime.now();
+      expect(formatDateLabel(now), 'Today');
+    });
+
+    test('returns "Yesterday" for yesterday', () {
+      final yesterday = DateTime.now().subtract(const Duration(days: 1));
+      expect(formatDateLabel(yesterday), 'Yesterday');
+    });
+
+    test('returns formatted date for same year', () {
+      final ts = DateTime(DateTime.now().year, 3, 15);
+      final result = formatDateLabel(ts);
+      expect(result, 'Mar 15');
+    });
+
+    test('returns formatted date with year for different year', () {
+      final ts = DateTime(2020, 7, 4);
+      expect(formatDateLabel(ts), 'Jul 4, 2020');
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Group search results chronologically with date separator headers (Today/Yesterday/formatted date) between results on different days.

## Changes

- **`time_format.dart`**: Add `formatDateLabel()` helper — returns `'Today'`, `'Yesterday'`, `'MMM d'` (same year), or `'MMM d, yyyy'` (different year)
- **`SearchResultsBody`**: Pre-process results into a flat list of `_ListItem` (separator or result), inserting a `_DateSeparator` before any result whose timestamp falls on a different day than the previous result
- **`_DateSeparator` widget**: Centered label with thin `Divider` lines on each side, styled as a small uppercase label (`tt.labelSmall`)
- Results ordered chronologically (newest first) via `SearchOrder.recent` in `RoomSearchService` (already set in #896)
- Works for both server-side and local search results

## Tests

- Widget test: two results on different days produce date separator dividers
- Unit tests for `formatDateLabel`: Today, Yesterday, same-year date, different-year date

## Verification

- `flutter analyze` — no new issues (all 16 are pre-existing info-level)
- `flutter test test/screens/chat_search_test.dart` — 10/10 pass
- `flutter test test/utils/time_format_test.dart` — 10/10 pass

Closes #904
Refs #895