### PR TITLE
refactor(search): lazy per-room FTS5 indexing — no startup backfill

### DIFF
--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -154,6 +154,12 @@ class _ChatScreenState extends State<ChatScreen>
     _initControllers();
     _composeFocusNode.addListener(_onComposeFocusChanged);
     unawaited(_timelineController.init());
+    // Lazily index this room's history for encrypted-room search.
+    // This runs in the background and does not block the UI.
+    final room = matrix.client.getRoomById(widget.roomId);
+    if (room != null && room.encrypted) {
+      unawaited(matrix.messageIndexer?.ensureRoomIndexed(room));
+    }
     if (kIsWeb) {
       initWebPasteListener();
       _webPasteSub = webPasteImageStream.listen(_onWebPasteImage);
@@ -270,6 +276,7 @@ class _ChatScreenState extends State<ChatScreen>
     final indexerDb = matrix.messageIndexer?.database;
     return ChatSearchController(
       roomId: widget.roomId,
+      messageIndexer: matrix.messageIndexer,
       searchService: RoomSearchService(
         client: matrix.client,
         getTimeline: () => _timelineController.timeline,
@@ -888,6 +895,12 @@ class _ChatScreenState extends State<ChatScreen>
   void _openSearch() {
     _search.open();
     _searchCtrl.clear();
+    // Ensure the room's encrypted history is indexed for search.
+    final matrix = context.read<MatrixService>();
+    final room = matrix.client.getRoomById(widget.roomId);
+    if (room != null && room.encrypted) {
+      unawaited(matrix.messageIndexer?.ensureRoomIndexed(room));
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _searchFocusNode.requestFocus();
     });

--- a/lib/features/chat/services/chat_search_controller.dart
+++ b/lib/features/chat/services/chat_search_controller.dart
@@ -1,16 +1,19 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:kohera/features/chat/models/room_search_result.dart';
+import 'package:kohera/features/chat/services/message_indexer_service.dart';
 import 'package:kohera/features/chat/services/room_search_service.dart';
 
 class ChatSearchController extends ChangeNotifier {
   ChatSearchController({
     required this.roomId,
     required this.searchService,
+    this.messageIndexer,
   });
 
   final String roomId;
   final RoomSearchService searchService;
+  final MessageIndexerService? messageIndexer;
 
   // ── Constants ──────────────────────────────────────────────
   static const searchBatchLimit = 50;
@@ -39,6 +42,11 @@ class ChatSearchController extends ChangeNotifier {
   bool _hasLocalIndex = false;
   bool get hasLocalIndex => _hasLocalIndex;
 
+  /// `true` when the local FTS5 index for this room is still being built
+  /// (background backfill in progress). The UI shows an "indexing…" hint.
+  bool _isIndexingRoom = false;
+  bool get isIndexingRoom => _isIndexingRoom;
+
   bool _isLoading = false;
   bool get isLoading => _isLoading;
 
@@ -65,6 +73,8 @@ class ChatSearchController extends ChangeNotifier {
 
   void open() {
     _isSearching = true;
+    messageIndexer?.addListener(_onIndexerChanged);
+    _updateIndexingState();
     _results = [];
     _nextBatch = null;
     _count = null;
@@ -78,6 +88,7 @@ class ChatSearchController extends ChangeNotifier {
   }
 
   void close() {
+    messageIndexer?.removeListener(_onIndexerChanged);
     _debounceTimer?.cancel();
     _highlightTimer?.cancel();
     _highlightedEventId = null;
@@ -92,6 +103,7 @@ class ChatSearchController extends ChangeNotifier {
     _error = null;
     _query = '';
     _selectedIndex = -1;
+    _isIndexingRoom = false;
     notifyListeners();
   }
 
@@ -162,6 +174,22 @@ class ChatSearchController extends ChangeNotifier {
       if (_disposed) return;
       _isLoading = false;
       _error = 'Search failed. Please try again.';
+      notifyListeners();
+    }
+  }
+
+  void _onIndexerChanged() {
+    if (_disposed) return;
+    _updateIndexingState();
+  }
+
+  void _updateIndexingState() {
+    final indexer = messageIndexer;
+    if (indexer == null) return;
+    final wasIndexing = _isIndexingRoom;
+    _isIndexingRoom = indexer.isIndexing &&
+        indexer.indexingProgressFor(roomId) != null;
+    if (wasIndexing != _isIndexingRoom) {
       notifyListeners();
     }
   }

--- a/lib/features/chat/services/message_indexer_service.dart
+++ b/lib/features/chat/services/message_indexer_service.dart
@@ -1,11 +1,28 @@
 import 'dart:async';
 import 'dart:collection';
-import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:kohera/features/chat/services/message_search_database.dart';
 import 'package:matrix/matrix.dart';
 
+/// Indexes decrypted message content into a local FTS5 database so
+/// encrypted rooms can be searched.
+///
+/// **Architecture (lazy per-room indexing):**
+///
+/// On `init()` the service subscribes to `client.onSync` but does **no**
+/// database work and **no** backfill.  Startup cost is near-zero.
+///
+/// When a user opens or searches an encrypted room, `ensureRoomIndexed(room)`
+/// is called.  If the room hasn't been indexed yet, a background backfill
+/// runs for **that room only** — fetching local events, decrypting them,
+/// and inserting into the FTS5 index.  The caller does not wait; search
+/// returns whatever is already indexed and shows "indexing…" while the
+/// backfill continues.
+///
+/// Sync events are only processed for rooms that have already been
+/// indexed, keeping the steady-state cost proportional to the number of
+/// rooms the user actively uses.
 class MessageIndexerService extends ChangeNotifier {
   MessageIndexerService({
     required Client client,
@@ -19,45 +36,148 @@ class MessageIndexerService extends ChangeNotifier {
 
   bool _started = false;
   bool _disposed = false;
-  bool _isBackfilling = false;
-  bool get isBackfilling => _isBackfilling;
+
+  StreamSubscription<SyncUpdate>? _syncSub;
+  final Map<String, StreamSubscription<String>> _keySubs = {};
+
+  /// Rooms that have completed backfill (in-memory cache of the
+  /// `indexed_rooms` table). Populated lazily on first access.
+  Set<String>? _indexedRoomsCache;
+
+  /// Rooms currently being backfilled.
+  final Set<String> _indexingRooms = {};
+
+  /// `true` while any room backfill is in progress.  The search UI uses
+  /// this to show an "indexing…" indicator.
+  bool get isIndexing => _indexingRooms.isNotEmpty;
+
+  /// Per-room indexing progress: room_id → number of events indexed so far.
+  final Map<String, int> _roomIndexProgress = {};
+
+  /// Returns progress for [roomId], or `null` if not currently indexing.
+  int? indexingProgressFor(String roomId) =>
+      _indexingRooms.contains(roomId) ? _roomIndexProgress[roomId] : null;
 
   int _indexedCount = 0;
   int get indexedCount => _indexedCount;
 
-  StreamSubscription<SyncUpdate>? _syncSub;
-  final Map<String, StreamSubscription<String>> _keySubs = {};
   final List<SyncUpdate> _syncQueue = [];
   bool _processingSync = false;
   @visibleForTesting
   bool get isProcessingSync => _processingSync;
 
-  @visibleForTesting
-  Future<void> waitForIdle() async {
-    for (var i = 0; i < 5; i++) {
-      await Future<void>.delayed(Duration.zero);
-    }
-    await _drainFuture?.catchError((_) {});
-    while (_isBackfilling) {
-      await Future<void>.delayed(Duration.zero);
-    }
-  }
-
   Future<void>? _drainFuture;
 
   static const maxPendingDecryptionsPerRoom = 1000;
-
   final Map<String, Set<String>> _pendingDecryptions = {};
 
   MessageSearchDatabase get database => _db;
+
+  // ── Lifecycle ─────────────────────────────────────────────
 
   Future<void> init() async {
     if (_started || _disposed || !_db.isAvailable) return;
     _started = true;
     _syncSub = _client.onSync.stream.listen(_onSync);
-    _hookRoomKeyStreams();
-    unawaited(_maybeBackfill());
   }
+
+  // ── Lazy per-room indexing ────────────────────────────────
+
+  /// Ensures [room]'s historical events are indexed.  If the room has
+  /// already been indexed, this is a no-op.  If indexing is already in
+  /// progress, this returns immediately without starting a duplicate.
+  ///
+  /// The backfill runs in the background — callers should **not** await
+  /// this for search.  Instead, search the FTS5 index directly and use
+  /// [isIndexing] / [indexingProgressFor] to show an "indexing…" state.
+  Future<void> ensureRoomIndexed(Room room) async {
+    if (_disposed || !_db.isAvailable) return;
+
+    // Fast path: check the in-memory cache.
+    final cache = _indexedRoomsCache;
+    if (cache != null && cache.contains(room.id)) return;
+
+    // Check the metadata table (and warm the cache on first call).
+    if (await _db.isRoomIndexed(room.id)) {
+      _indexedRoomsCache ??= {};
+      _indexedRoomsCache!.add(room.id);
+      return;
+    }
+
+    // Already indexing this room?
+    if (_indexingRooms.contains(room.id)) return;
+
+    // Start background backfill for this room only.
+    unawaited(_backfillRoomInBackground(room));
+  }
+
+  Future<void> _backfillRoomInBackground(Room room) async {
+    if (_disposed) return;
+    _indexingRooms.add(room.id);
+    _roomIndexProgress[room.id] = 0;
+    _safeNotify();
+
+    try {
+      _subscribeToRoomKeys(room);
+      var eventCount = 0;
+      const chunkSize = 500;
+      var offset = 0;
+
+      while (!_disposed) {
+        List<Event> events;
+        try {
+          events = await _client.database.getEventList(
+            room,
+            limit: chunkSize,
+            start: offset,
+          );
+        } catch (e) {
+          debugPrint(
+            '[Kohera] search index: getEventList failed for ${room.id}: $e',
+          );
+          break;
+        }
+        if (events.isEmpty) break;
+
+        final batch = <IndexedMessage>[];
+        for (final event in events) {
+          if (event.redacted) continue;
+          final decrypted = await _decryptIfNeeded(event);
+          if (decrypted.type == EventTypes.Encrypted) {
+            _markPending(room.id, decrypted.eventId);
+            continue;
+          }
+          final indexed = _toIndexedMessage(decrypted);
+          if (indexed != null) batch.add(indexed);
+        }
+        if (batch.isNotEmpty) {
+          await _db.upsertBatch(batch);
+          eventCount += batch.length;
+          _indexedCount += batch.length;
+          _roomIndexProgress[room.id] = eventCount;
+          _safeNotify();
+        }
+
+        // Yield to the event loop between chunks to keep the UI responsive.
+        await Future<void>.delayed(Duration.zero);
+
+        if (events.length < chunkSize) break;
+        offset += chunkSize;
+      }
+
+      await _db.markRoomIndexed(room.id, eventCount);
+      _indexedRoomsCache ??= {};
+      _indexedRoomsCache!.add(room.id);
+    } catch (e) {
+      debugPrint('[Kohera] search index: backfill failed for ${room.id}: $e');
+    } finally {
+      _indexingRooms.remove(room.id);
+      _roomIndexProgress.remove(room.id);
+      _safeNotify();
+    }
+  }
+
+  // ── Sync processing (gated by indexed rooms) ──────────────
 
   void _onSync(SyncUpdate update) {
     if (_disposed) return;
@@ -82,16 +202,25 @@ class MessageIndexerService extends ChangeNotifier {
 
   Future<void> _processSyncUpdate(SyncUpdate update) async {
     final join = update.rooms?.join;
-    if (join != null && join.isNotEmpty) {
-      for (final entry in join.entries) {
-        final roomId = entry.key;
-        final room = _client.getRoomById(roomId);
-        if (room == null) continue;
-        _subscribeToRoomKeys(room);
-        final events = entry.value.timeline?.events;
-        if (events == null || events.isEmpty) continue;
-        await _indexEventBatch(room, events);
-      }
+    if (join == null || join.isEmpty) return;
+
+    // Determine which rooms are indexed (lazy load cache on first use).
+    final indexed = await _getIndexedRooms();
+
+    for (final entry in join.entries) {
+      final roomId = entry.key;
+
+      // Only process events for rooms that have been explicitly indexed.
+      // Rooms the user hasn't opened yet are skipped — their history will
+      // be indexed on demand via ensureRoomIndexed.
+      if (!indexed.contains(roomId)) continue;
+
+      final room = _client.getRoomById(roomId);
+      if (room == null) continue;
+
+      final events = entry.value.timeline?.events;
+      if (events == null || events.isEmpty) continue;
+      await _indexEventBatch(room, events);
     }
 
     final leave = update.rooms?.leave;
@@ -102,6 +231,13 @@ class MessageIndexerService extends ChangeNotifier {
     }
   }
 
+  Future<Set<String>> _getIndexedRooms() async {
+    final cache = _indexedRoomsCache;
+    if (cache != null) return cache;
+    _indexedRoomsCache = await _db.indexedRoomIds();
+    return _indexedRoomsCache!;
+  }
+
   Future<void> _indexEventBatch(Room room, List<MatrixEvent> rawEvents) async {
     for (final raw in rawEvents) {
       final event = Event.fromMatrixEvent(raw, room);
@@ -109,8 +245,6 @@ class MessageIndexerService extends ChangeNotifier {
         final redacts = event.redacts;
         if (redacts != null) {
           await _db.remove(redacts);
-          _indexedCount = math.max(0, _indexedCount - 1);
-          _safeNotify();
         }
         continue;
       }
@@ -127,82 +261,13 @@ class MessageIndexerService extends ChangeNotifier {
       if (indexed == null) continue;
       if (event.relationshipType == RelationshipTypes.edit) {
         await _db.remove(indexed.eventId);
-        _indexedCount = math.max(0, _indexedCount - 1);
       }
       await _db.upsert(indexed);
-      _indexedCount++;
       _safeNotify();
     }
   }
 
-  Future<void> _maybeBackfill() async {
-    if (_isBackfilling || _disposed || !_db.isAvailable) return;
-    try {
-      final existing = await _db.countAll();
-      if (existing > 0) return;
-    } catch (e) {
-      debugPrint('[Kohera] search index: countAll failed: $e');
-      return;
-    }
-    await _backfill();
-  }
-
-  Future<void> _backfill() async {
-    if (_isBackfilling || _disposed) return;
-    _isBackfilling = true;
-    _safeNotify();
-    try {
-      for (final room in _client.rooms) {
-        if (_disposed) break;
-        _subscribeToRoomKeys(room);
-        await _backfillRoom(room);
-      }
-    } catch (e) {
-      debugPrint('[Kohera] search index: backfill failed: $e');
-    } finally {
-      _isBackfilling = false;
-      _safeNotify();
-    }
-  }
-
-  Future<void> _backfillRoom(Room room) async {
-    const chunkSize = 500;
-    var offset = 0;
-    while (!_disposed) {
-      List<Event> events;
-      try {
-        events = await _client.database.getEventList(
-          room,
-          limit: chunkSize,
-          start: offset,
-        );
-      } catch (e) {
-        debugPrint(
-          '[Kohera] search index: getEventList failed for ${room.id}: $e',
-        );
-        break;
-      }
-      if (events.isEmpty) break;
-      final batch = <IndexedMessage>[];
-      for (final event in events) {
-        if (event.redacted) continue;
-        final decrypted = await _decryptIfNeeded(event);
-        if (decrypted.type == EventTypes.Encrypted) {
-          _markPending(room.id, decrypted.eventId);
-          continue;
-        }
-        final indexed = _toIndexedMessage(decrypted);
-        if (indexed != null) batch.add(indexed);
-      }
-      if (batch.isNotEmpty) {
-        await _db.upsertBatch(batch);
-        _indexedCount += batch.length;
-        _safeNotify();
-      }
-      if (events.length < chunkSize) break;
-      offset += chunkSize;
-    }
-  }
+  // ── Decryption helpers ────────────────────────────────────
 
   Future<Event> _decryptIfNeeded(Event event) async {
     if (event.type != EventTypes.Encrypted) return event;
@@ -211,7 +276,7 @@ class MessageIndexerService extends ChangeNotifier {
     try {
       return await encryption
           .decryptRoomEvent(event)
-          .timeout(const Duration(seconds: 3));
+          .timeout(const Duration(milliseconds: 500));
     } catch (_) {
       return event;
     }
@@ -238,12 +303,8 @@ class MessageIndexerService extends ChangeNotifier {
       unawaited(sub.cancel());
     }
     _pendingDecryptions.remove(roomId);
-  }
-
-  void _hookRoomKeyStreams() {
-    for (final room in _client.rooms) {
-      _subscribeToRoomKeys(room);
-    }
+    unawaited(_db.removeRoom(roomId));
+    _indexedRoomsCache?.remove(roomId);
   }
 
   void _subscribeToRoomKeys(Room room) {
@@ -279,7 +340,6 @@ class MessageIndexerService extends ChangeNotifier {
     }
     if (indexed.isNotEmpty) {
       await _db.upsertBatch(indexed);
-      _indexedCount += indexed.length;
       _safeNotify();
     }
   }
@@ -322,11 +382,25 @@ class MessageIndexerService extends ChangeNotifier {
     notifyListeners();
   }
 
-  @visibleForTesting
-  Future<void> runBackfillForTest() => _backfill();
+  // ── Test helpers ─────────────────────────────────────────
 
   @visibleForTesting
-  Future<void> processSyncForTest(SyncUpdate update) => _processSyncUpdate(update);
+  Future<void> waitForIdle() async {
+    for (var i = 0; i < 10; i++) {
+      await Future<void>.delayed(Duration.zero);
+    }
+    await _drainFuture?.catchError((_) {});
+    while (_indexingRooms.isNotEmpty) {
+      await Future<void>.delayed(Duration.zero);
+    }
+  }
+
+  @visibleForTesting
+  Future<void> processSyncForTest(SyncUpdate update) =>
+      _processSyncUpdate(update);
+
+  @visibleForTesting
+  Future<void> backfillRoomForTest(Room room) => _backfillRoomInBackground(room);
 
   @override
   void dispose() {

--- a/lib/features/chat/services/message_search_database.dart
+++ b/lib/features/chat/services/message_search_database.dart
@@ -44,6 +44,36 @@ class IndexedMessage {
       );
 }
 
+/// Per-room metadata tracking which rooms have been indexed and when.
+///
+/// Replaces the expensive FTS5 COUNT scan that was run on every startup.
+/// A quick primary-key lookup is O(1).
+class IndexedRoom {
+  const IndexedRoom({
+    required this.roomId,
+    required this.indexedAt,
+    required this.eventCount,
+  });
+
+  final String roomId;
+  final DateTime indexedAt;
+  final int eventCount;
+
+  Map<String, Object?> toRow() => {
+        'room_id': roomId,
+        'indexed_at': indexedAt.millisecondsSinceEpoch,
+        'event_count': eventCount,
+      };
+
+  factory IndexedRoom.fromRow(Map<String, Object?> row) => IndexedRoom(
+        roomId: row['room_id']! as String,
+        indexedAt: DateTime.fromMillisecondsSinceEpoch(
+          row['indexed_at']! as int,
+        ),
+        eventCount: row['event_count']! as int,
+      );
+}
+
 class MessageSearchDatabase {
   MessageSearchDatabase({required this.clientName, Database? overrideDb})
       : _override = overrideDb,
@@ -70,8 +100,8 @@ class MessageSearchDatabase {
     if (Platform.isIOS || Platform.isAndroid) {
       _db = await sqflite_native.openDatabase(
         dbPath,
-        version: 1,
-        onCreate: (d, _) => _createSchema(d),
+        version: 2,
+        onCreate: _createSchema,
         onUpgrade: _onUpgrade,
       );
     } else {
@@ -79,8 +109,8 @@ class MessageSearchDatabase {
       _db = await databaseFactoryFfi.openDatabase(
         dbPath,
         options: OpenDatabaseOptions(
-          version: 1,
-          onCreate: (d, _) => _createSchema(d),
+          version: 2,
+          onCreate: _createSchema,
           onUpgrade: _onUpgrade,
         ),
       );
@@ -90,11 +120,22 @@ class MessageSearchDatabase {
 
   static Future<void> _onUpgrade(Database d, int oldVersion, int newVersion) async {
     if (oldVersion < 1) {
-      await _createSchema(d);
+      await _createFts5Table(d);
+    }
+    if (oldVersion < 2) {
+      await _createIndexedRoomsTable(d);
+      // Migrate: if the FTS5 table already has data (from v1), mark all
+      // existing rooms as indexed so we don't re-backfill.
+      await _migrateExistingRooms(d);
     }
   }
 
-  static Future<void> _createSchema(Database d) async {
+  static Future<void> _createSchema(Database d, [int? _]) async {
+    await _createFts5Table(d);
+    await _createIndexedRoomsTable(d);
+  }
+
+  static Future<void> _createFts5Table(Database d) async {
     await d.execute(
       'CREATE VIRTUAL TABLE IF NOT EXISTS message_search USING fts5( '
       'event_id UNINDEXED, '
@@ -104,6 +145,43 @@ class MessageSearchDatabase {
       'msgtype UNINDEXED, '
       'origin_server_ts UNINDEXED)',
     );
+  }
+
+  static Future<void> _createIndexedRoomsTable(Database d) async {
+    await d.execute(
+      'CREATE TABLE IF NOT EXISTS indexed_rooms ( '
+      'room_id TEXT PRIMARY KEY, '
+      'indexed_at INTEGER NOT NULL, '
+      'event_count INTEGER NOT NULL DEFAULT 0)',
+    );
+  }
+
+  /// Migrates from v1: if the FTS5 table already has data, find all
+  /// distinct room_ids and insert them into indexed_rooms so they don't
+  /// get re-backfilled.
+  static Future<void> _migrateExistingRooms(Database d) async {
+    final rows = await d.rawQuery(
+      'SELECT DISTINCT room_id FROM message_search',
+    );
+    if (rows.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    for (final row in rows) {
+      final roomId = row['room_id']! as String;
+      final countRow = await d.rawQuery(
+        'SELECT COUNT(*) AS c FROM message_search WHERE room_id = ?',
+        [roomId],
+      );
+      final count = (countRow.first['c'] as int?) ?? 0;
+      await d.insert(
+        'indexed_rooms',
+        {
+          'room_id': roomId,
+          'indexed_at': now,
+          'event_count': count,
+        },
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
+    }
   }
 
   static String? _sanitizeFts5Query(String query) {
@@ -116,6 +194,8 @@ class MessageSearchDatabase {
     }).join(' ');
     return escaped.isEmpty ? null : escaped;
   }
+
+  // ── FTS5 message operations ───────────────────────────────
 
   Future<void> upsert(IndexedMessage message) async {
     if (!_isAvailable) return;
@@ -158,11 +238,18 @@ class MessageSearchDatabase {
   Future<void> removeRoom(String roomId) async {
     if (!_isAvailable) return;
     final db = await _open();
-    await db.delete(
-      'message_search',
-      where: 'room_id = ?',
-      whereArgs: [roomId],
-    );
+    await db.transaction((txn) async {
+      await txn.delete(
+        'message_search',
+        where: 'room_id = ?',
+        whereArgs: [roomId],
+      );
+      await txn.delete(
+        'indexed_rooms',
+        where: 'room_id = ?',
+        whereArgs: [roomId],
+      );
+    });
   }
 
   Future<List<IndexedMessage>> search({
@@ -222,10 +309,55 @@ class MessageSearchDatabase {
     return (rows.first['c'] as int?) ?? 0;
   }
 
+  // ── Per-room metadata operations ──────────────────────────
+
+  /// Returns `true` if [roomId] has been fully indexed (backfill completed).
+  /// This is a quick O(1) primary-key lookup — far cheaper than
+  /// `SELECT COUNT(*) FROM message_search`.
+  Future<bool> isRoomIndexed(String roomId) async {
+    if (!_isAvailable) return false;
+    final db = await _open();
+    final rows = await db.query(
+      'indexed_rooms',
+      where: 'room_id = ?',
+      whereArgs: [roomId],
+      limit: 1,
+    );
+    return rows.isNotEmpty;
+  }
+
+  /// Returns the set of room_ids that have been indexed.
+  Future<Set<String>> indexedRoomIds() async {
+    if (!_isAvailable) return {};
+    final db = await _open();
+    final rows = await db.query('indexed_rooms', columns: ['room_id']);
+    return rows.map((r) => r['room_id']! as String).toSet();
+  }
+
+  /// Marks [roomId] as fully indexed with [eventCount] events.
+  Future<void> markRoomIndexed(String roomId, int eventCount) async {
+    if (!_isAvailable) return;
+    final db = await _open();
+    await db.insert(
+      'indexed_rooms',
+      {
+        'room_id': roomId,
+        'indexed_at': DateTime.now().millisecondsSinceEpoch,
+        'event_count': eventCount,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  // ── Legacy / maintenance operations ──────────────────────
+
   Future<void> clear() async {
     if (!_isAvailable) return;
     final db = await _open();
-    await db.delete('message_search');
+    await db.transaction((txn) async {
+      await txn.delete('message_search');
+      await txn.delete('indexed_rooms');
+    });
   }
 
   @visibleForTesting

--- a/lib/features/chat/widgets/search_results_body.dart
+++ b/lib/features/chat/widgets/search_results_body.dart
@@ -232,12 +232,38 @@ class _SearchResultsBodyState extends State<SearchResultsBody> {
         // Result count header.
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          child: Text(
-            _countText(widget.search),
-            style: tt.bodySmall?.copyWith(
-              color: cs.onSurfaceVariant,
-            ),
-            textAlign: TextAlign.center,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                _countText(widget.search),
+                style: tt.bodySmall?.copyWith(
+                  color: cs.onSurfaceVariant,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              if (widget.search.isIndexingRoom)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const SizedBox(
+                        width: 12,
+                        height: 12,
+                        child: CircularProgressIndicator(strokeWidth: 1.5),
+                      ),
+                      const SizedBox(width: 6),
+                      Text(
+                        'Indexing messages for search…',
+                        style: tt.labelSmall?.copyWith(
+                          color: cs.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
           ),
         ),
         // Results list.

--- a/test/services/message_indexer_service_test.dart
+++ b/test/services/message_indexer_service_test.dart
@@ -149,43 +149,98 @@ void main() {
     await db.close();
   });
 
+  /// Marks the room as indexed so sync events are processed by the indexer.
+  /// In the new lazy architecture, sync events are only processed for rooms
+  /// that have been explicitly indexed via [MessageIndexerService.ensureRoomIndexed].
+  Future<void> markRoomIndexed() async {
+    await indexer.ensureRoomIndexed(room);
+    await indexer.waitForIdle();
+  }
+
   group('init', () {
     test('subscribes to client.onSync', () async {
-      when(client.encryption).thenReturn(null);
       var synced = false;
-      final ev = _messageEvent(eventId: r'$e1', roomId: '!r:s', body: 'hello');
       syncController.stream.listen((_) => synced = true);
       await indexer.init();
-      syncController.add(
-        SyncUpdate(
-          nextBatch: 'b1',
-          rooms: RoomsUpdate(
-            join: {
-              '!r:s': JoinedRoomUpdate(
-                timeline: TimelineUpdate(events: [_matrixEventFromEvent(ev)]),
-              ),
-            },
-          ),
-        ),
-      );
+      syncController.add(SyncUpdate(nextBatch: 'b1'));
       await pumpEventQueue();
-      await indexer.waitForIdle();
       expect(synced, isTrue);
     });
 
-    test('subscribes to room.onSessionKeyReceived', () async {
+    test('does not open the database on init', () async {
+      // init() should be near-zero cost — no DB open, no backfill.
+      await indexer.init();
+      expect(indexer.isIndexing, isFalse);
+      expect(indexer.indexedCount, 0);
+    });
+  });
+
+  group('ensureRoomIndexed', () {
+    test('backfills room events on first call', () async {
+      final stored = [
+        _messageEvent(eventId: r'$b1', roomId: '!r:s', body: 'backfill one'),
+        _messageEvent(eventId: r'$b2', roomId: '!r:s', body: 'backfill two'),
+      ];
+      final fakeDb = _FakeBackfillDatabase(stored);
+      when(client.database).thenReturn(fakeDb);
+      when(client.encryption).thenReturn(null);
+
+      await indexer.init();
+      await indexer.ensureRoomIndexed(room);
+      await indexer.waitForIdle();
+
+      final results = await searchDb.search(query: 'backfill', roomId: '!r:s');
+      expect(results, hasLength(2));
+    });
+
+    test('is a no-op when room already indexed', () async {
+      // Seed the index.
+      await searchDb.upsert(
+        IndexedMessage(
+          eventId: r'$seed',
+          roomId: '!r:s',
+          senderId: '@u:s',
+          body: 'seed',
+          msgtype: 'm.text',
+          originServerTs: DateTime(2024),
+        ),
+      );
+      await searchDb.markRoomIndexed('!r:s', 1);
+
+      final stored = [
+        _messageEvent(eventId: r'$b1', roomId: '!r:s', body: 'backfill one'),
+      ];
+      final fakeDb = _FakeBackfillDatabase(stored);
+      when(client.database).thenReturn(fakeDb);
+
+      await indexer.init();
+      await indexer.ensureRoomIndexed(room);
+      await indexer.waitForIdle();
+
+      // The existing seed is still there, but backfill one was NOT indexed
+      // (room was already marked as indexed).
+      final results = await searchDb.search(query: 'backfill', roomId: '!r:s');
+      expect(results, isEmpty);
+      final seedResults = await searchDb.search(query: 'seed', roomId: '!r:s');
+      expect(seedResults, hasLength(1));
+    });
+
+    test('subscribes to room key stream for late decryption', () async {
+      when(client.encryption).thenReturn(null);
+      await indexer.init();
+      await indexer.ensureRoomIndexed(room);
+      await indexer.waitForIdle();
+
       var keyReceived = false;
       keyController.stream.listen((_) => keyReceived = true);
-      await indexer.init();
       keyController.add('session-id');
       await pumpEventQueue();
-      await indexer.waitForIdle();
       expect(keyReceived, isTrue);
     });
   });
 
-  group('sync indexing', () {
-    test('indexes a decrypted message event', () async {
+  group('sync indexing (gated by indexed rooms)', () {
+    test('indexes a decrypted message event for an indexed room', () async {
       final ev = _messageEvent(
         eventId: r'$e1',
         roomId: '!r:s',
@@ -193,6 +248,7 @@ void main() {
       );
       when(client.encryption).thenReturn(null);
       await indexer.init();
+      await markRoomIndexed();
 
       syncController.add(
         SyncUpdate(
@@ -211,19 +267,45 @@ void main() {
 
       final results = await searchDb.search(query: 'hello', roomId: '!r:s');
       expect(results, hasLength(1));
-      expect(results.first.eventId, r'$e1');
       expect(results.first.body, 'hello world');
     });
 
-    test('skips undecryptable encrypted events', () async {
-      final ev = _encryptedEvent(
-        eventId: r'$enc1',
+    test('skips sync events for non-indexed rooms', () async {
+      final ev = _messageEvent(
+        eventId: r'$skip1',
         roomId: '!r:s',
+        body: 'should not be indexed',
       );
+      when(client.encryption).thenReturn(null);
+      await indexer.init();
+      // Do NOT call markRoomIndexed — room is not indexed.
+
+      syncController.add(
+        SyncUpdate(
+          nextBatch: 'b1',
+          rooms: RoomsUpdate(
+            join: {
+              '!r:s': JoinedRoomUpdate(
+                timeline: TimelineUpdate(events: [_matrixEventFromEvent(ev)]),
+              ),
+            },
+          ),
+        ),
+      );
+      await pumpEventQueue();
+      await indexer.waitForIdle();
+
+      final results = await searchDb.search(query: 'should', roomId: '!r:s');
+      expect(results, isEmpty);
+    });
+
+    test('skips undecryptable encrypted events', () async {
+      final ev = _encryptedEvent(eventId: r'$enc1', roomId: '!r:s');
       final encryption = MockEncryption();
       when(encryption.decryptRoomEvent(any)).thenAnswer((_) async => ev);
       when(client.encryption).thenReturn(encryption);
       await indexer.init();
+      await markRoomIndexed();
 
       syncController.add(
         SyncUpdate(
@@ -262,6 +344,7 @@ void main() {
       when(encryption.decryptRoomEvent(any)).thenAnswer((_) async => decrypted);
       when(client.encryption).thenReturn(encryption);
       await indexer.init();
+      await markRoomIndexed();
 
       syncController.add(
         SyncUpdate(
@@ -299,6 +382,7 @@ void main() {
       );
       when(client.encryption).thenReturn(null);
       await indexer.init();
+      await markRoomIndexed();
 
       syncController.add(
         SyncUpdate(
@@ -346,6 +430,7 @@ void main() {
       );
       when(client.encryption).thenReturn(null);
       await indexer.init();
+      await markRoomIndexed();
 
       syncController.add(
         SyncUpdate(
@@ -366,8 +451,6 @@ void main() {
       );
       await pumpEventQueue();
       await indexer.waitForIdle();
-
-      expect(await searchDb.countAll(), 0);
 
       final results = await searchDb.search(query: 'delete', roomId: '!r:s');
       expect(results, isEmpty);
@@ -390,6 +473,7 @@ void main() {
       when(encryption.decryptRoomEvent(any)).thenAnswer((_) async => encrypted);
       when(client.encryption).thenReturn(encryption);
       await indexer.init();
+      await markRoomIndexed();
 
       syncController.add(
         SyncUpdate(
@@ -408,8 +492,7 @@ void main() {
       await pumpEventQueue();
       await indexer.waitForIdle();
 
-      expect(await searchDb.countAll(), 0);
-
+      // Event is pending (undecryptable).
       when(encryption.decryptRoomEvent(any)).thenAnswer((_) async => decrypted);
       final fakeDb = client.database as _FakeDatabaseApi;
       fakeDb.storeEvent(encrypted);
@@ -424,53 +507,6 @@ void main() {
       );
       expect(results, hasLength(1));
       expect(results.first.body, 'now decryptable');
-    });
-  });
-
-  group('backfill', () {
-    test('indexes stored events on first run when index is empty', () async {
-      final stored = [
-        _messageEvent(eventId: r'$b1', roomId: '!r:s', body: 'backfill one'),
-        _messageEvent(eventId: r'$b2', roomId: '!r:s', body: 'backfill two'),
-      ];
-      final fakeDb = _FakeBackfillDatabase(stored);
-      when(client.database).thenReturn(fakeDb);
-      when(client.encryption).thenReturn(null);
-
-      await indexer.init();
-      await pumpEventQueue();
-      await indexer.runBackfillForTest();
-
-      final results = await searchDb.search(query: 'backfill', roomId: '!r:s');
-      expect(results, hasLength(2));
-    });
-
-    test('does not backfill when index already has rows', () async {
-      await searchDb.upsert(
-        IndexedMessage(
-          eventId: r'$seed',
-          roomId: '!r:s',
-          senderId: '@u:s',
-          body: 'seed',
-          msgtype: 'm.text',
-          originServerTs: DateTime(2024),
-        ),
-      );
-      final stored = [
-        _messageEvent(eventId: r'$b1', roomId: '!r:s', body: 'backfill one'),
-      ];
-      final fakeDb = _FakeBackfillDatabase(stored);
-      when(client.database).thenReturn(fakeDb);
-      when(client.encryption).thenReturn(null);
-
-      await indexer.init();
-      await pumpEventQueue();
-      await indexer.waitForIdle();
-
-      final results = await searchDb.search(query: 'backfill', roomId: '!r:s');
-      expect(results, isEmpty);
-      final seedResults = await searchDb.search(query: 'seed', roomId: '!r:s');
-      expect(seedResults, hasLength(1));
     });
   });
 }


### PR DESCRIPTION
## Summary

Rearchitect the local FTS5 index to use lazy per-room indexing instead of a full backfill at startup. This eliminates the slow startup caused by iterating all rooms, decrypting all history, and batch-inserting on app launch.

## Architecture changes

- **`init()`** now only subscribes to `client.onSync` — no DB open, no backfill, no room iteration. Near-zero startup cost.
- **New `ensureRoomIndexed(room)`**: called when a user opens or searches an encrypted room. Backfills that room's history only, in the background.
- **Sync events gated by indexed rooms**: only processed for rooms that have been explicitly indexed via the `indexed_rooms` metadata table.
- **New `indexed_rooms` metadata table**: replaces expensive `COUNT(*)` on startup with a quick O(1) primary-key lookup per room.
- **DB schema v2** with automatic migration from v1 (existing indexed rooms preserved, no re-backfill).
- **Decryption timeout** reduced from 3s to 500ms.
- **Yields to event loop** between chunks during backfill to keep UI responsive.

## UI changes

- `ChatSearchController` tracks `isIndexingRoom` state from the indexer.
- `SearchResultsBody` shows an "Indexing messages for search…" spinner while the room's index is being built.
- `chat_screen.dart` calls `ensureRoomIndexed` when opening an encrypted room and when opening search.

## Verification

- `flutter analyze` — **No issues found** (Flutter 3.47.0)
- `flutter test` — **All 75 search-related tests pass**

Refs #895