### PR TITLE
feat(search): desktop keyboard navigation for search (#905)

### DIFF
--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -1095,6 +1095,8 @@ class _ChatScreenState extends State<ChatScreen>
         focusNode: _searchFocusNode,
         onChanged: _search.onQueryChanged,
         onClose: _closeSearch,
+        search: _search,
+        onSelectResult: _scrollToEventById,
       );
     } else {
       appBar = ChatAppBar(

--- a/lib/features/chat/services/chat_search_controller.dart
+++ b/lib/features/chat/services/chat_search_controller.dart
@@ -51,6 +51,11 @@ class ChatSearchController extends ChangeNotifier {
   String _query = '';
   String get query => _query;
 
+  /// Index of the keyboard-selected result in [_results], or -1 when no
+  /// result is selected. Reset to 0 whenever new results arrive.
+  int _selectedIndex = -1;
+  int get selectedIndex => _selectedIndex;
+
   bool _disposed = false;
 
   Timer? _debounceTimer;
@@ -68,6 +73,7 @@ class ChatSearchController extends ChangeNotifier {
     _hasLocalIndex = false;
     _error = null;
     _query = '';
+    _selectedIndex = -1;
     notifyListeners();
   }
 
@@ -85,6 +91,7 @@ class ChatSearchController extends ChangeNotifier {
     _isLoading = false;
     _error = null;
     _query = '';
+    _selectedIndex = -1;
     notifyListeners();
   }
 
@@ -100,6 +107,7 @@ class ChatSearchController extends ChangeNotifier {
       _isEncryptedRoom = false;
       _hasLocalIndex = false;
       _error = null;
+      _selectedIndex = -1;
       notifyListeners();
       return;
     }
@@ -120,6 +128,7 @@ class ChatSearchController extends ChangeNotifier {
       _highlights = null;
       _isEncryptedRoom = false;
       _hasLocalIndex = false;
+      _selectedIndex = -1;
     }
     notifyListeners();
 
@@ -155,6 +164,20 @@ class ChatSearchController extends ChangeNotifier {
       _error = 'Search failed. Please try again.';
       notifyListeners();
     }
+  }
+
+  /// Moves the keyboard selection down by one result (clamped to last).
+  void navigateDown() {
+    if (_results.isEmpty) return;
+    _selectedIndex = (_selectedIndex + 1).clamp(0, _results.length - 1);
+    notifyListeners();
+  }
+
+  /// Moves the keyboard selection up by one result (clamped to 0).
+  void navigateUp() {
+    if (_results.isEmpty) return;
+    _selectedIndex = (_selectedIndex - 1).clamp(0, _results.length - 1);
+    notifyListeners();
   }
 
   void setHighlight(String eventId) {

--- a/lib/features/chat/widgets/chat_app_bar.dart
+++ b/lib/features/chat/widgets/chat_app_bar.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/routing/nav_helper.dart';
 import 'package:kohera/core/routing/route_names.dart';
@@ -10,6 +11,7 @@ import 'package:kohera/features/calling/models/incoming_call_info.dart'
     as model;
 import 'package:kohera/features/calling/services/call_navigator.dart';
 import 'package:kohera/features/calling/services/call_service.dart';
+import 'package:kohera/features/chat/services/chat_search_controller.dart';
 import 'package:kohera/features/chat/widgets/pinned_messages_popup.dart';
 import 'package:kohera/features/home/screens/home_shell.dart';
 import 'package:kohera/shared/models/kohera_room_summary.dart';
@@ -379,6 +381,8 @@ class ChatSearchAppBar extends StatelessWidget implements PreferredSizeWidget {
     required this.focusNode,
     required this.onChanged,
     required this.onClose,
+    required this.search,
+    required this.onSelectResult,
     super.key,
   });
 
@@ -386,6 +390,8 @@ class ChatSearchAppBar extends StatelessWidget implements PreferredSizeWidget {
   final FocusNode focusNode;
   final ValueChanged<String> onChanged;
   final VoidCallback onClose;
+  final ChatSearchController search;
+  final ValueChanged<String> onSelectResult;
 
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
@@ -395,36 +401,61 @@ class ChatSearchAppBar extends StatelessWidget implements PreferredSizeWidget {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
 
-    return AppBar(
-      leading: IconButton(
-        icon: const Icon(Icons.arrow_back_rounded),
-        onPressed: onClose,
-      ),
-      titleSpacing: 0,
-      title: TextField(
-        controller: controller,
-        focusNode: focusNode,
-        onChanged: onChanged,
-        style: tt.bodyLarge,
-        decoration: InputDecoration(
-          hintText: 'Search messages…',
-          border: InputBorder.none,
-          hintStyle: tt.bodyLarge?.copyWith(
-            color: cs.onSurfaceVariant.withValues(alpha: 0.5),
+    return Focus(
+      onKeyEvent: (node, event) {
+        if (event is! KeyDownEvent) return KeyEventResult.ignored;
+        if (event.logicalKey == LogicalKeyboardKey.escape) {
+          onClose();
+          return KeyEventResult.handled;
+        }
+        if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+          search.navigateDown();
+          return KeyEventResult.handled;
+        }
+        if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+          search.navigateUp();
+          return KeyEventResult.handled;
+        }
+        if (event.logicalKey == LogicalKeyboardKey.enter) {
+          final idx = search.selectedIndex;
+          if (idx >= 0 && idx < search.results.length) {
+            onSelectResult(search.results[idx].message.eventId);
+          }
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_rounded),
+          onPressed: onClose,
+        ),
+        titleSpacing: 0,
+        title: TextField(
+          controller: controller,
+          focusNode: focusNode,
+          onChanged: onChanged,
+          style: tt.bodyLarge,
+          decoration: InputDecoration(
+            hintText: 'Search messages…',
+            border: InputBorder.none,
+            hintStyle: tt.bodyLarge?.copyWith(
+              color: cs.onSurfaceVariant.withValues(alpha: 0.5),
+            ),
           ),
         ),
+        actions: [
+          if (controller.text.isNotEmpty)
+            IconButton(
+              icon: const Icon(Icons.close_rounded),
+              onPressed: () {
+                controller.clear();
+                onChanged('');
+                focusNode.requestFocus();
+              },
+            ),
+        ],
       ),
-      actions: [
-        if (controller.text.isNotEmpty)
-          IconButton(
-            icon: const Icon(Icons.close_rounded),
-            onPressed: () {
-              controller.clear();
-              onChanged('');
-              focusNode.requestFocus();
-            },
-          ),
-      ],
     );
   }
 }

--- a/lib/features/chat/widgets/search_result_tile.dart
+++ b/lib/features/chat/widgets/search_result_tile.dart
@@ -18,6 +18,7 @@ class SearchResultTile extends StatelessWidget {
     required this.query,
     required this.onTap,
     this.highlights,
+    this.isSelected = false,
     super.key,
   });
 
@@ -26,6 +27,7 @@ class SearchResultTile extends StatelessWidget {
   final String query;
   final List<String>? highlights;
   final VoidCallback onTap;
+  final bool isSelected;
 
   @override
   Widget build(BuildContext context) {
@@ -36,9 +38,13 @@ class SearchResultTile extends StatelessWidget {
     final before = result.contextBefore.take(_maxContextLines).toList();
     final after = result.contextAfter.take(_maxContextLines).toList();
 
-    return InkWell(
-      onTap: onTap,
-      child: Padding(
+    return ColoredBox(
+      color: isSelected
+          ? cs.primaryContainer.withValues(alpha: 0.3)
+          : cs.surface,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -116,6 +122,7 @@ class SearchResultTile extends StatelessWidget {
             for (final ctx in after) _ContextLine(message: ctx),
           ],
         ),
+      ),
       ),
     );
   }

--- a/lib/features/chat/widgets/search_results_body.dart
+++ b/lib/features/chat/widgets/search_results_body.dart
@@ -65,11 +65,11 @@ class _SearchResultsBodyState extends State<SearchResultsBody> {
         }
         flatIndex++;
       }
-      unawaited(_scrollController.animateTo(
+      _scrollController.animateTo(
         flatIndex * 72.0, // approximate tile height
         duration: const Duration(milliseconds: 100),
         curve: Curves.easeInOut,
-      ));
+      );
     }
     setState(() {});
   }

