### PR TITLE
feat(search): side panel on wide screens for search results (#906)

### DIFF
--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -1114,21 +1114,58 @@ class _ChatScreenState extends State<ChatScreen>
       );
     }
 
+    final isNarrow =
+        MediaQuery.sizeOf(context).width < HomeShell.wideBreakpoint;
+
+    if (isNarrow) {
+      // Narrow screens: full-screen overlay (existing behavior).
+      return Scaffold(
+        appBar: appBar,
+        body: Stack(
+          fit: StackFit.expand,
+          children: [
+            _buildChatBody(matrix, room.id),
+            if (_search.isSearching)
+              ColoredBox(
+                color: Theme.of(context).colorScheme.surface,
+                child: SearchResultsBody(
+                  search: _search,
+                  avatarResolver: matrix.avatarResolver,
+                  onTapResult: _scrollToEventById,
+                ),
+              ),
+          ],
+        ),
+      );
+    }
+
+    // Wide screens: side panel preserves chat context.
+    final cs = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: appBar,
-      body: Stack(
-        fit: StackFit.expand,
+      body: Row(
         children: [
-          _buildChatBody(matrix, room.id),
-          if (_search.isSearching)
-            ColoredBox(
-              color: Theme.of(context).colorScheme.surface,
-              child: SearchResultsBody(
-                search: _search,
-                avatarResolver: matrix.avatarResolver,
-                onTapResult: _scrollToEventById,
-              ),
-            ),
+          Expanded(child: _buildChatBody(matrix, room.id)),
+          AnimatedSize(
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeInOut,
+            child: _search.isSearching
+                ? Container(
+                    width: 380,
+                    decoration: BoxDecoration(
+                      color: cs.surface,
+                      border: Border(
+                        left: BorderSide(color: cs.outlineVariant),
+                      ),
+                    ),
+                    child: SearchResultsBody(
+                      search: _search,
+                      avatarResolver: matrix.avatarResolver,
+                      onTapResult: _scrollToEventById,
+                    ),
+                  )
+                : const SizedBox.shrink(),
+          ),
         ],
       ),
     );

--- a/test/screens/chat_search_test.dart
+++ b/test/screens/chat_search_test.dart
@@ -33,6 +33,17 @@ void main() {
   late SelectionService selectionService;
 
   setUp(() {
+    // Use a narrow screen so the search overlay (Stack) layout is used,
+    // matching the test expectations. The default 800px width would
+    // trigger the side panel layout on wide screens.
+    final binding = TestWidgetsFlutterBinding.ensureInitialized();
+    binding.platformDispatcher.views.first.physicalSize =
+        const Size(600, 1200);
+    binding.platformDispatcher.views.first.devicePixelRatio = 1.0;
+    addTearDown(() {
+      binding.platformDispatcher.views.first.resetPhysicalSize();
+    });
+
     mockClient = MockClient();
     mockMatrix = MockMatrixService();
     mockRoom = MockRoom();
@@ -423,6 +434,65 @@ void main() {
         find.byType(ColoredBox),
       );
       expect(coloredBoxes, isNotEmpty);
+    });
+
+    testWidgets('wide screen shows side panel instead of full overlay',
+        (tester) async {
+      // Override the narrow screen set in setUp with a wide screen.
+      final binding = TestWidgetsFlutterBinding.ensureInitialized();
+      binding.platformDispatcher.views.first.physicalSize =
+          const Size(1200, 1000);
+      binding.platformDispatcher.views.first.devicePixelRatio = 1.0;
+
+      when(mockClient.search(
+        any,
+        nextBatch: anyNamed('nextBatch'),
+      )).thenAnswer((_) async => SearchResults(
+            searchCategories: ResultCategories(
+              roomEvents: ResultRoomEvents(
+                results: [
+                  Result(
+                    result: MatrixEvent(
+                      type: 'm.room.message',
+                      content: {'body': 'hello world', 'msgtype': 'm.text'},
+                      eventId: r'$1:example.com',
+                      senderId: '@alice:example.com',
+                      originServerTs: DateTime(2024, 1, 1, 12),
+                      roomId: '!room:example.com',
+                    ),
+                    rank: 0.1,
+                    context: SearchResultsEventContext(),
+                  ),
+                ],
+                count: 1,
+              ),
+            ),
+          ));
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      // Open search.
+      await tester.tap(find.byIcon(Icons.search_rounded));
+      await tester.pumpAndSettle();
+
+      // On wide screens, the search body should appear in a side panel
+      // (not a full-screen overlay). Verify a Row layout is present.
+      expect(find.byType(Row), findsWidgets);
+
+      // The search field should be present in the app bar.
+      expect(find.byType(TextField), findsWidgets);
+
+      // Type and search.
+      await tester.enterText(find.byType(TextField).last, 'hello');
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pumpAndSettle();
+
+      // Result count should be visible in the side panel.
+      expect(find.textContaining('Found 1 results'), findsOneWidget);
+
+      // Reset screen size for subsequent tests.
+      binding.platformDispatcher.views.first.resetPhysicalSize();
     });
   });
 }


### PR DESCRIPTION
## Summary

Show search results in a 380px side panel on wide screens instead of a full-screen overlay, preserving chat context on desktop.

## Changes

- **`chat_screen.dart`**: Check `isNarrow` via `HomeShell.wideBreakpoint` (720px):
  - **Narrow screens** (< 720px): Keep existing `Stack` overlay (full-screen search)
  - **Wide screens** (≥ 720px): Use `Row` with `Expanded` chat body + 380px side panel with left border (`cs.outlineVariant`) and surface background
  - `AnimatedSize` for smooth panel slide-in/out transition (200ms easeInOut)
- **Tests**: 
  - Set narrow screen (600px) in `setUp` for existing overlay tests
  - Add wide screen (1200px) test verifying side panel layout with `Row`, search results, and count header

## Verification

- `flutter analyze` — no new issues (all 17 are pre-existing info-level, CI Flutter 3.47 ignores the one local-only `discarded_futures`)
- `flutter test test/screens/chat_search_test.dart` — 13/13 pass

Closes #906
Refs #895