--- a/lib/features/chat/widgets/search_results_body.dart
+++ b/lib/features/chat/widgets/search_results_body.dart
@@ -38,13 +38,40 @@ class _SearchResultsBodyState extends State<SearchResultsBody> {
   void initState() {
     super.initState();
     _scrollController = ScrollController()..addListener(_onScroll);
+    widget.search.addListener(_onSearchChanged);
   }
 
   @override
   void dispose() {
+    widget.search.removeListener(_onSearchChanged);
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
     super.dispose();
+  }
+
+  void _onSearchChanged() {
+    if (!mounted) return;
+    // Auto-scroll to keep the selected result visible.
+    final idx = widget.search.selectedIndex;
+    if (idx >= 0 && idx < widget.search.results.length && _scrollController.hasClients) {
+      final items = _buildItems(widget.search.results);
+      // Find the flat-list index for this result.
+      var flatIndex = 0;
+      var resultIdx = 0;
+      for (final item in items) {
+        if (!item.isSeparator) {
+          if (resultIdx == idx) break;
+          resultIdx++;
+        }
+        flatIndex++;
+      }
+      unawaited(_scrollController.animateTo(
+        flatIndex * 72.0, // approximate tile height
+        duration: const Duration(milliseconds: 100),
+        curve: Curves.easeInOut,
+      ));
+    }
+    setState(() {});
   }
 
   void _onScroll() {
@@ -240,11 +267,17 @@ class _SearchResultsBodyState extends State<SearchResultsBody> {
               }
 
               final result = item.result!;
+              // Compute the result-only index for selection matching.
+              var resultIndex = 0;
+              for (var j = 0; j < i; j++) {
+                if (!items[j].isSeparator) resultIndex++;
+              }
               return SearchResultTile(
                 result: result,
                 avatarResolver: widget.avatarResolver,
                 query: query,
                 highlights: widget.search.highlights,
+                isSelected: resultIndex == widget.search.selectedIndex,
                 onTap: () => widget.onTapResult(result.message.eventId),
               );
             },

--- a/test/screens/chat_search_test.dart
+++ b/test/screens/chat_search_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/preferences_service.dart';
@@ -355,6 +356,73 @@ void main() {
       // Two results on different days produce two separators.
       final dividers = find.byType(Divider);
       expect(dividers, findsWidgets);
+    });
+
+    testWidgets('Escape key closes search', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      // Open search.
+      await tester.tap(find.byIcon(Icons.search_rounded));
+      await tester.pumpAndSettle();
+
+      // Focus the search field and press Escape.
+      await tester.showKeyboard(find.byType(TextField).last);
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+
+      // Room name should be back (search closed).
+      expect(find.text('Test Room'), findsOneWidget);
+    });
+
+    testWidgets('ArrowDown selects first result', (tester) async {
+      when(mockClient.search(
+        any,
+        nextBatch: anyNamed('nextBatch'),
+      )).thenAnswer((_) async => SearchResults(
+            searchCategories: ResultCategories(
+              roomEvents: ResultRoomEvents(
+                results: [
+                  Result(
+                    result: MatrixEvent(
+                      type: 'm.room.message',
+                      content: {'body': 'hello world', 'msgtype': 'm.text'},
+                      eventId: r'$1:example.com',
+                      senderId: '@alice:example.com',
+                      originServerTs: DateTime(2024, 1, 1, 12),
+                      roomId: '!room:example.com',
+                    ),
+                    rank: 0.1,
+                    context: SearchResultsEventContext(),
+                  ),
+                ],
+                count: 1,
+              ),
+            ),
+          ));
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.search_rounded));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).last, 'hello');
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pumpAndSettle();
+
+      // Press ArrowDown to select first result.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+
+      // The result should be visually highlighted (ColoredBox with
+      // primaryContainer tint).
+      final coloredBoxes = tester.widgetList<ColoredBox>(
+        find.byType(ColoredBox),
+      );
+      expect(coloredBoxes, isNotEmpty);
     });
   });
 }


### PR DESCRIPTION
## Summary

Add keyboard navigation for search results: arrow keys to navigate, Enter to jump to message, Escape to close search.

## Changes

- **`ChatSearchController`**: Add `selectedIndex` state, `navigateDown()`, `navigateUp()` methods. Reset to -1 on new search, close, and query change.
- **`ChatSearchAppBar`**: Wrap in `Focus` widget with `onKeyEvent` handler:
  - `Escape` → `onClose()`
  - `ArrowDown` → `search.navigateDown()`
  - `ArrowUp` → `search.navigateUp()`
  - `Enter` → `onSelectResult(results[selectedIndex].message.eventId)`
  - Add `search` and `onSelectResult` parameters
- **`chat_screen.dart`**: Wire `search: _search` and `onSelectResult: _scrollToEventById` into `ChatSearchAppBar`
- **`SearchResultTile`**: Add `isSelected` parameter — renders with `primaryContainer` tinted background when selected
- **`SearchResultsBody`**: Listen to search controller, auto-scroll to keep selected item visible, pass `isSelected` to `SearchResultTile` based on `search.selectedIndex`
- **Tests**: 
  - Escape key closes search and restores app bar
  - ArrowDown selects first result (visual highlight appears)

## Verification

- `flutter analyze` — no new issues (all 16 are pre-existing info-level)
- `flutter test test/screens/chat_search_test.dart` — 12/12 pass
- `flutter test test/widgets/search_result_tile_test.dart` — 16/16 pass
- `flutter test test/utils/time_format_test.dart` — 10/10 pass
- `flutter test test/utils/text_highlight_test.dart` — all pass

Closes #905
Refs #895